### PR TITLE
feat: 로그인 및 실패 예외처리 YPW-55

### DIFF
--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -4,14 +4,16 @@ import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.security.JwtGenerator
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.security.Token
-import co.yappuworld.user.domain.UserRole
 import co.yappuworld.operation.application.ConfigInquiryComponent
+import co.yappuworld.user.application.dto.request.LoginAppRequestDto
 import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
-import co.yappuworld.user.domain.UserSignUpApplicationStatus
 import co.yappuworld.user.domain.SignUpApplication
+import co.yappuworld.user.domain.UserRole
+import co.yappuworld.user.domain.UserSignUpApplicationStatus
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.domain.Limit
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -51,6 +53,16 @@ class UserAuthService(
         }
     }
 
+    @Transactional
+    fun login(
+        request: LoginAppRequestDto,
+        now: LocalDateTime
+    ): Token {
+        return userRepository.findUserOrNullByEmail(request.email)?.let {
+            jwtGenerator.generateToken(SecurityUser.fromUser(it), now)
+        } ?: processLoginException(request.email)
+    }
+
     private fun validateApplication(email: String) {
         if (userRepository.existsUserByEmail(email)) {
             logger.error { "${email}은 이미 가입된 이메일입니다." }
@@ -84,6 +96,33 @@ class UserAuthService(
             "authenticationCodeAdmin" -> UserRole.ADMIN
             "authenticationCodeAlumni" -> UserRole.ALUMNI
             else -> UserRole.ACTIVE
+        }
+    }
+
+    private fun processLoginException(email: String): Nothing {
+        val recentApplication = userSignUpApplicationRepository.findByApplicantEmailOrderByUpdatedAtDesc(
+            email,
+            Limit.of(1)
+        )
+
+        if (recentApplication == null) {
+            logger.error { "${email}로 가입 시도조차 없습니다." }
+            throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
+        }
+
+        throw when (recentApplication.status) {
+            UserSignUpApplicationStatus.PENDING -> {
+                logger.error { "${email}의 기존 가입 신청이 처리되지 않았습니다." }
+                BusinessException(UserError.CANNOT_LOGIN_WITH_UNPROCESSED_SIGN_UP_APPLICATION)
+            }
+            UserSignUpApplicationStatus.REJECTED -> {
+                logger.error { "${email}의 기존 가입 신청이 처리되지 않았습니다." }
+                BusinessException(UserError.RECENT_SIGN_UP_APPLICATION_REJECTED)
+            }
+            UserSignUpApplicationStatus.APPROVED -> {
+                logger.error { "${email}의 가입 프로세스에 문제가 생겼습니다." }
+                BusinessException(UserError.CANNOT_LOGIN_WRONG_USER_STATE)
+            }
         }
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserError.kt
@@ -19,9 +19,33 @@ enum class UserError : Error {
         override val code: String = "USR-0003"
         override val type: ErrorType = ErrorType.WRONG_STATE
     },
+
+    // 2000번대 - 회원가입 에러
     NOT_FOUND_SIGN_UP_APPLICATION {
         override val message: String = "회원가입 신청 내역을 찾을 수 없습니다."
         override val code: String = "USR-2001"
         override val type: ErrorType = ErrorType.NOT_FOUND
+    },
+
+    // 2100번대 - 로그인 에러
+    FAIL_LOGIN_NOT_FOUND_USER {
+        override val message: String = "계정 정보를 찾을 수 없습니다."
+        override val code: String = "USR-2101"
+        override val type: ErrorType = ErrorType.NOT_FOUND
+    },
+    CANNOT_LOGIN_WITH_UNPROCESSED_SIGN_UP_APPLICATION {
+        override val message: String = "회원가입 처리가 진행 중입니다."
+        override val code: String = "USR-2102"
+        override val type: ErrorType = ErrorType.NOT_FOUND
+    },
+    RECENT_SIGN_UP_APPLICATION_REJECTED {
+        override val message: String = "최근의 회원가입 신청은 거절되었습니다."
+        override val code: String = "USR-2103"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    },
+    CANNOT_LOGIN_WRONG_USER_STATE {
+        override val message: String = "로그인이 불가능한 회원 상태입니다."
+        override val code: String = "USR-2104"
+        override val type: ErrorType = ErrorType.WRONG_STATE
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/LoginAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/LoginAppRequestDto.kt
@@ -1,0 +1,6 @@
+package co.yappuworld.user.application.dto.request
+
+data class LoginAppRequestDto(
+    val email: String,
+    val password: String
+)

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserRepository.kt
@@ -7,5 +7,8 @@ import java.util.UUID
 
 @Repository
 interface UserRepository : CrudRepository<User, UUID> {
+
     fun existsUserByEmail(email: String): Boolean
+
+    fun findUserOrNullByEmail(email: String): User?
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserSignUpApplicationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserSignUpApplicationRepository.kt
@@ -1,7 +1,8 @@
 package co.yappuworld.user.infrastructure
 
-import co.yappuworld.user.domain.UserSignUpApplicationStatus
 import co.yappuworld.user.domain.SignUpApplication
+import co.yappuworld.user.domain.UserSignUpApplicationStatus
+import org.springframework.data.domain.Limit
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -13,4 +14,9 @@ interface UserSignUpApplicationRepository : CrudRepository<SignUpApplication, UU
         applicantEmail: String,
         status: UserSignUpApplicationStatus
     ): List<SignUpApplication>
+
+    fun findByApplicantEmailOrderByUpdatedAtDesc(
+        applicantEmail: String,
+        limit: Limit
+    ): SignUpApplication?
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
@@ -3,6 +3,7 @@ package co.yappuworld.user.presentation
 import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.Token
+import co.yappuworld.user.presentation.dto.request.LoginApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserSignUpApiRequestDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -111,5 +112,104 @@ interface UserAuthApi {
     @PostMapping("/v1/auth/sign-up")
     fun signUp(
         @RequestBody request: UserSignUpApiRequestDto
+    ): ResponseEntity<SuccessResponse<Token>>
+
+    @Operation(summary = "로그인")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                description = "성공",
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = SuccessResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "로그인 성공",
+                                value = """
+                                    {
+                                        "isSuccess": "true",
+                                        "data": {
+                                            "accessToken": "accessToken...",
+                                            "refreshToken": "refreshToken..."
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                description = "로그인 실패",
+                responseCode = "404",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "이메일과 매칭되는 유저 정보를 찾을 수 없음",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "계정 정보를 찾을 수 없습니다.",
+                                        "errorCode": "USR-2101"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                description = "로그인 실패",
+                responseCode = "409",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "회원가입 처리가 진행 중입니다",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "회원가입 처리가 진행 중입니다.",
+                                        "errorCode": "USR-2102"
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "최근의 회원가입 신청은 거절되었습니다.",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "최근의 회원가입 신청은 거절되었습니다.",
+                                        "errorCode": "USR-2103"
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "회원가입 승인은 되었으나, 유저 데이터가 생성되지 않음.",
+                                description = "해당 예외는 서버 에러이므로 노티 필요",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "로그인이 불가능한 회원 상태입니다.",
+                                        "errorCode": "USR-2104"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @PostMapping("/v1/auth/login")
+    fun login(
+        @RequestBody request: LoginApiRequestDto
     ): ResponseEntity<SuccessResponse<Token>>
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
@@ -3,6 +3,7 @@ package co.yappuworld.user.presentation
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.Token
 import co.yappuworld.user.application.UserAuthService
+import co.yappuworld.user.presentation.dto.request.LoginApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserSignUpApiRequestDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -24,5 +25,11 @@ class UserAuthController(
         return ResponseEntity.ok(
             SuccessResponse.of(userAuthService.signUpWithCode(request.toAppRequest(), now))
         )
+    }
+
+    override fun login(request: LoginApiRequestDto): ResponseEntity<SuccessResponse<Token>> {
+        val now = LocalDateTime.now()
+        userAuthService.login(request.toAppRequest(), now)
+        TODO("Not yet implemented")
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/LoginApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/LoginApiRequestDto.kt
@@ -1,0 +1,18 @@
+package co.yappuworld.user.presentation.dto.request
+
+import co.yappuworld.user.application.dto.request.LoginAppRequestDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class LoginApiRequestDto(
+    @Schema(description = "이메일")
+    val email: String,
+    @Schema(description = "비밀번호")
+    val password: String
+) {
+    fun toAppRequest(): LoginAppRequestDto {
+        return LoginAppRequestDto(
+            this.email,
+            this.password
+        )
+    }
+}

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
@@ -3,19 +3,17 @@ package co.yappuworld.user.application
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.security.JwtGenerator
 import co.yappuworld.operation.application.ConfigInquiryComponent
-import co.yappuworld.user.domain.UserSignUpApplicationStatus
+import co.yappuworld.user.application.dto.request.ActivityUnitAppRequestDto
+import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
 import co.yappuworld.user.domain.SignUpApplication
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
-import co.yappuworld.user.presentation.dto.request.ActivityUnitRequestDto
-import co.yappuworld.user.presentation.dto.request.UserSignUpRequestDto
 import co.yappuworld.user.presentation.vo.PositionApiType
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import java.time.LocalDateTime
-import java.util.UUID
 import kotlin.test.Test
 
 class UserAuthServiceTest {
@@ -32,11 +30,11 @@ class UserAuthServiceTest {
     )
 
     val email = "abc@abc.com"
-    val request = UserSignUpRequestDto(
+    val request = UserSignUpAppRequestDto(
         email,
         "password",
         "name",
-        listOf(ActivityUnitRequestDto(1, PositionApiType.PM)),
+        listOf(ActivityUnitAppRequestDto(1, PositionApiType.PM)),
         ""
     )
 
@@ -44,15 +42,9 @@ class UserAuthServiceTest {
     @DisplayName("기존에 처리되지 않은 신청이 있다면 예외가 발생한다.")
     fun validateExistsPendingApplication() {
         every { userRepository.existsUserByEmail(any()) } returns false
-        every { authApplicationRepository.findByApplicantEmailAndStatus(email, any()) } returns listOf(
-            SignUpApplication(
-                UUID.randomUUID(),
-                request.email,
-                request.toSignUpApplication(),
-                UserSignUpApplicationStatus.PENDING,
-                null
-            )
-        )
+        every {
+            authApplicationRepository.findByApplicantEmailAndStatus(email, any())
+        } returns listOf(SignUpApplication(request.toSignUpApplication()))
 
         assertThatThrownBy { userAuthService.submitSignUpRequest(request, LocalDateTime.now()) }
             .isInstanceOf(BusinessException::class.java)

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
@@ -10,7 +10,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.data.domain.Limit
 import org.springframework.data.repository.findByIdOrNull
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @DataJdbcTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -21,7 +24,7 @@ class SignUpApplicantDetailsRepositoryConverterTest {
 
     @Test
     @DisplayName("UserSignUpApplication Custom Converter 정상 동작 확인")
-    fun test() {
+    fun testCustomConverter() {
         val application = SignUpApplicantDetails(
             "abc@abc.com",
             "abc",
@@ -31,5 +34,39 @@ class SignUpApplicantDetailsRepositoryConverterTest {
 
         assertThat(checkNotNull(userSignUpApplicationRepository.findByIdOrNull(application.id)))
             .isInstanceOf(SignUpApplication::class.java)
+    }
+
+    @Test
+    @DisplayName("가장 최근에 신청된 신청서를 조회한다.")
+    fun testFindingApplicationByApplicantEmailLimit1() {
+        val firstDetails = SignUpApplicantDetails(
+            "abc@abc.com",
+            "abc",
+            "abc",
+            listOf(ActivityUnit(0, Position.PM))
+        )
+        val firstApplication = SignUpApplication(firstDetails).also { it.reject("거절") }
+        val secondApplication = SignUpApplication(firstDetails)
+
+        userSignUpApplicationRepository.save(firstApplication)
+        userSignUpApplicationRepository.save(secondApplication)
+
+        val findApplication = userSignUpApplicationRepository.findByApplicantEmailOrderByUpdatedAtDesc(
+            firstDetails.email,
+            Limit.of(1)
+        )
+
+        assertThat(firstApplication.id).isEqualTo(assertNotNull(findApplication).id)
+    }
+
+    @Test
+    @DisplayName("회원가입 신청을 한 적이 없다면 Null을 반환한다.")
+    fun testCannotFindingApplicationByApplicantEmailLimit1() {
+        val findApplication = userSignUpApplicationRepository.findByApplicantEmailOrderByUpdatedAtDesc(
+            "abc@abc.com",
+            Limit.of(1)
+        )
+
+        assertNull(findApplication)
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
#10 


## 🚨 해결하려는 문제가 무엇인가요?
- 로그인 구현
- 로그인 시 발생하는 예외 처리


## ⭐️ 어떻게 해결했나요?
크게 두 가지 프로세스가 존재합니다.
1. email로 User 테이블 조회 -> 성공하면 Token 반환
2. User 테이블에 존재하지 않는 경우 -> SignUpApplication 테이블 조회
	- 조회 결과에 따라 4가지 케이스 발생 (모두 예외 처리)
		- 조회 실패
		- status
			- status = PENDING
			- status = REJECTED
			- statis = APPROVED


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?
- 현재 일부 로직이 application으로 튀어 나와 있는데, 추후 작업하면서 domain으로 넣을 예정이긴 합니다.
- 보셨을 때, 아 이건 진짜 domain에 넣어야 할 거 같은데(?) 싶으신 거 간단히 말씀해주시면 고려하며 작업하겠습니다.


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
