### PR TITLE
feat: 토큰 재발급 YPW-56

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/security/JwtResolver.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/JwtResolver.kt
@@ -1,11 +1,14 @@
 package co.yappuworld.global.security
 
+import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.property.JwtProperty
+import co.yappuworld.global.security.error.TokenError
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwt
 import io.jsonwebtoken.Jwts
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 private val logger = KotlinLogging.logger { }
 
@@ -19,6 +22,11 @@ class JwtResolver(
             val payload = parseToken(it).payload
             SecurityUser.fromValidToken(payload as Map<String, String>)
         }
+    }
+
+    fun extractUserIdFrom(accessToken: String): UUID {
+        return UUID.fromString(getClaimsFrom(accessToken)["userId"].toString())
+            ?: throw BusinessException(TokenError.INVALID_TOKEN)
     }
 
     fun getClaimsFrom(accessToken: String): Map<String, Any> {

--- a/src/main/kotlin/co/yappuworld/global/security/SecurityUser.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/SecurityUser.kt
@@ -23,7 +23,7 @@ class SecurityUser(
             )
         }
 
-        fun fromUser(user: User): SecurityUser {
+        fun from(user: User): SecurityUser {
             return SecurityUser(user.id, user.role)
         }
     }

--- a/src/main/kotlin/co/yappuworld/global/security/error/TokenError.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/error/TokenError.kt
@@ -1,15 +1,17 @@
 package co.yappuworld.global.security.error
 
-enum class TokenError(
-    val message: String,
-    val code: String
-) {
-    EXPIRED_TOKEN(
-        "만료된 토큰입니다.",
-        "TKN-0001"
-    ),
-    INVALID_TOKEN(
-        "비정상 토큰입니다.",
-        "TKN-0002"
-    )
+import co.yappuworld.global.exception.Error
+import co.yappuworld.global.exception.ErrorType
+
+enum class TokenError : Error {
+    EXPIRED_TOKEN {
+        override val message: String = "만료된 토큰입니다."
+        override val code: String = "TKN - 0001"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    },
+    INVALID_TOKEN {
+        override val message: String = "비정상 토큰입니다."
+        override val code: String = "TKN-0002"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -20,7 +20,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
-import java.util.UUID
 
 private val logger = KotlinLogging.logger { }
 
@@ -70,12 +69,17 @@ class UserAuthService(
 
     @Transactional
     fun reissueToken(request: ReissueTokenAppRequestDto): Token {
-        val userId = UUID.fromString(jwtResolver.getClaimsFrom(request.accessToken)["userId"].toString())
-        val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
+        val userId = jwtResolver.extractUserIdFrom(request.accessToken)
+        val userOrNull = userRepository.findByIdOrNull(userId)
+
+        if (userOrNull == null) {
+            logger.error { "$userId 유저를 찾을 수 없습니다." }
+            throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
+        }
 
         // TODO - AT와 RT의 화이트리스트 또는 블랙리스트 전략 필요
 
-        return jwtGenerator.generateToken(SecurityUser.from(user), request.now)
+        return jwtGenerator.generateToken(SecurityUser.from(userOrNull), request.now)
     }
 
     private fun validateApplication(email: String) {

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/ReissueTokenAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/ReissueTokenAppRequestDto.kt
@@ -1,0 +1,9 @@
+package co.yappuworld.user.application.dto.request
+
+import java.time.LocalDateTime
+
+data class ReissueTokenAppRequestDto(
+    val accessToken: String,
+    val refreshToken: String,
+    val now: LocalDateTime
+)

--- a/src/main/kotlin/co/yappuworld/user/domain/User.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/User.kt
@@ -8,17 +8,28 @@ import org.springframework.data.relational.core.mapping.Table
 import java.util.UUID
 
 @Table("users")
-class User(
+class User private constructor(
     val email: String,
     val password: String,
     val name: String,
     val role: UserRole,
-    val isActive: Boolean = true
-) : BaseEntity(), Persistable<UUID> {
-
+    val isActive: Boolean = true,
     @Id
     @JvmField
-    val id: UUID = UlidCreator.getMonotonicUlid().toUuid()
+    val id: UUID
+) : BaseEntity(), Persistable<UUID> {
+
+    constructor(
+        email: String,
+        password: String,
+        name: String,
+        role: UserRole,
+        isActive: Boolean = true
+    ) : this(email, password, name, role, isActive, UlidCreator.getMonotonicUlid().toUuid())
+
+    fun withId(id: UUID): User {
+        return User(this.email, this.password, this.name, this.role, this.isActive, id)
+    }
 
     override fun getId(): UUID {
         return this.id

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
@@ -4,6 +4,7 @@ import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.Token
 import co.yappuworld.user.presentation.dto.request.LoginApiRequestDto
+import co.yappuworld.user.presentation.dto.request.ReissueTokenApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserSignUpApiRequestDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -211,5 +212,10 @@ interface UserAuthApi {
     @PostMapping("/v1/auth/login")
     fun login(
         @RequestBody request: LoginApiRequestDto
+    ): ResponseEntity<SuccessResponse<Token>>
+
+    @PostMapping("/v1/auth/reissue-token")
+    fun reissueToken(
+        @RequestBody request: ReissueTokenApiRequestDto
     ): ResponseEntity<SuccessResponse<Token>>
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
@@ -214,6 +214,79 @@ interface UserAuthApi {
         @RequestBody request: LoginApiRequestDto
     ): ResponseEntity<SuccessResponse<Token>>
 
+    @Operation(summary = "토큰 재발급")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                description = "성공",
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = SuccessResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "토큰 재발급 성공",
+                                value = """
+                                    {
+                                        "isSuccess": "true",
+                                        "data": {
+                                            "accessToken": "accessToken...",
+                                            "refreshToken": "refreshToken..."
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                description = "로그인 실패",
+                responseCode = "404",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "토큰 정보와 매칭되는 유저를 찾을 수 없습니다.",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "계정 정보를 찾을 수 없습니다.",
+                                        "errorCode": "USR-2101"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                description = "토큰 오류",
+                responseCode = "409",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "비정상 토큰",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "비정상 토큰입니다.",
+                                        "errorCode": "TKN-0002"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
     @PostMapping("/v1/auth/reissue-token")
     fun reissueToken(
         @RequestBody request: ReissueTokenApiRequestDto

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
@@ -4,6 +4,7 @@ import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.Token
 import co.yappuworld.user.application.UserAuthService
 import co.yappuworld.user.presentation.dto.request.LoginApiRequestDto
+import co.yappuworld.user.presentation.dto.request.ReissueTokenApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserSignUpApiRequestDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -31,5 +32,12 @@ class UserAuthController(
         val now = LocalDateTime.now()
         userAuthService.login(request.toAppRequest(), now)
         TODO("Not yet implemented")
+    }
+
+    override fun reissueToken(request: ReissueTokenApiRequestDto): ResponseEntity<SuccessResponse<Token>> {
+        val token = userAuthService.reissueToken(request.toAppRequest(LocalDateTime.now()))
+        return ResponseEntity.ok(
+            SuccessResponse.of(token)
+        )
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/ReissueTokenApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/ReissueTokenApiRequestDto.kt
@@ -1,0 +1,18 @@
+package co.yappuworld.user.presentation.dto.request
+
+import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
+import java.time.LocalDateTime
+
+data class ReissueTokenApiRequestDto(
+    val accessToken: String,
+    val refreshToken: String
+) {
+
+    fun toAppRequest(now: LocalDateTime): ReissueTokenAppRequestDto {
+        return ReissueTokenAppRequestDto(
+            this.accessToken,
+            this.refreshToken,
+            now
+        )
+    }
+}

--- a/src/test/kotlin/co/yappuworld/support/fixture/UserFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/UserFixture.kt
@@ -1,0 +1,18 @@
+package co.yappuworld.support.fixture
+
+import co.yappuworld.user.domain.User
+import co.yappuworld.user.domain.UserRole
+
+fun getUserFixture(
+    email: String = "email@email.com",
+    password: String = "password",
+    name: String = "name",
+    role: UserRole = UserRole.ACTIVE,
+    isActive: Boolean = true
+) = User(
+    email = email,
+    password = password,
+    name = name,
+    role = role,
+    isActive = isActive
+)


### PR DESCRIPTION
## 📌 Related Issue
#12 


## 🚨 해결하려는 문제가 무엇인가요?
- 로그인 유지를 위해 토큰 재발급 기능을 구현


## ⭐️ 어떻게 해결했나요?
- [로그인 PR](https://github.com/YAPP-admin/yappu-world-server/pull/11)에 이어 작업했습니다.

- AT와 RT를 Body로 받고, 만료 여부에 관계 없이 재발급을 진행합니다.
	- Resolver를 통해 AccessToken을 검증 및 claim을 추출
	- User 테이블에서 정보 확인
	- User 테이블 데이터 기반으로 Token 재생성

- 추후에 화이트리스트 혹은 블랙리스트 방식을 도입하여 보안성을 높일 예정입니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?
- 토큰 재발급 구조와 플로우가 적절한지 확인 부탁드립니다


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
