### PR TITLE
feat: 이메일 중복 검사 YPW-62

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-security")
     runtimeOnly("org.springframework.boot:spring-boot-docker-compose")
 

--- a/src/main/kotlin/co/yappuworld/global/exception/ErrorType.kt
+++ b/src/main/kotlin/co/yappuworld/global/exception/ErrorType.kt
@@ -5,10 +5,12 @@ package co.yappuworld.global.exception
  * @property UNAUTHORIZED 인증, 인가 오류
  * @property NOT_FOUND 리소스를 찾지 못하는 모든 상황에 해당
  * @property WRONG_STATE 요청을 처리할 수 없는 상태 (데이터 정합성 문제, 비즈니스 요구사항 문제)
+ * @property UNEXPECTED_ERROR 예기치 못한 에러의 발생 (Internal Server Error)
  */
 enum class ErrorType {
     WRONG_ARGUMENT,
     UNAUTHORIZED,
     NOT_FOUND,
-    WRONG_STATE
+    WRONG_STATE,
+    UNEXPECTED_ERROR
 }

--- a/src/main/kotlin/co/yappuworld/global/exception/GlobalError.kt
+++ b/src/main/kotlin/co/yappuworld/global/exception/GlobalError.kt
@@ -1,0 +1,14 @@
+package co.yappuworld.global.exception
+
+enum class GlobalError : Error {
+    INTERNAL_SERVER_ERROR {
+        override val message: String = "예기치 못한 에러가 발생했습니다. 서버 관리자에게 문의해주세요."
+        override val code: String = "COM_0001"
+        override val type: ErrorType = ErrorType.UNEXPECTED_ERROR
+    },
+    INVALID_REQUEST_ARGUMENT {
+        override val message: String = "요청된 인자에 잘못된 값이 있습니다."
+        override val code: String = "COM_0002"
+        override val type: ErrorType = ErrorType.WRONG_ARGUMENT
+    }
+}

--- a/src/main/kotlin/co/yappuworld/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/co/yappuworld/global/exception/GlobalExceptionHandler.kt
@@ -28,7 +28,12 @@ class GlobalExceptionHandler {
         return e.bindingResult.fieldErrors[0].defaultMessage?.let {
             ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(message = it))
+                .body(
+                    ErrorResponse.of(
+                        message = it,
+                        errorCode = GlobalError.INVALID_REQUEST_ARGUMENT.code
+                    )
+                )
         } ?: getInternalServerErrorResponse()
     }
 
@@ -44,12 +49,13 @@ class GlobalExceptionHandler {
             ErrorType.UNAUTHORIZED -> HttpStatus.UNAUTHORIZED
             ErrorType.NOT_FOUND -> HttpStatus.NOT_FOUND
             ErrorType.WRONG_STATE -> HttpStatus.CONFLICT
+            ErrorType.UNEXPECTED_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR
         }
     }
 
     private fun getInternalServerErrorResponse(): ResponseEntity<ErrorResponse> {
         return ResponseEntity
             .internalServerError()
-            .body(ErrorResponse.internalServerError())
+            .body(ErrorResponse.of(GlobalError.INTERNAL_SERVER_ERROR))
     }
 }

--- a/src/main/kotlin/co/yappuworld/global/response/ErrorResponse.kt
+++ b/src/main/kotlin/co/yappuworld/global/response/ErrorResponse.kt
@@ -31,12 +31,5 @@ data class ErrorResponse(
                 error.code
             )
         }
-
-        fun internalServerError(): ErrorResponse {
-            return ErrorResponse(
-                "서버 관리자에게 문의해주세요.",
-                null
-            )
-        }
     }
 }

--- a/src/main/kotlin/co/yappuworld/global/response/ErrorResponse.kt
+++ b/src/main/kotlin/co/yappuworld/global/response/ErrorResponse.kt
@@ -17,7 +17,7 @@ data class ErrorResponse(
     companion object {
         fun of(
             message: String,
-            errorCode: String?
+            errorCode: String? = null
         ): ErrorResponse {
             return ErrorResponse(
                 message,
@@ -29,6 +29,13 @@ data class ErrorResponse(
             return ErrorResponse(
                 error.message,
                 error.code
+            )
+        }
+
+        fun internalServerError(): ErrorResponse {
+            return ErrorResponse(
+                "서버 관리자에게 문의해주세요.",
+                null
             )
         }
     }

--- a/src/main/kotlin/co/yappuworld/global/security/error/TokenError.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/error/TokenError.kt
@@ -6,12 +6,12 @@ import co.yappuworld.global.exception.ErrorType
 enum class TokenError : Error {
     EXPIRED_TOKEN {
         override val message: String = "만료된 토큰입니다."
-        override val code: String = "TKN - 0001"
+        override val code: String = "TKN_0001"
         override val type: ErrorType = ErrorType.WRONG_STATE
     },
     INVALID_TOKEN {
         override val message: String = "비정상 토큰입니다."
-        override val code: String = "TKN-0002"
+        override val code: String = "TKN_0002"
         override val type: ErrorType = ErrorType.WRONG_STATE
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -6,6 +6,7 @@ import co.yappuworld.global.security.JwtResolver
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.security.Token
 import co.yappuworld.operation.application.ConfigInquiryComponent
+import co.yappuworld.user.application.dto.request.CheckingEmailAvailabilityAppRequestDto
 import co.yappuworld.user.application.dto.request.LoginAppRequestDto
 import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
 import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
@@ -80,6 +81,14 @@ class UserAuthService(
         // TODO - AT와 RT의 화이트리스트 또는 블랙리스트 전략 필요
 
         return jwtGenerator.generateToken(SecurityUser.from(userOrNull), request.now)
+    }
+
+    @Transactional(readOnly = true)
+    fun checkEmailAvailability(request: CheckingEmailAvailabilityAppRequestDto) {
+        val findUserOrNullByEmail = userRepository.findUserOrNullByEmail(request.email)
+        if (findUserOrNullByEmail?.isActive == true) {
+            throw BusinessException(UserError.DUPLICATE_EMAIL)
+        }
     }
 
     private fun validateApplication(email: String) {

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -20,7 +20,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
-import java.util.UUID
 
 private val logger = KotlinLogging.logger { }
 
@@ -70,12 +69,17 @@ class UserAuthService(
 
     @Transactional
     fun reissueToken(request: ReissueTokenAppRequestDto): Token {
-        val userId = UUID.fromString(jwtResolver.getClaimsFrom(request.accessToken)["userId"].toString())
-        val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
+        val userId = jwtResolver.extractUserIdFrom(request.accessToken)
+        val userOrNull = userRepository.findByIdOrNull(userId)
+
+        if (userOrNull == null) {
+            logger.error { "$userId 유저를 찾을 수 없습니다." }
+            throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
+        }
 
         // TODO - AT와 RT의 화이트리스트 또는 블랙리스트 전략 필요
 
-        return jwtGenerator.generateToken(SecurityUser.from(user), request.now)
+        return jwtGenerator.generateToken(SecurityUser.from(userOrNull), request.now)
     }
 
     private fun validateApplication(email: String) {

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -85,8 +85,7 @@ class UserAuthService(
 
     @Transactional(readOnly = true)
     fun checkEmailAvailability(request: CheckingEmailAvailabilityAppRequestDto) {
-        val findUserOrNullByEmail = userRepository.findUserOrNullByEmail(request.email)
-        if (findUserOrNullByEmail?.isActive == true) {
+        if (userRepository.existsUserByEmail(request.email)) {
             throw BusinessException(UserError.DUPLICATE_EMAIL)
         }
     }

--- a/src/main/kotlin/co/yappuworld/user/application/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserError.kt
@@ -4,48 +4,58 @@ import co.yappuworld.global.exception.Error
 import co.yappuworld.global.exception.ErrorType
 
 enum class UserError : Error {
+
+    // 1000번대 - 회원가입 에러
     INVALID_SIGN_UP_CODE {
         override val message: String = "잘못된 가입코드입니다."
-        override val code: String = "USR-0001"
+        override val code: String = "USR_1001"
         override val type: ErrorType = ErrorType.WRONG_ARGUMENT
     },
     ALREADY_SIGNED_UP_EMAIL {
         override val message: String = "이미 가입된 이메일입니다."
-        override val code: String = "USR-0002"
+        override val code: String = "USR_1002"
         override val type: ErrorType = ErrorType.WRONG_STATE
     },
     UNPROCESSED_APPLICATION_EXISTS {
         override val message: String = "처리되지 않은 가입 신청이 존재하여, 추가 가입 신청이 불가합니다."
-        override val code: String = "USR-0003"
+        override val code: String = "USR_1003"
         override val type: ErrorType = ErrorType.WRONG_STATE
     },
-
-    // 2000번대 - 회원가입 에러
+    INVALID_EMAIL {
+        override val message: String = "이메일 형식이 아닙니다."
+        override val code: String = "USR_1004"
+        override val type: ErrorType = ErrorType.WRONG_ARGUMENT
+    },
+    DUPLICATE_EMAIL {
+        override val message: String = "중복된 이메일입니다."
+        override val code: String = "USR_1005"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    },
     NOT_FOUND_SIGN_UP_APPLICATION {
         override val message: String = "회원가입 신청 내역을 찾을 수 없습니다."
-        override val code: String = "USR-2001"
+        override val code: String = "USR_1099"
         override val type: ErrorType = ErrorType.NOT_FOUND
     },
 
-    // 2100번대 - 로그인 에러
+    // 1100번대 - 로그인 에러
     FAIL_LOGIN_NOT_FOUND_USER {
         override val message: String = "계정 정보를 찾을 수 없습니다."
-        override val code: String = "USR-2101"
+        override val code: String = "USR_1101"
         override val type: ErrorType = ErrorType.NOT_FOUND
     },
     CANNOT_LOGIN_WITH_UNPROCESSED_SIGN_UP_APPLICATION {
         override val message: String = "회원가입 처리가 진행 중입니다."
-        override val code: String = "USR-2102"
+        override val code: String = "USR_1102"
         override val type: ErrorType = ErrorType.NOT_FOUND
     },
     RECENT_SIGN_UP_APPLICATION_REJECTED {
         override val message: String = "최근의 회원가입 신청은 거절되었습니다."
-        override val code: String = "USR-2103"
+        override val code: String = "USR_1103"
         override val type: ErrorType = ErrorType.WRONG_STATE
     },
     CANNOT_LOGIN_WRONG_USER_STATE {
         override val message: String = "로그인이 불가능한 회원 상태입니다."
-        override val code: String = "USR-2104"
+        override val code: String = "USR_1104"
         override val type: ErrorType = ErrorType.WRONG_STATE
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/CheckingEmailAvailabilityAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/CheckingEmailAvailabilityAppRequestDto.kt
@@ -1,0 +1,5 @@
+package co.yappuworld.user.application.dto.request
+
+data class CheckingEmailAvailabilityAppRequestDto(
+    val email: String
+)

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
@@ -55,7 +55,7 @@ interface UserAuthAdminApi {
                                 value = """
                                     {
                                         "message": "회원가입 신청 내역을 찾을 수 없습니다.",
-                                        "errorCode": "USR-2001"
+                                        "errorCode": "USR_1099"
                                     }
                                 """
                             )
@@ -106,7 +106,7 @@ interface UserAuthAdminApi {
                                 value = """
                                     {
                                         "message": "회원가입 신청 내역을 찾을 수 없습니다.",
-                                        "errorCode": "USR-2001"
+                                        "errorCode": "USR_1099"
                                     }
                                 """
                             )

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
@@ -3,6 +3,7 @@ package co.yappuworld.user.presentation
 import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.Token
+import co.yappuworld.user.presentation.dto.request.CheckingEmailAvailabilityApiRequestDto
 import co.yappuworld.user.presentation.dto.request.LoginApiRequestDto
 import co.yappuworld.user.presentation.dto.request.ReissueTokenApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserSignUpApiRequestDto
@@ -13,13 +14,12 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 
 @Tag(name = "유저 인증 API", description = "회원가입, 로그인, 로그아웃 등..")
-@Validated
 interface UserAuthApi {
 
     @Operation(summary = "회원가입")
@@ -65,11 +65,11 @@ interface UserAuthApi {
                         schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
-                                name = "가입코드 오류(USR-0001)",
+                                name = "가입코드 오류",
                                 value = """
                                     {
                                         "isSuccess": "false",
-                                        "errorCode": "USR-0001",
+                                        "errorCode": "USR_1001",
                                         "message": "잘못된 가입코드입니다."
                                     }
                                 """
@@ -85,21 +85,21 @@ interface UserAuthApi {
                         schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
-                                name = "이미 가입된 유저(USR-0002)",
+                                name = "이미 가입된 이메일",
                                 value = """
                                     {
                                         "isSuccess": "false",
-                                        "errorCode": "USR-0002",
+                                        "errorCode": "USR_1002",
                                         "message": "이미 가입된 이메일입니다."
                                     }
                                 """
                             ),
                             ExampleObject(
-                                name = "처리되지 않은 기존 신청이 존재하는 경우(USR-0003)",
+                                name = "처리되지 않은 회원가입 신청이 존재하는 경우",
                                 value = """
                                     {
                                         "isSuccess": "false",
-                                        "errorCode": "USR-0003",
+                                        "errorCode": "USR_1003",
                                         "message": "처리되지 않은 가입 신청이 존재하여, 추가 가입 신청이 불가합니다."
                                     }
                                 """
@@ -112,7 +112,7 @@ interface UserAuthApi {
     )
     @PostMapping("/v1/auth/sign-up")
     fun signUp(
-        @RequestBody request: UserSignUpApiRequestDto
+        @Valid @RequestBody request: UserSignUpApiRequestDto
     ): ResponseEntity<SuccessResponse<Token>>
 
     @Operation(summary = "로그인")
@@ -156,7 +156,7 @@ interface UserAuthApi {
                                     {
                                         "isSuccess": "false",
                                         "message": "계정 정보를 찾을 수 없습니다.",
-                                        "errorCode": "USR-2101"
+                                        "errorCode": "USR_1101"
                                     }
                                 """
                             )
@@ -178,7 +178,7 @@ interface UserAuthApi {
                                     {
                                         "isSuccess": "false",
                                         "message": "회원가입 처리가 진행 중입니다.",
-                                        "errorCode": "USR-2102"
+                                        "errorCode": "USR_1102"
                                     }
                                 """
                             ),
@@ -188,7 +188,7 @@ interface UserAuthApi {
                                     {
                                         "isSuccess": "false",
                                         "message": "최근의 회원가입 신청은 거절되었습니다.",
-                                        "errorCode": "USR-2103"
+                                        "errorCode": "USR_1103"
                                     }
                                 """
                             ),
@@ -199,7 +199,7 @@ interface UserAuthApi {
                                     {
                                         "isSuccess": "false",
                                         "message": "로그인이 불가능한 회원 상태입니다.",
-                                        "errorCode": "USR-2104"
+                                        "errorCode": "USR_1104"
                                     }
                                 """
                             )
@@ -211,7 +211,7 @@ interface UserAuthApi {
     )
     @PostMapping("/v1/auth/login")
     fun login(
-        @RequestBody request: LoginApiRequestDto
+        @Valid @RequestBody request: LoginApiRequestDto
     ): ResponseEntity<SuccessResponse<Token>>
 
     @Operation(summary = "토큰 재발급")
@@ -255,7 +255,7 @@ interface UserAuthApi {
                                     {
                                         "isSuccess": "false",
                                         "message": "계정 정보를 찾을 수 없습니다.",
-                                        "errorCode": "USR-2101"
+                                        "errorCode": "USR_1101"
                                     }
                                 """
                             )
@@ -277,7 +277,7 @@ interface UserAuthApi {
                                     {
                                         "isSuccess": "false",
                                         "message": "비정상 토큰입니다.",
-                                        "errorCode": "TKN-0002"
+                                        "errorCode": "TKN_0002"
                                     }
                                 """
                             )
@@ -291,4 +291,57 @@ interface UserAuthApi {
     fun reissueToken(
         @RequestBody request: ReissueTokenApiRequestDto
     ): ResponseEntity<SuccessResponse<Token>>
+
+    @Operation(summary = "이메일 중복 검사")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                description = "성공",
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = SuccessResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "토큰 재발급 성공",
+                                value = """
+                                    {
+                                        "isSuccess": "true",
+                                        "data": null
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                description = "중복된 이메일입니다.",
+                responseCode = "409",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "중복된 이메일입니다.",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "중복된 이메일입니다.",
+                                        "errorCode": "USR_1005"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @PostMapping("/v1/auth/check-email")
+    fun checkEmailAvailability(
+        @Valid @RequestBody request: CheckingEmailAvailabilityApiRequestDto
+    ): ResponseEntity<SuccessResponse<Unit>>
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
@@ -3,6 +3,7 @@ package co.yappuworld.user.presentation
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.Token
 import co.yappuworld.user.application.UserAuthService
+import co.yappuworld.user.presentation.dto.request.CheckingEmailAvailabilityApiRequestDto
 import co.yappuworld.user.presentation.dto.request.LoginApiRequestDto
 import co.yappuworld.user.presentation.dto.request.ReissueTokenApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserSignUpApiRequestDto
@@ -39,5 +40,12 @@ class UserAuthController(
         return ResponseEntity.ok(
             SuccessResponse.of(token)
         )
+    }
+
+    override fun checkEmailAvailability(
+        request: CheckingEmailAvailabilityApiRequestDto
+    ): ResponseEntity<SuccessResponse<Unit>> {
+        userAuthService.checkEmailAvailability(request.toAppRequest())
+        return ResponseEntity.ok(SuccessResponse())
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/ActivityUnitApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/ActivityUnitApiRequestDto.kt
@@ -6,11 +6,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotEmpty
 
 data class ActivityUnitApiRequestDto(
-    @NotEmpty
     @Schema(description = "기수")
+    @field:NotEmpty(message = "기수는 필수로 입력해야 합니다.")
     val generation: Int,
-    @NotEmpty
     @Schema(description = "직군")
+    @field:NotEmpty(message = "직군은 필수로 입력해야 합니다.")
     val position: PositionApiType
 ) {
     fun toAppRequest(): ActivityUnitAppRequestDto {

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/CheckingEmailAvailabilityApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/CheckingEmailAvailabilityApiRequestDto.kt
@@ -1,0 +1,15 @@
+package co.yappuworld.user.presentation.dto.request
+
+import co.yappuworld.user.application.dto.request.CheckingEmailAvailabilityAppRequestDto
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotEmpty
+
+data class CheckingEmailAvailabilityApiRequestDto(
+    @field:Email(message = "이메일 형식이 잘못되었습니다.")
+    @field:NotEmpty(message = "이메일은 필수로 입력해야 합니다.")
+    val email: String
+) {
+    fun toAppRequest(): CheckingEmailAvailabilityAppRequestDto {
+        return CheckingEmailAvailabilityAppRequestDto(this.email)
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/LoginApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/LoginApiRequestDto.kt
@@ -2,11 +2,17 @@ package co.yappuworld.user.presentation.dto.request
 
 import co.yappuworld.user.application.dto.request.LoginAppRequestDto
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotEmpty
+import org.hibernate.validator.constraints.Length
 
 data class LoginApiRequestDto(
     @Schema(description = "이메일")
+    @field:Email(message = "이메일 형식이 아닙니다.")
+    @field:NotEmpty(message = "이메일은 필수로 입력해야 합니다.")
     val email: String,
     @Schema(description = "비밀번호")
+    @field:Length(min = 8, max = 20, message = "올바르지 않은 비밀번호입니다.")
     val password: String
 ) {
     fun toAppRequest(): LoginAppRequestDto {

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/UserSignUpApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/UserSignUpApiRequestDto.kt
@@ -4,17 +4,20 @@ import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotEmpty
+import org.hibernate.validator.constraints.Length
 
 @Schema(description = "회원가입 요청")
 data class UserSignUpApiRequestDto(
-    @Email
     @Schema(description = "이메일", requiredMode = Schema.RequiredMode.REQUIRED)
+    @field:Email(message = "올바르지 않은 이메일 형식입니다.")
+    @field:NotEmpty(message = "이메일은 필수로 입력해야 합니다.")
     val email: String,
-    @NotEmpty
     @Schema(description = "비밀번호, 8~20자")
+    @field:NotEmpty(message = "비밀번호는 필수로 입력해야 합니다.")
+    @field:Length(min = 8, max = 20, message = "올바르지 않은 비밀번호입니다.")
     val password: String,
-    @NotEmpty
     @Schema(description = "실명")
+    @field:NotEmpty(message = "실명은 필수로 입력해야 합니다.")
     val name: String,
     @NotEmpty
     @Schema(description = "활동한 기수와 직군 기입")

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,3 +1,6 @@
+server:
+    forward-headers-strategy: framework
+
 spring:
     mvc:
         hidden-method:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,5 +1,6 @@
 server:
     forward-headers-strategy: framework
+    port: ${DEV_PORT}
 
 spring:
     mvc:
@@ -10,7 +11,7 @@ spring:
         compose:
             enabled: false
     datasource:
-        url: ${DB_HOST}
+        url: ${DB_URL}
         username: ${DB_USERNAME}
         password: ${DB_PASSWORD}
     sql:
@@ -19,5 +20,5 @@ spring:
 
 jwt:
     secret_key: ${JWT_SECRET_KEY}
-    access_token_expiration_times: 3600000 # 1hour = 1000(=1s) * 60 * 60
-    refresh_token_expiration_times: 1209600000 # 2weeks = 1000(=1s) * 60 * 60 * 24 * 14
+    access_token_expiration_times: ${ACCESS_TOKEN_EXPIRATION_TIMES} # 1hour = 1000(=1s) * 60 * 60
+    refresh_token_expiration_times: ${REFRESH_TOKEN_EXPIRATION_TIMES} # 2weeks = 1000(=1s) * 60 * 60 * 24 * 14


### PR DESCRIPTION
## 📌 Related Issue
#14 


## 🚨 해결하려는 문제가 무엇인가요?
- 회원가입 시 사용 가능한 이메일인지 검증이 필요합니다.


## ⭐️ 어떻게 해결했나요?
- [이전 PR](https://github.com/YAPP-admin/yappu-world-server/pull/13)에 이어 진행했습니다.
	- 이전 PR이 머지되면 commit 정리 진행하겠습니다.
- 사용 가능한 이메일인지 검증을 위한 기능을 제공합니다.
	- User 테이블에 요청으로 보낸 email이 있는지 확인합니다.
	- 존재하는 경우 exception을 던집니다.
	- 존재하지 않는 경우 (사용할 수 있는 email), 200 응답이 반환됩니다.
- 탈퇴 여부는 고려하지 않습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?
- 단순한 기능이라 특별히 집중할 부분은 없는 거 같습니다!


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
