### PR TITLE
feat: 프로필 조회 YPW-64

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/persistence/CustomConverter.kt
+++ b/src/main/kotlin/co/yappuworld/global/persistence/CustomConverter.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.global.persistence
 
-import co.yappuworld.user.domain.SignUpApplicantDetails
+import co.yappuworld.user.domain.model.SignUpApplicantDetails
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.core.convert.converter.Converter

--- a/src/main/kotlin/co/yappuworld/global/security/SecurityUser.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/SecurityUser.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.global.security
 
-import co.yappuworld.user.domain.UserRole
+import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.domain.model.User
 import java.util.UUID
 

--- a/src/main/kotlin/co/yappuworld/global/security/SecurityUser.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/SecurityUser.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.global.security
 
 import co.yappuworld.user.domain.UserRole
-import co.yappuworld.user.domain.User
+import co.yappuworld.user.domain.model.User
 import java.util.UUID
 
 class SecurityUser(

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthAdminService.kt
@@ -3,7 +3,8 @@ package co.yappuworld.user.application
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.user.application.dto.request.SignUpApplicationApproveAppRequestDto
 import co.yappuworld.user.application.dto.request.SignUpApplicationRejectAppRequestDto
-import co.yappuworld.user.domain.UserError
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.infrastructure.ActivityUnitRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -13,17 +14,19 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class UserAuthAdminService(
     private val userRepository: UserRepository,
-    private val signUpApplicationRepository: UserSignUpApplicationRepository
+    private val signUpApplicationRepository: UserSignUpApplicationRepository,
+    private val activityUnitRepository: ActivityUnitRepository
 ) {
 
     @Transactional
     fun approveSignUpApplication(request: SignUpApplicationApproveAppRequestDto) {
         val application = signUpApplicationRepository.findByIdOrNull(request.applicationId)
-            ?.apply { approve(request.role) }
+            ?.apply { approve() }
             ?: throw BusinessException(UserError.NOT_FOUND_SIGN_UP_APPLICATION)
 
         signUpApplicationRepository.save(application)
-        userRepository.save(application.toUser(request.role))
+        val user = userRepository.save(application.toUser(request.role))
+        activityUnitRepository.saveAll(application.toActivityUnits(user))
     }
 
     @Transactional

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -12,7 +12,7 @@ import co.yappuworld.user.application.dto.request.LoginAppRequestDto
 import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
 import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
 import co.yappuworld.user.application.dto.response.LatestSignUpApplicationAppResponseDto
-import co.yappuworld.user.domain.SignUpApplication
+import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.UserError
 import co.yappuworld.user.domain.UserRole
 import co.yappuworld.user.domain.UserSignUpApplicationStatus

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -13,9 +13,10 @@ import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
 import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
 import co.yappuworld.user.application.dto.response.LatestSignUpApplicationAppResponseDto
 import co.yappuworld.user.domain.model.SignUpApplication
-import co.yappuworld.user.domain.UserError
-import co.yappuworld.user.domain.UserRole
-import co.yappuworld.user.domain.UserSignUpApplicationStatus
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
+import co.yappuworld.user.infrastructure.ActivityUnitRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -31,6 +32,7 @@ private val logger = KotlinLogging.logger { }
 class UserAuthService(
     private val userRepository: UserRepository,
     private val userSignUpApplicationRepository: UserSignUpApplicationRepository,
+    private val activityUnitRepository: ActivityUnitRepository,
     private val jwtGenerator: JwtGenerator,
     private val jwtResolver: JwtResolver,
     private val configInquiryComponent: ConfigInquiryComponent
@@ -54,9 +56,13 @@ class UserAuthService(
         now: LocalDateTime
     ): Token {
         val role = getUserRoleWithSignUpCode(request.signUpCode)
+        val user = request.toUser(role).also {
+            activityUnitRepository.saveAll(request.toActivityUnits(it))
+            userRepository.save(it)
+        }
 
-        return userRepository.save(request.toUser(role)).let { user ->
-            val securityUser = SecurityUser.from(user)
+        return user.let {
+            val securityUser = SecurityUser.from(it)
             jwtGenerator.generateToken(securityUser, now)
         }
     }

--- a/src/main/kotlin/co/yappuworld/user/application/UserProfileService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserProfileService.kt
@@ -2,7 +2,8 @@ package co.yappuworld.user.application
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.user.application.dto.response.UserProfileAppResponseDto
-import co.yappuworld.user.domain.UserError
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.infrastructure.ActivityUnitRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -11,12 +12,14 @@ import java.util.UUID
 
 @Service
 class UserProfileService(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val activityUnitRepository: ActivityUnitRepository
 ) {
 
     @Transactional(readOnly = true)
     fun findUserProfile(userId: UUID): UserProfileAppResponseDto {
         val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(UserError.USER_NOT_FOUND)
-        return UserProfileAppResponseDto.of(user, emptyList())
+        val activityUnits = activityUnitRepository.findAllByUserId(userId)
+        return UserProfileAppResponseDto.of(user, activityUnits)
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/UserProfileService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserProfileService.kt
@@ -1,0 +1,22 @@
+package co.yappuworld.user.application
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.user.application.dto.response.UserProfileAppResponseDto
+import co.yappuworld.user.domain.UserError
+import co.yappuworld.user.infrastructure.UserRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class UserProfileService(
+    private val userRepository: UserRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun findUserProfile(userId: UUID): UserProfileAppResponseDto {
+        val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(UserError.USER_NOT_FOUND)
+        return UserProfileAppResponseDto.of(user, emptyList())
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/ActivityUnitAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/ActivityUnitAppRequestDto.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.application.dto.request
 
-import co.yappuworld.user.domain.ActivityUnit
+import co.yappuworld.user.domain.model.ActivityUnit
 import co.yappuworld.user.presentation.vo.PositionApiType
 
 data class ActivityUnitAppRequestDto(

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/ActivityUnitAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/ActivityUnitAppRequestDto.kt
@@ -1,14 +1,14 @@
 package co.yappuworld.user.application.dto.request
 
-import co.yappuworld.user.domain.model.ActivityUnit
+import co.yappuworld.user.domain.model.ActivityUnitParam
 import co.yappuworld.user.presentation.vo.PositionApiType
 
 data class ActivityUnitAppRequestDto(
     val generation: Int,
     val position: PositionApiType
 ) {
-    fun toDomain(): ActivityUnit {
-        return ActivityUnit(
+    fun toActivityUnitParam(): ActivityUnitParam {
+        return ActivityUnitParam(
             this.generation,
             this.position.toDomainType()
         )

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/SignUpApplicationApproveAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/SignUpApplicationApproveAppRequestDto.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.application.dto.request
 
-import co.yappuworld.user.domain.UserRole
+import co.yappuworld.user.domain.vo.UserRole
 import java.util.UUID
 
 data class SignUpApplicationApproveAppRequestDto(

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/UserSignUpAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/UserSignUpAppRequestDto.kt
@@ -1,8 +1,8 @@
 package co.yappuworld.user.application.dto.request
 
 import co.yappuworld.user.domain.UserRole
-import co.yappuworld.user.domain.User
-import co.yappuworld.user.domain.SignUpApplicantDetails
+import co.yappuworld.user.domain.model.User
+import co.yappuworld.user.domain.model.SignUpApplicantDetails
 
 data class UserSignUpAppRequestDto(
     val email: String,

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/UserSignUpAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/UserSignUpAppRequestDto.kt
@@ -1,8 +1,9 @@
 package co.yappuworld.user.application.dto.request
 
-import co.yappuworld.user.domain.UserRole
-import co.yappuworld.user.domain.model.User
+import co.yappuworld.user.domain.model.ActivityUnit
 import co.yappuworld.user.domain.model.SignUpApplicantDetails
+import co.yappuworld.user.domain.model.User
+import co.yappuworld.user.domain.vo.UserRole
 
 data class UserSignUpAppRequestDto(
     val email: String,
@@ -25,7 +26,17 @@ data class UserSignUpAppRequestDto(
             this.email,
             this.password,
             this.name,
-            this.activityUnits.map { it.toDomain() }
+            this.activityUnits.map { it.toActivityUnitParam() }
         )
+    }
+
+    fun toActivityUnits(user: User): List<ActivityUnit> {
+        return this.activityUnits.map {
+            ActivityUnit(
+                it.generation,
+                it.position.toDomainType(),
+                user.id
+            )
+        }
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/ActivityUnitAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/ActivityUnitAppResponseDto.kt
@@ -1,0 +1,19 @@
+package co.yappuworld.user.application.dto.response
+
+import co.yappuworld.user.domain.Position
+import co.yappuworld.user.domain.model.ActivityUnit
+
+data class ActivityUnitAppResponseDto(
+    val generation: Int,
+    val position: Position
+) {
+
+    companion object {
+        fun of(activityUnit: ActivityUnit): ActivityUnitAppResponseDto {
+            return ActivityUnitAppResponseDto(
+                activityUnit.generation,
+                activityUnit.position
+            )
+        }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/ActivityUnitAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/ActivityUnitAppResponseDto.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.application.dto.response
 
-import co.yappuworld.user.domain.Position
+import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.model.ActivityUnit
 
 data class ActivityUnitAppResponseDto(

--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/LatestSignUpApplicationAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/LatestSignUpApplicationAppResponseDto.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.application.dto.response
 
-import co.yappuworld.user.domain.SignUpApplication
+import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.UserSignUpApplicationStatus
 
 data class LatestSignUpApplicationAppResponseDto(

--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/LatestSignUpApplicationAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/LatestSignUpApplicationAppResponseDto.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.application.dto.response
 
 import co.yappuworld.user.domain.model.SignUpApplication
-import co.yappuworld.user.domain.UserSignUpApplicationStatus
+import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
 
 data class LatestSignUpApplicationAppResponseDto(
     val status: UserSignUpApplicationStatus,

--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/UserProfileAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/UserProfileAppResponseDto.kt
@@ -1,0 +1,27 @@
+package co.yappuworld.user.application.dto.response
+
+import co.yappuworld.user.domain.model.ActivityUnit
+import co.yappuworld.user.domain.model.User
+import java.util.UUID
+
+data class UserProfileAppResponseDto(
+    val id: UUID,
+    val name: String,
+    val role: String,
+    val activityUnits: List<ActivityUnitAppResponseDto>
+) {
+
+    companion object {
+        fun of(
+            user: User,
+            activityUnits: List<ActivityUnit>
+        ): UserProfileAppResponseDto {
+            return UserProfileAppResponseDto(
+                user.id,
+                user.name,
+                user.role.label,
+                activityUnits.map { ActivityUnitAppResponseDto.of(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/domain/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/UserError.kt
@@ -5,6 +5,13 @@ import co.yappuworld.global.exception.ErrorType
 
 enum class UserError : Error {
 
+    // 회원 일반 에러
+    USER_NOT_FOUND {
+        override val message: String = "유저가 존재하지 않습니다."
+        override val code: String = "USR_0001"
+        override val type: ErrorType = ErrorType.NOT_FOUND
+    },
+
     // 1000번대 - 회원가입 에러
     INVALID_SIGN_UP_CODE {
         override val message: String = "잘못된 가입코드입니다."

--- a/src/main/kotlin/co/yappuworld/user/domain/UserRole.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/UserRole.kt
@@ -7,10 +7,11 @@ package co.yappuworld.user.domain
  * @property ACTIVE 활동회원
  */
 enum class UserRole(
-    val authority: String
+    val authority: String,
+    val label: String
 ) {
-    ADMIN("ROLE_ADMIN"),
-    ALUMNI("ROLE_ALUMNI"),
-    GRADUATE("ROLE_GRADUATE"),
-    ACTIVE("ROLE_ACTIVE")
+    ADMIN("ROLE_ADMIN", "관리자"),
+    ALUMNI("ROLE_ALUMNI", "정회원"),
+    GRADUATE("ROLE_GRADUATE", "수료회원"),
+    ACTIVE("ROLE_ACTIVE", "활동회원")
 }

--- a/src/main/kotlin/co/yappuworld/user/domain/model/ActivityUnit.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/ActivityUnit.kt
@@ -1,4 +1,6 @@
-package co.yappuworld.user.domain
+package co.yappuworld.user.domain.model
+
+import co.yappuworld.user.domain.Position
 
 /**
  * @property generation 기수

--- a/src/main/kotlin/co/yappuworld/user/domain/model/ActivityUnit.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/ActivityUnit.kt
@@ -1,12 +1,42 @@
 package co.yappuworld.user.domain.model
 
-import co.yappuworld.user.domain.Position
+import co.yappuworld.global.persistence.BaseEntity
+import co.yappuworld.user.domain.vo.Position
+import com.github.f4b6a3.ulid.UlidCreator
+import org.springframework.data.annotation.Id
+import org.springframework.data.domain.Persistable
+import org.springframework.data.relational.core.mapping.Table
+import java.util.UUID
 
 /**
  * @property generation 기수
  * @property position 직군
  */
-data class ActivityUnit(
+@Table("activity_units")
+class ActivityUnit private constructor(
     val generation: Int,
-    val position: Position
-)
+    val position: Position,
+    val userId: UUID,
+    @Id
+    @JvmField
+    val id: UUID
+) : BaseEntity(), Persistable<UUID> {
+
+    constructor(
+        generation: Int,
+        position: Position,
+        userId: UUID
+    ) : this(generation, position, userId, UlidCreator.getMonotonicUlid().toUuid())
+
+    fun withId(id: UUID): ActivityUnit {
+        return ActivityUnit(generation, position, userId, id)
+    }
+
+    override fun getId(): UUID {
+        return this.id
+    }
+
+    override fun isNew(): Boolean {
+        return !isCreatedAtInitialized()
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/domain/model/ActivityUnitParam.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/ActivityUnitParam.kt
@@ -1,0 +1,17 @@
+package co.yappuworld.user.domain.model
+
+import co.yappuworld.user.domain.vo.Position
+import java.util.UUID
+
+data class ActivityUnitParam(
+    val generation: Int,
+    val position: Position
+) {
+    fun toActivityUnit(userId: UUID): ActivityUnit {
+        return ActivityUnit(
+            generation,
+            position,
+            userId
+        )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplicantDetails.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplicantDetails.kt
@@ -1,12 +1,12 @@
 package co.yappuworld.user.domain.model
 
-import co.yappuworld.user.domain.UserRole
+import co.yappuworld.user.domain.vo.UserRole
 
 data class SignUpApplicantDetails(
     val email: String,
     val password: String,
     val name: String,
-    val activityUnits: List<ActivityUnit>
+    val activityUnits: List<ActivityUnitParam>
 ) {
     fun toUser(role: UserRole): User {
         return User(

--- a/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplicantDetails.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplicantDetails.kt
@@ -1,4 +1,6 @@
-package co.yappuworld.user.domain
+package co.yappuworld.user.domain.model
+
+import co.yappuworld.user.domain.UserRole
 
 data class SignUpApplicantDetails(
     val email: String,

--- a/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplication.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplication.kt
@@ -1,7 +1,10 @@
-package co.yappuworld.user.domain
+package co.yappuworld.user.domain.model
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.persistence.BaseEntity
+import co.yappuworld.user.domain.UserError
+import co.yappuworld.user.domain.UserRole
+import co.yappuworld.user.domain.UserSignUpApplicationStatus
 import com.github.f4b6a3.ulid.UlidCreator
 import org.springframework.data.annotation.Id
 import org.springframework.data.domain.Persistable

--- a/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplication.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplication.kt
@@ -2,9 +2,9 @@ package co.yappuworld.user.domain.model
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.persistence.BaseEntity
-import co.yappuworld.user.domain.UserError
-import co.yappuworld.user.domain.UserRole
-import co.yappuworld.user.domain.UserSignUpApplicationStatus
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
 import com.github.f4b6a3.ulid.UlidCreator
 import org.springframework.data.annotation.Id
 import org.springframework.data.domain.Persistable
@@ -35,7 +35,7 @@ class SignUpApplication private constructor(
         null
     )
 
-    fun approve(role: UserRole) {
+    fun approve() {
         this.status = UserSignUpApplicationStatus.APPROVED
     }
 
@@ -60,5 +60,11 @@ class SignUpApplication private constructor(
 
     override fun isNew(): Boolean {
         return !isCreatedAtInitialized()
+    }
+
+    fun toActivityUnits(user: User): List<ActivityUnit> {
+        return this.applicantDetails.activityUnits.map {
+            it.toActivityUnit(user.id)
+        }
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
@@ -1,6 +1,7 @@
-package co.yappuworld.user.domain
+package co.yappuworld.user.domain.model
 
 import co.yappuworld.global.persistence.BaseEntity
+import co.yappuworld.user.domain.UserRole
 import com.github.f4b6a3.ulid.UlidCreator
 import org.springframework.data.annotation.Id
 import org.springframework.data.domain.Persistable

--- a/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.domain.model
 
 import co.yappuworld.global.persistence.BaseEntity
-import co.yappuworld.user.domain.UserRole
+import co.yappuworld.user.domain.vo.UserRole
 import com.github.f4b6a3.ulid.UlidCreator
 import org.springframework.data.annotation.Id
 import org.springframework.data.domain.Persistable

--- a/src/main/kotlin/co/yappuworld/user/domain/model/UserProfile.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/UserProfile.kt
@@ -1,0 +1,10 @@
+package co.yappuworld.user.domain.model
+
+import co.yappuworld.user.domain.UserRole
+import java.util.UUID
+
+data class UserProfile(
+    val id: UUID,
+    val name: String,
+    val role: UserRole
+)

--- a/src/main/kotlin/co/yappuworld/user/domain/model/UserProfile.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/UserProfile.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.domain.model
 
-import co.yappuworld.user.domain.UserRole
+import co.yappuworld.user.domain.vo.UserRole
 import java.util.UUID
 
 data class UserProfile(

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.user.domain
+package co.yappuworld.user.domain.vo
 
 enum class Position {
     PM,

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.user.domain
+package co.yappuworld.user.domain.vo
 
 import co.yappuworld.global.exception.Error
 import co.yappuworld.global.exception.ErrorType

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.user.domain
+package co.yappuworld.user.domain.vo
 
 /**
  * @property ADMIN 관리자

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserSignUpApplicationStatus.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserSignUpApplicationStatus.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.user.domain
+package co.yappuworld.user.domain.vo
 
 /**
  * @property PENDING 신청상태

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/ActivityUnitRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/ActivityUnitRepository.kt
@@ -1,0 +1,9 @@
+package co.yappuworld.user.infrastructure
+
+import co.yappuworld.user.domain.model.ActivityUnit
+import org.springframework.data.repository.CrudRepository
+import java.util.UUID
+
+interface ActivityUnitRepository : CrudRepository<ActivityUnit, UUID> {
+    fun findAllByUserId(userId: UUID): List<ActivityUnit>
+}

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserRepository.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.infrastructure
 
-import co.yappuworld.user.domain.User
+import co.yappuworld.user.domain.model.User
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserSignUpApplicationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserSignUpApplicationRepository.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.infrastructure
 
-import co.yappuworld.user.domain.SignUpApplication
+import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.UserSignUpApplicationStatus
 import org.springframework.data.domain.Limit
 import org.springframework.data.repository.CrudRepository

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserSignUpApplicationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserSignUpApplicationRepository.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.infrastructure
 
 import co.yappuworld.user.domain.model.SignUpApplication
-import co.yappuworld.user.domain.UserSignUpApplicationStatus
+import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
 import org.springframework.data.domain.Limit
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserProfileApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserProfileApi.kt
@@ -1,0 +1,61 @@
+package co.yappuworld.user.presentation
+
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.global.security.SecurityUser
+import co.yappuworld.user.presentation.dto.response.UserProfileApiResponseDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+
+@Tag(name = "유저 프로필 API", description = "프로필 조회, 수정 등..")
+interface UserProfileApi {
+
+    @Operation(summary = "프로필 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "프로필 조회 성공",
+                                value = """
+                                    {
+                                        "isSuccess": "true",
+                                        "data": {
+                                            "id": "79d52d77-6123-40f1-9f70-64bcbd6ca21a",
+                                            "name": "홍길동",
+                                            "email": "abc@abc.com",
+                                            "activityUnits": [
+                                                {
+                                                    "generation": "1",
+                                                    "position": "PM"
+                                                },
+                                                {
+                                                    "generation": "2",
+                                                    "position": "ANDROID"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/v1/users/profile")
+    fun getProfile(
+        @AuthenticationPrincipal securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<UserProfileApiResponseDto>>
+}

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserProfileController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserProfileController.kt
@@ -1,0 +1,24 @@
+package co.yappuworld.user.presentation
+
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.global.security.SecurityUser
+import co.yappuworld.user.application.UserProfileService
+import co.yappuworld.user.presentation.dto.response.UserProfileApiResponseDto
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class UserProfileController(
+    private val userProfileService: UserProfileService
+) : UserProfileApi {
+
+    override fun getProfile(securityUser: SecurityUser): ResponseEntity<SuccessResponse<UserProfileApiResponseDto>> {
+        return ResponseEntity.ok(
+            SuccessResponse.of(
+                UserProfileApiResponseDto.of(
+                    userProfileService.findUserProfile(securityUser.userId)
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/ActivityUnitApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/ActivityUnitApiRequestDto.kt
@@ -3,11 +3,13 @@ package co.yappuworld.user.presentation.dto.request
 import co.yappuworld.user.application.dto.request.ActivityUnitAppRequestDto
 import co.yappuworld.user.presentation.vo.PositionApiType
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
 
 data class ActivityUnitApiRequestDto(
     @Schema(description = "기수")
     @field:NotEmpty(message = "기수는 필수로 입력해야 합니다.")
+    @field:Min(value = 1L)
     val generation: Int,
     @Schema(description = "직군")
     @field:NotEmpty(message = "직군은 필수로 입력해야 합니다.")

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/SignUpApplicationApproveApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/SignUpApplicationApproveApiRequestDto.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.presentation.dto.request
 
-import co.yappuworld.user.domain.UserRole
+import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.application.dto.request.SignUpApplicationApproveAppRequestDto
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/UserSignUpApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/UserSignUpApiRequestDto.kt
@@ -8,19 +8,19 @@ import org.hibernate.validator.constraints.Length
 
 @Schema(description = "회원가입 요청")
 data class UserSignUpApiRequestDto(
-    @Schema(description = "이메일", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "이메일", example = "email@email.com")
     @field:Email(message = "올바르지 않은 이메일 형식입니다.")
     @field:NotEmpty(message = "이메일은 필수로 입력해야 합니다.")
     val email: String,
-    @Schema(description = "비밀번호, 8~20자")
+    @Schema(description = "비밀번호, 8~20자", example = "abcabC!!")
     @field:NotEmpty(message = "비밀번호는 필수로 입력해야 합니다.")
     @field:Length(min = 8, max = 20, message = "올바르지 않은 비밀번호입니다.")
     val password: String,
-    @Schema(description = "실명")
+    @Schema(description = "실명", example = "홍길동")
     @field:NotEmpty(message = "실명은 필수로 입력해야 합니다.")
     val name: String,
-    @NotEmpty
     @Schema(description = "활동한 기수와 직군 기입")
+    @field:NotEmpty
     val activityUnits: List<ActivityUnitApiRequestDto>,
     @Schema(description = "가입코드, 6자리 숫자", example = "000000")
     val signUpCode: String

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/response/ActivityUnitApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/response/ActivityUnitApiResponseDto.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.presentation.dto.response
 
 import co.yappuworld.user.application.dto.response.ActivityUnitAppResponseDto
-import co.yappuworld.user.domain.Position
+import co.yappuworld.user.domain.vo.Position
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class ActivityUnitApiResponseDto(

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/response/ActivityUnitApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/response/ActivityUnitApiResponseDto.kt
@@ -1,0 +1,22 @@
+package co.yappuworld.user.presentation.dto.response
+
+import co.yappuworld.user.application.dto.response.ActivityUnitAppResponseDto
+import co.yappuworld.user.domain.Position
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ActivityUnitApiResponseDto(
+    @Schema(description = "기수")
+    val generation: Int,
+    @Schema(description = "직군")
+    val position: Position
+) {
+
+    companion object {
+        fun of(response: ActivityUnitAppResponseDto): ActivityUnitApiResponseDto {
+            return ActivityUnitApiResponseDto(
+                response.generation,
+                response.position
+            )
+        }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/response/LatestSignUpApplicationApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/response/LatestSignUpApplicationApiResponseDto.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.presentation.dto.response
 
 import co.yappuworld.user.application.dto.response.LatestSignUpApplicationAppResponseDto
-import co.yappuworld.user.domain.UserSignUpApplicationStatus
+import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class LatestSignUpApplicationApiResponseDto(

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/response/UserProfileApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/response/UserProfileApiResponseDto.kt
@@ -1,0 +1,28 @@
+package co.yappuworld.user.presentation.dto.response
+
+import co.yappuworld.user.application.dto.response.UserProfileAppResponseDto
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+data class UserProfileApiResponseDto(
+    @Schema(description = "유저 식별자")
+    val id: UUID,
+    @Schema(description = "실명")
+    val name: String,
+    @Schema(description = "유저 유형")
+    val role: String,
+    @Schema(description = "기수, 직군 목록")
+    val activityUnits: List<ActivityUnitApiResponseDto>
+) {
+
+    companion object {
+        fun of(response: UserProfileAppResponseDto): UserProfileApiResponseDto {
+            return UserProfileApiResponseDto(
+                response.id,
+                response.name,
+                response.role,
+                response.activityUnits.map { ActivityUnitApiResponseDto.of(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/presentation/vo/PositionApiType.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/vo/PositionApiType.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.presentation.vo
 
-import co.yappuworld.user.domain.Position
+import co.yappuworld.user.domain.vo.Position
 
 enum class PositionApiType {
     PM,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -30,4 +30,15 @@ CREATE TABLE sign_up_application
     applicant_details json        NOT NULL,
     status            varchar(16) NOT NULL,
     reject_reason     varchar(128)
-)
+);
+
+DROP TABLE IF EXISTS activity_units;
+CREATE TABLE activity_units
+(
+    id         varchar(36) PRIMARY KEY,
+    created_at datetime,
+    updated_at datetime,
+    generation int         NOT NULL,
+    position   varchar(16) NOT NULL,
+    user_id    varchar(36) NOT NULL
+);

--- a/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
@@ -1,10 +1,10 @@
 package co.yappuworld.support.fixture.user
 
-import co.yappuworld.user.domain.ActivityUnit
+import co.yappuworld.user.domain.model.ActivityUnit
 import co.yappuworld.user.domain.Position
-import co.yappuworld.user.domain.SignUpApplicantDetails
-import co.yappuworld.user.domain.SignUpApplication
-import co.yappuworld.user.domain.User
+import co.yappuworld.user.domain.model.SignUpApplicantDetails
+import co.yappuworld.user.domain.model.SignUpApplication
+import co.yappuworld.user.domain.model.User
 import co.yappuworld.user.domain.UserRole
 
 fun getUserFixture(

--- a/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
@@ -1,11 +1,11 @@
 package co.yappuworld.support.fixture.user
 
 import co.yappuworld.user.domain.model.ActivityUnit
-import co.yappuworld.user.domain.Position
+import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.model.SignUpApplicantDetails
 import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.model.User
-import co.yappuworld.user.domain.UserRole
+import co.yappuworld.user.domain.vo.UserRole
 
 fun getUserFixture(
     email: String = "email@email.com",

--- a/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
@@ -1,11 +1,13 @@
 package co.yappuworld.support.fixture.user
 
 import co.yappuworld.user.domain.model.ActivityUnit
-import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.domain.model.ActivityUnitParam
 import co.yappuworld.user.domain.model.SignUpApplicantDetails
 import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.model.User
+import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.vo.UserRole
+import com.github.f4b6a3.ulid.UlidCreator
 
 fun getUserFixture(
     email: String = "email@email.com",
@@ -29,19 +31,27 @@ fun getSignUpApplicationDetails(
     email: String = "email@email.com",
     password: String = "abcabC!!",
     name: String = "name",
-    activityUnits: List<ActivityUnit> = getActivityUnits()
+    activityUnitParams: List<ActivityUnitParam> = getActivityUnitParams()
 ): SignUpApplicantDetails {
     return SignUpApplicantDetails(
         email,
         password,
         name,
-        activityUnits
+        activityUnitParams
     )
+}
+
+fun getActivityUnitParams(
+    vararg activityUnitParams: ActivityUnitParam = arrayOf(
+        ActivityUnitParam(1, Position.PM)
+    )
+): List<ActivityUnitParam> {
+    return activityUnitParams.toList()
 }
 
 fun getActivityUnits(
     vararg activityUnits: ActivityUnit = arrayOf(
-        ActivityUnit(1, Position.PM)
+        ActivityUnit(1, Position.PM, UlidCreator.getMonotonicUlid().toUuid())
     )
 ): List<ActivityUnit> {
     return activityUnits.toList()

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
@@ -10,7 +10,7 @@ import co.yappuworld.support.fixture.user.getUserFixture
 import co.yappuworld.user.application.dto.request.ActivityUnitAppRequestDto
 import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
 import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
-import co.yappuworld.user.domain.SignUpApplication
+import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.UserError
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
@@ -11,7 +11,7 @@ import co.yappuworld.user.application.dto.request.ActivityUnitAppRequestDto
 import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
 import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
 import co.yappuworld.user.domain.model.SignUpApplication
-import co.yappuworld.user.domain.UserError
+import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import co.yappuworld.user.presentation.vo.PositionApiType

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
@@ -12,6 +12,7 @@ import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
 import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
 import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.infrastructure.ActivityUnitRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import co.yappuworld.user.presentation.vo.PositionApiType
@@ -34,12 +35,14 @@ class UserAuthServiceTest {
     )
     private val userRepository = mockk<UserRepository>()
     private val authApplicationRepository = mockk<UserSignUpApplicationRepository>()
+    private val activityUnitRepository = mockk<ActivityUnitRepository>()
     private val jwtGenerator = JwtGenerator(jwtProperty)
     private val jwtResolver = JwtResolver(jwtProperty)
     private val configInquiryComponent = mockk<ConfigInquiryComponent>()
     private val userAuthService = UserAuthService(
         userRepository,
         authApplicationRepository,
+        activityUnitRepository,
         jwtGenerator,
         jwtResolver,
         configInquiryComponent

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthSignUpApplicationServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthSignUpApplicationServiceTest.kt
@@ -9,8 +9,8 @@ import co.yappuworld.support.fixture.user.dto.getLatestSignUpApplicationAppReque
 import co.yappuworld.support.fixture.user.getSignUpApplication
 import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.vo.UserError
-import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
+import co.yappuworld.user.infrastructure.ActivityUnitRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import io.mockk.every
@@ -32,12 +32,14 @@ class UserAuthSignUpApplicationServiceTest {
     )
     private val userRepository = mockk<UserRepository>()
     private val authApplicationRepository = mockk<UserSignUpApplicationRepository>()
+    private val activityUnitRepository = mockk<ActivityUnitRepository>()
     private val jwtGenerator = JwtGenerator(jwtProperty)
     private val jwtResolver = JwtResolver(jwtProperty)
     private val configInquiryComponent = mockk<ConfigInquiryComponent>()
     private val userAuthService = UserAuthService(
         userRepository,
         authApplicationRepository,
+        activityUnitRepository,
         jwtGenerator,
         jwtResolver,
         configInquiryComponent
@@ -49,7 +51,7 @@ class UserAuthSignUpApplicationServiceTest {
             return listOf(
                 getSignUpApplication(),
                 getSignUpApplication().apply { reject("거절") },
-                getSignUpApplication().apply { approve(UserRole.ADMIN) }
+                getSignUpApplication().apply { approve() }
             )
         }
     }

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthSignUpApplicationServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthSignUpApplicationServiceTest.kt
@@ -8,9 +8,9 @@ import co.yappuworld.operation.application.ConfigInquiryComponent
 import co.yappuworld.support.fixture.user.dto.getLatestSignUpApplicationAppRequestDtoFixture
 import co.yappuworld.support.fixture.user.getSignUpApplication
 import co.yappuworld.user.domain.model.SignUpApplication
-import co.yappuworld.user.domain.UserError
-import co.yappuworld.user.domain.UserRole
-import co.yappuworld.user.domain.UserSignUpApplicationStatus
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import io.mockk.every

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthSignUpApplicationServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthSignUpApplicationServiceTest.kt
@@ -7,7 +7,7 @@ import co.yappuworld.global.security.JwtResolver
 import co.yappuworld.operation.application.ConfigInquiryComponent
 import co.yappuworld.support.fixture.user.dto.getLatestSignUpApplicationAppRequestDtoFixture
 import co.yappuworld.support.fixture.user.getSignUpApplication
-import co.yappuworld.user.domain.SignUpApplication
+import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.UserError
 import co.yappuworld.user.domain.UserRole
 import co.yappuworld.user.domain.UserSignUpApplicationStatus

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
@@ -1,9 +1,9 @@
 package co.yappuworld.user.infrastructure
 
-import co.yappuworld.user.domain.ActivityUnit
+import co.yappuworld.user.domain.model.ActivityUnit
 import co.yappuworld.user.domain.Position
-import co.yappuworld.user.domain.SignUpApplicantDetails
-import co.yappuworld.user.domain.SignUpApplication
+import co.yappuworld.user.domain.model.SignUpApplicantDetails
+import co.yappuworld.user.domain.model.SignUpApplication
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.infrastructure
 
 import co.yappuworld.user.domain.model.ActivityUnit
-import co.yappuworld.user.domain.Position
+import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.model.SignUpApplicantDetails
 import co.yappuworld.user.domain.model.SignUpApplication
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
@@ -1,9 +1,9 @@
 package co.yappuworld.user.infrastructure
 
-import co.yappuworld.user.domain.model.ActivityUnit
-import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.domain.model.ActivityUnitParam
 import co.yappuworld.user.domain.model.SignUpApplicantDetails
 import co.yappuworld.user.domain.model.SignUpApplication
+import co.yappuworld.user.domain.vo.Position
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ class SignUpApplicantDetailsRepositoryConverterTest {
             "abc@abc.com",
             "abc",
             "abc",
-            listOf(ActivityUnit(0, Position.PM))
+            listOf(ActivityUnitParam(0, Position.PM))
         ).let { userSignUpApplicationRepository.save(SignUpApplication(it)) }
 
         assertThat(checkNotNull(userSignUpApplicationRepository.findByIdOrNull(application.id)))
@@ -43,7 +43,7 @@ class SignUpApplicantDetailsRepositoryConverterTest {
             "abc@abc.com",
             "abc",
             "abc",
-            listOf(ActivityUnit(0, Position.PM))
+            listOf(ActivityUnitParam(0, Position.PM))
         )
         val firstApplication = SignUpApplication(firstDetails).also { it.reject("거절") }
         val secondApplication = SignUpApplication(firstDetails)


### PR DESCRIPTION
## 📌 Related Issue
#20 


## 🚨 해결하려는 문제가 무엇인가요?
- 홈화면에 노출되는 프로필 정보를 제공해야 합니다.


## ⭐️ 어떻게 해결했나요?
- 프로필 조회 API를 제공합니다.

### ActivityUnit
- 기존에 ActivityUnit(기수, 직군 정보) 관련 기능이 개발되지 않아서 함께 개발했습니다.
- ActivityUnit 변경
	- 데이터 저장을 위해 activity_units 테이블을 생성합니다.
	- 외래키로 user_id를 사용합니다. (fk 설정은 하지 않았습니다.)
	- 확장성을 고려하여 별도 테이블로 분리하는게 좋다고 판단했습니다.
		- 가령 특정 기수, 특정 직군 회원만 추출하는 경우에 용이
- 회원가입 신청 시
	- 메타 정보를 저장할 때 ActivityUnitParam 객체로 저장합니다.
	- ActivityUnit이 userId를 필수로 갖게 됨에 따라, 회원 신청 시에는 userId가 존재하지 않으므로 ActivityUnit을 신청서 내부에 저장할 수 없습니다.
	- 따라서, ActivityUnit이 아닌, ActivityUnitParam을 저장합니다.
- 회원가입 승인 시
	- User 저장 후 ActivityUnit까지 함께 저장합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
