### PR TITLE
fix: 직군 순서 변경

### DIFF
--- a/.github/workflows/yappu-world-dev-cd.yaml
+++ b/.github/workflows/yappu-world-dev-cd.yaml
@@ -46,7 +46,7 @@ jobs:
                 run: |
                     mkdir -p deployment/build/libs
                     cp ./docker/dockerfile-dev ./docker/docker-compose-dev.yaml deployment/
-                    cp -r ./build/libs/yappu-world.jar deployment/build/libs
+                    cp -r ./build/libs/yappu-world-dev.jar deployment/build/libs
 
             # Github Action 실행 서버 IP 추출
             -   name: Get Github Actions IP

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
@@ -8,6 +8,6 @@ enum class Position(
     WEB("Web"),
     ANDROID("Android"),
     IOS("iOS"),
-    SERVER("Server"),
-    FLUTTER("Flutter")
+    FLUTTER("Flutter"),
+    SERVER("Server")
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 직군 종류를 내려주는 API의 순서를 변경합니다.


## ⭐️ 어떻게 해결했나요?
- 현재 직군 정보는 Position Enum을 그대로 내려주고 있습니다.
- Kotlin Enum에서 entries는 선언된 순서대로 반환하므로, Position의 선언된 순서만 변경해주었습니다.
	- 약속된 순서는 PM, DESIGN, WEB, ANDROID, IOS, FLUTTER, SERVER 순입니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
