### PR TITLE
feat: 회원 탈퇴

### DIFF
--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -25,6 +25,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.util.UUID
 
 private val logger = KotlinLogging.logger { }
 
@@ -89,8 +90,6 @@ class UserAuthService(
             throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
         }
 
-        // TODO - AT와 RT의 화이트리스트 또는 블랙리스트 전략 필요
-
         return jwtGenerator.generateToken(SecurityUser.from(userOrNull), request.now)
     }
 
@@ -112,6 +111,14 @@ class UserAuthService(
             ?: throw BusinessException(UserError.NO_SIGN_UP_APPLICATION)
 
         return LatestSignUpApplicationAppResponseDto.of(signUpApplication)
+    }
+
+    @Transactional
+    fun withdrawUser(userId: UUID) {
+        userRepository.findByIdOrNull(userId)
+            ?.apply { withdraw() }
+            ?.let(userRepository::save)
+            ?: throw BusinessException(UserError.USER_NOT_FOUND)
     }
 
     private fun validateApplication(email: String) {

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -12,6 +12,8 @@ import co.yappuworld.user.application.dto.request.LoginAppRequestDto
 import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
 import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
 import co.yappuworld.user.application.dto.response.LatestSignUpApplicationAppResponseDto
+import co.yappuworld.user.domain.checkLoginAvailability
+import co.yappuworld.user.domain.checkNewApplications
 import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.domain.vo.UserRole
@@ -44,8 +46,7 @@ class UserAuthService(
         request: UserSignUpAppRequestDto,
         now: LocalDateTime
     ) {
-        validateApplication(request.email)
-
+        checkNewApplication(request.email)
         SignUpApplication(request.toSignUpApplication()).let {
             userSignUpApplicationRepository.save(it)
         }
@@ -73,24 +74,24 @@ class UserAuthService(
         request: LoginAppRequestDto,
         now: LocalDateTime
     ): Token {
-        return userRepository.findUserOrNullByEmail(request.email)
-            ?.let {
-                it.checkPassword(request.password)
-                jwtGenerator.generateToken(SecurityUser.from(it), now)
-            } ?: processLoginException(request.email)
+        val user = userRepository.findUserOrNullByEmail(request.email)
+            ?.apply { this.checkLoginAvailability(request.password) }
+            ?: processLoginException(request.email)
+
+        return jwtGenerator.generateToken(SecurityUser.from(user), now)
     }
 
     @Transactional
     fun reissueToken(request: ReissueTokenAppRequestDto): Token {
         val userId = jwtResolver.extractUserIdFrom(request.accessToken)
-        val userOrNull = userRepository.findByIdOrNull(userId)
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
 
-        if (userOrNull == null) {
-            logger.error { "$userId 유저를 찾을 수 없습니다." }
-            throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
+        if (!user.isActive) {
+            throw BusinessException(UserError.WITHDRAWN_USER)
         }
 
-        return jwtGenerator.generateToken(SecurityUser.from(userOrNull), request.now)
+        return jwtGenerator.generateToken(SecurityUser.from(user), request.now)
     }
 
     @Transactional(readOnly = true)
@@ -121,25 +122,16 @@ class UserAuthService(
             ?: throw BusinessException(UserError.USER_NOT_FOUND)
     }
 
-    private fun validateApplication(email: String) {
+    private fun checkNewApplication(email: String) {
         if (userRepository.existsUserByEmail(email)) {
             logger.error { "${email}은 이미 가입된 이메일입니다." }
             throw BusinessException(UserError.ALREADY_SIGNED_UP_EMAIL)
         }
 
-        val applications = userSignUpApplicationRepository.findByApplicantEmailAndStatus(
+        userSignUpApplicationRepository.findByApplicantEmailAndStatus(
             email,
             UserSignUpApplicationStatus.PENDING
-        )
-
-        if (applications.isEmpty()) {
-            return
-        }
-
-        if (applications.any { it.status == UserSignUpApplicationStatus.PENDING }) {
-            logger.error { "${email}의 처리되지 않은 기존 신청이 존재합니다." }
-            throw BusinessException(UserError.UNPROCESSED_APPLICATION_EXISTS)
-        }
+        ).apply { checkNewApplications(email) }
     }
 
     private fun getUserRoleWithSignUpCode(signUpCode: String): UserRole {

--- a/src/main/kotlin/co/yappuworld/user/domain/UserAuthValidator.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/UserAuthValidator.kt
@@ -1,0 +1,28 @@
+package co.yappuworld.user.domain
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.user.domain.model.SignUpApplication
+import co.yappuworld.user.domain.model.User
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger { }
+
+fun User.checkLoginAvailability(requestPassword: String) {
+    this.checkPassword(requestPassword)
+    if (isWithdrawn()) {
+        throw BusinessException(UserError.WITHDRAWN_USER)
+    }
+}
+
+fun List<SignUpApplication>.checkNewApplications(email: String) {
+    if (this.isEmpty()) {
+        return
+    }
+
+    if (this.any { it.status == UserSignUpApplicationStatus.PENDING }) {
+        logger.error { "${email}의 처리되지 않은 기존 신청이 존재합니다." }
+        throw BusinessException(UserError.UNPROCESSED_APPLICATION_EXISTS)
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
@@ -17,19 +17,21 @@ class User private constructor(
     val password: String,
     val name: String,
     val role: UserRole,
-    val isActive: Boolean = true,
+    isActive: Boolean = true,
     @Id
     @JvmField
     val id: UUID
 ) : BaseEntity(), Persistable<UUID> {
 
+    var isActive: Boolean = isActive
+        private set
+
     constructor(
         email: String,
         password: String,
         name: String,
-        role: UserRole,
-        isActive: Boolean = true
-    ) : this(email, password, name, role, isActive, UlidCreator.getMonotonicUlid().toUuid())
+        role: UserRole
+    ) : this(email, password, name, role, true, UlidCreator.getMonotonicUlid().toUuid())
 
     fun withId(id: UUID): User {
         return User(this.email, this.password, this.name, this.role, this.isActive, id)
@@ -47,5 +49,13 @@ class User private constructor(
         if (!EncryptUtils.isMatch(plainPassword, this.password)) {
             throw BusinessException(UserError.WRONG_LOGIN_USER_INFORMATION)
         }
+    }
+
+    fun withdraw() {
+        if (!this.isActive) {
+            throw BusinessException(UserError.ALREADY_WITHDRAWN_USER)
+        }
+
+        this.isActive = false
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
@@ -58,4 +58,8 @@ class User private constructor(
 
         this.isActive = false
     }
+
+    fun isWithdrawn(): Boolean {
+        return !this.isActive
+    }
 }

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
@@ -11,6 +11,11 @@ enum class UserError : Error {
         override val code: String = "USR_0001"
         override val type: ErrorType = ErrorType.NOT_FOUND
     },
+    WITHDRAWN_USER {
+        override val message: String = "탈퇴한 유저입니다."
+        override val code: String = "USR_0002"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    },
 
     // 1000번대 - 회원가입 에러
     INVALID_SIGN_UP_CODE {

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
@@ -79,5 +79,12 @@ enum class UserError : Error {
         override val message: String = "회원가입 신청을 한 내역이 없습니다."
         override val code: String = "USR_1122"
         override val type: ErrorType = ErrorType.NOT_FOUND
+    },
+
+    // 1200번대 - 회원탈퇴 에러
+    ALREADY_WITHDRAWN_USER {
+        override val message: String = "이미 탈퇴한 계정입니다."
+        override val code: String = "USR_1201"
+        override val type: ErrorType = ErrorType.WRONG_STATE
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
@@ -2,6 +2,7 @@ package co.yappuworld.user.presentation
 
 import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.security.Token
 import co.yappuworld.user.presentation.dto.request.CheckingEmailAvailabilityApiRequestDto
 import co.yappuworld.user.presentation.dto.request.LatestSignUpApplicationApiRequestDto
@@ -18,6 +19,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -449,4 +452,41 @@ interface UserAuthApi {
     fun findLatestSignUpApplication(
         @Valid @RequestBody request: LatestSignUpApplicationApiRequestDto
     ): ResponseEntity<SuccessResponse<LatestSignUpApplicationApiResponseDto>>
+
+    @Operation(summary = "회원탈퇴")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                description = "회원탈퇴 성공",
+                responseCode = "204",
+                content = [Content(examples = emptyArray())]
+            ),
+            ApiResponse(
+                description = "이미 탈퇴한 계정입니다.",
+                responseCode = "409",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "이미 탈퇴한 계정입니다.",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "이미 탈퇴한 계정입니다.",
+                                        "errorCode": "USR_1201"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @DeleteMapping("/v1/auth/user")
+    fun withdrawUser(
+        @AuthenticationPrincipal securityUser: SecurityUser
+    ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
@@ -1,6 +1,7 @@
 package co.yappuworld.user.presentation
 
 import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.security.Token
 import co.yappuworld.user.application.UserAuthService
 import co.yappuworld.user.presentation.dto.request.CheckingEmailAvailabilityApiRequestDto
@@ -64,5 +65,10 @@ class UserAuthController(
                 )
             )
         )
+    }
+
+    override fun withdrawUser(securityUser: SecurityUser): ResponseEntity<Unit> {
+        userAuthService.withdrawUser(securityUser.userId)
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
@@ -15,14 +15,12 @@ object UserFixture {
         email: String = "email@email.com",
         password: String = "password",
         name: String = "name",
-        role: UserRole = UserRole.ACTIVE,
-        isActive: Boolean = true
+        role: UserRole = UserRole.ACTIVE
     ) = User(
         email = email,
         password = password,
         name = name,
-        role = role,
-        isActive = isActive
+        role = role
     )
 
     fun getSignUpApplication(details: SignUpApplicantDetails = getSignUpApplicationDetails()): SignUpApplication {

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
@@ -124,4 +124,23 @@ class UserAuthServiceTest {
             checkNotNull(jwtResolver.extractSecurityUserOrNull(reissuedToken.accessToken))
         }
     }
+
+    @Test
+    fun `이미 회원탈퇴 된 유저는 탈퇴 시 예외가 발생한다`() {
+        val user = getUserFixture().apply { withdraw() }
+        every { userRepository.findByIdOrNull(any()) } returns user
+
+        assertThatThrownBy { userAuthService.withdrawUser(user.id) }
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessage(UserError.ALREADY_WITHDRAWN_USER.message)
+    }
+
+    @Test
+    fun `탈퇴한 적 없는 유저는 정상적으로 탈퇴된다`() {
+        val user = getUserFixture()
+        every { userRepository.findByIdOrNull(any()) } returns user
+        every { userRepository.save(any()) } returns user
+
+        assertDoesNotThrow { userAuthService.withdrawUser(user.id) }
+    }
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 회원 탈퇴 기능을 개발합니다.


## ⭐️ 어떻게 해결했나요?
- isActive 필드만 false로 변경합니다.
- 로그인과 토큰 재발급 시 탈퇴 여부를 검증하도록 했습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?
- 검증 로직을 domain 영역으로 분리하려는 시도를 했는데 문제가 좀 있습니다.
  - 현재 Service에서 Domain과 Infrastructure를 참조하도록 해둔 상황입니다.
  - 가령, Email 중복 검사를 수행할 때는 Repository에서 exist 여부만 확인하면 됩니다. 도메인 영역을 거쳐 검증할 이유가 없습니다.
  - 그러나 로그인 시 비밀번호 검증과 같이, 도메인 영역에 위임하는게 적절한 경우가 있습니다.

- 정리하자면, 검증 로직이 두 가지 형태가 있습니다.
  1. Domain에 위임하는게 적합한 형태
  2. Infrastructure 레이어를 통해 Repository만 체크하면 되는 형태

- 검증의 유형에 따라 두 개의 방식이 존재하게 되고, 이에 따라 검증 로직이 Domain과 Service 영역에 분산되는 형태입니다.
- 현재의 구조도 크게 이상하다고 생각이 들지는 않지만, 검증 로직이 분산되는게 좋지는 않아보입니다.
- 대안이라면 Domain에서도 Infrastructure를 바라볼 수 있어야 한다는 것인데, 이 경우 Service에서 Infrastructure를 바라보지 않는게 합당해 보입니다.
- 의견 부탁드려요!


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
