### PR TITLE
feat: FCM 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -468,3 +468,5 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij,intellij+iml,intellij+all,eclipse,linux,windows,macos,java,kotlin,gradle,maven,git
+
+application-fcm-local.yaml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
 
     // fcm
     implementation("com.google.firebase:firebase-admin:9.4.3")
-    implementation("com.google.firebase:firebase-messaging:24.1.0")
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,10 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
+
+    // fcm
+    implementation("com.google.firebase:firebase-admin:9.4.3")
+    implementation("com.google.firebase:firebase-messaging:24.1.0")
 }
 
 kotlin {

--- a/src/main/kotlin/co/yappuworld/global/client/fcm/FcmClient.kt
+++ b/src/main/kotlin/co/yappuworld/global/client/fcm/FcmClient.kt
@@ -1,85 +1,16 @@
 package co.yappuworld.global.client.fcm
 
-import com.google.firebase.messaging.BatchResponse
-import com.google.firebase.messaging.FirebaseMessaging
-import com.google.firebase.messaging.FirebaseMessagingException
-import com.google.firebase.messaging.Message
-import com.google.firebase.messaging.MulticastMessage
 import com.google.firebase.messaging.Notification
-import io.github.oshai.kotlinlogging.KotlinLogging
-import org.springframework.stereotype.Component
 
-private val logger = KotlinLogging.logger { }
-
-@Component
-class FcmClient(
-    private val firebaseMessaging: FirebaseMessaging
-) {
+interface FcmClient {
 
     fun sendNotification(
         token: String,
         notification: Notification
-    ) {
-        try {
-            firebaseMessaging.send(
-                Message.builder()
-                    .setToken(token)
-                    .setNotification(notification)
-                    .build()
-            )
-        } catch (e: FirebaseMessagingException) {
-            logger.warn {
-                """
-                    푸시 알림 전송에 실패했습니다.
-                    실패 사유: ${e.messagingErrorCode.name}
-                    fcm_token: $token
-                """.trimIndent()
-            }
-        }
-    }
+    )
 
     fun sendNotification(
         tokens: List<String>,
         notification: Notification
-    ) {
-        if (tokens.size > 500) {
-            val message = "한 번에 요청할 수 있는 푸시 알림의 수는 500개입니다. 요청 개수: ${tokens.size}"
-            logger.warn { message }
-            throw IllegalArgumentException(message)
-        }
-
-        try {
-            val responses = firebaseMessaging.sendEachForMulticast(
-                MulticastMessage.builder()
-                    .addAllTokens(tokens)
-                    .setNotification(notification)
-                    .build()
-            )
-            loggingFirebaseMessaging(responses)
-        } catch (e: FirebaseMessagingException) {
-            logger.warn {
-                """
-                    다수의 푸시 알림 전송에 실패했습니다.
-                    실패 사유: ${e.messagingErrorCode.name}
-                """.trimIndent()
-            }
-        }
-    }
-
-    private fun loggingFirebaseMessaging(responses: BatchResponse) {
-        logger.info {
-            """
-                푸시 알림 전송 결과: 성공 ${responses.successCount}, 실패 ${responses.failureCount}
-                에러코드별 실패 횟수
-                ${getCountByErrorCode(responses)}
-            """.trimIndent()
-        }
-    }
-
-    private fun getCountByErrorCode(response: BatchResponse): Map<String, Int> {
-        return response.responses
-            .filter { !it.isSuccessful }
-            .groupingBy { it.exception.messagingErrorCode.name }
-            .eachCount()
-    }
+    )
 }

--- a/src/main/kotlin/co/yappuworld/global/client/fcm/FcmClient.kt
+++ b/src/main/kotlin/co/yappuworld/global/client/fcm/FcmClient.kt
@@ -1,0 +1,85 @@
+package co.yappuworld.global.client.fcm
+
+import com.google.firebase.messaging.BatchResponse
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.Notification
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger { }
+
+@Component
+class FcmClient(
+    private val firebaseMessaging: FirebaseMessaging
+) {
+
+    fun sendNotification(
+        token: String,
+        notification: Notification
+    ) {
+        try {
+            firebaseMessaging.send(
+                Message.builder()
+                    .setToken(token)
+                    .setNotification(notification)
+                    .build()
+            )
+        } catch (e: FirebaseMessagingException) {
+            logger.warn {
+                """
+                    푸시 알림 전송에 실패했습니다.
+                    실패 사유: ${e.messagingErrorCode.name}
+                    fcm_token: $token
+                """.trimIndent()
+            }
+        }
+    }
+
+    fun sendNotification(
+        tokens: List<String>,
+        notification: Notification
+    ) {
+        if (tokens.size > 500) {
+            val message = "한 번에 요청할 수 있는 푸시 알림의 수는 500개입니다. 요청 개수: ${tokens.size}"
+            logger.warn { message }
+            throw IllegalArgumentException(message)
+        }
+
+        try {
+            val responses = firebaseMessaging.sendEachForMulticast(
+                MulticastMessage.builder()
+                    .addAllTokens(tokens)
+                    .setNotification(notification)
+                    .build()
+            )
+            loggingFirebaseMessaging(responses)
+        } catch (e: FirebaseMessagingException) {
+            logger.warn {
+                """
+                    다수의 푸시 알림 전송에 실패했습니다.
+                    실패 사유: ${e.messagingErrorCode.name}
+                """.trimIndent()
+            }
+        }
+    }
+
+    private fun loggingFirebaseMessaging(responses: BatchResponse) {
+        logger.info {
+            """
+                푸시 알림 전송 결과: 성공 ${responses.successCount}, 실패 ${responses.failureCount}
+                에러코드별 실패 횟수
+                ${getCountByErrorCode(responses)}
+            """.trimIndent()
+        }
+    }
+
+    private fun getCountByErrorCode(response: BatchResponse): Map<String, Int> {
+        return response.responses
+            .filter { !it.isSuccessful }
+            .groupingBy { it.exception.messagingErrorCode.name }
+            .eachCount()
+    }
+}

--- a/src/main/kotlin/co/yappuworld/global/client/fcm/FcmClientImpl.kt
+++ b/src/main/kotlin/co/yappuworld/global/client/fcm/FcmClientImpl.kt
@@ -1,0 +1,89 @@
+package co.yappuworld.global.client.fcm
+
+import com.google.firebase.messaging.BatchResponse
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.Notification
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger { }
+
+@Component
+@Primary
+@Profile("!test")
+class FcmClientImpl(
+    private val firebaseMessaging: FirebaseMessaging
+) : FcmClient {
+
+    override fun sendNotification(
+        token: String,
+        notification: Notification
+    ) {
+        try {
+            firebaseMessaging.send(
+                Message.builder()
+                    .setToken(token)
+                    .setNotification(notification)
+                    .build()
+            )
+        } catch (e: FirebaseMessagingException) {
+            logger.warn {
+                """
+                    푸시 알림 전송에 실패했습니다.
+                    실패 사유: ${e.messagingErrorCode.name}
+                    fcm_token: $token
+                """.trimIndent()
+            }
+        }
+    }
+
+    override fun sendNotification(
+        tokens: List<String>,
+        notification: Notification
+    ) {
+        if (tokens.size > 500) {
+            val message = "한 번에 요청할 수 있는 푸시 알림의 수는 500개입니다. 요청 개수: ${tokens.size}"
+            logger.warn { message }
+            throw IllegalArgumentException(message)
+        }
+
+        try {
+            val responses = firebaseMessaging.sendEachForMulticast(
+                MulticastMessage.builder()
+                    .addAllTokens(tokens)
+                    .setNotification(notification)
+                    .build()
+            )
+            loggingFirebaseMessaging(responses)
+        } catch (e: FirebaseMessagingException) {
+            logger.warn {
+                """
+                    다수의 푸시 알림 전송에 실패했습니다.
+                    실패 사유: ${e.messagingErrorCode.name}
+                """.trimIndent()
+            }
+        }
+    }
+
+    private fun loggingFirebaseMessaging(responses: BatchResponse) {
+        logger.info {
+            """
+                푸시 알림 전송 결과: 성공 ${responses.successCount}, 실패 ${responses.failureCount}
+                에러코드별 실패 횟수
+                ${getCountByErrorCode(responses)}
+            """.trimIndent()
+        }
+    }
+
+    private fun getCountByErrorCode(response: BatchResponse): Map<String, Int> {
+        return response.responses
+            .filter { !it.isSuccessful }
+            .groupingBy { it.exception.messagingErrorCode.name }
+            .eachCount()
+    }
+}

--- a/src/main/kotlin/co/yappuworld/global/client/fcm/FcmClientInTest.kt
+++ b/src/main/kotlin/co/yappuworld/global/client/fcm/FcmClientInTest.kt
@@ -1,0 +1,22 @@
+package co.yappuworld.global.client.fcm
+
+import com.google.firebase.messaging.Notification
+import org.springframework.stereotype.Component
+
+@Component
+class FcmClientInTest : FcmClient {
+
+    override fun sendNotification(
+        token: String,
+        notification: Notification
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendNotification(
+        tokens: List<String>,
+        notification: Notification
+    ) {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/co/yappuworld/global/config/AppConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/AppConfig.kt
@@ -1,9 +1,10 @@
 package co.yappuworld.global.config
 
+import co.yappuworld.global.property.FcmProperty
 import co.yappuworld.global.property.JwtProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@EnableConfigurationProperties(JwtProperty::class)
+@EnableConfigurationProperties(JwtProperty::class, FcmProperty::class)
 class AppConfig

--- a/src/main/kotlin/co/yappuworld/global/config/FcmConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/FcmConfig.kt
@@ -7,8 +7,10 @@ import com.google.firebase.FirebaseOptions
 import com.google.firebase.messaging.FirebaseMessaging
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 
 @Configuration
+@Profile("!test")
 class FcmConfig(
     private val fcmProperty: FcmProperty
 ) {

--- a/src/main/kotlin/co/yappuworld/global/config/FcmConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/FcmConfig.kt
@@ -1,0 +1,40 @@
+package co.yappuworld.global.config
+
+import co.yappuworld.global.property.FcmProperty
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class FcmConfig(
+    private val fcmProperty: FcmProperty
+) {
+
+    @Bean
+    fun firebaseMessaging(): FirebaseMessaging {
+        val apps = FirebaseApp.getApps()
+        return when (apps.isEmpty()) {
+            true -> initializeApp()
+            false -> getApp(apps)
+        }.let { FirebaseMessaging.getInstance(it) }
+    }
+
+    private fun getApp(apps: List<FirebaseApp>): FirebaseApp {
+        return try {
+            apps.single { it.name == FirebaseApp.DEFAULT_APP_NAME }
+        } catch (e: NoSuchElementException) {
+            initializeApp()
+        }
+    }
+
+    private fun initializeApp(): FirebaseApp {
+        return FirebaseApp.initializeApp(
+            FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(fcmProperty.toInputStream()))
+                .build()
+        )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/global/property/FcmProperty.kt
+++ b/src/main/kotlin/co/yappuworld/global/property/FcmProperty.kt
@@ -1,0 +1,40 @@
+package co.yappuworld.global.property
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+
+@ConfigurationProperties(prefix = "fcm")
+data class FcmProperty(
+    @JsonProperty("type")
+    val type: String,
+    @JsonProperty("project_id")
+    val projectId: String,
+    @JsonProperty("private_key_id")
+    val privateKeyId: String,
+    @JsonProperty("private_key")
+    val privateKey: String,
+    @JsonProperty("client_email")
+    val clientEmail: String,
+    @JsonProperty("client_id")
+    val clientId: String,
+    @JsonProperty("auth_uri")
+    val authUri: String,
+    @JsonProperty("token_uri")
+    val tokenUri: String,
+    @JsonProperty("auth_provider_x509_cert_url")
+    val authProviderX509CertUrl: String,
+    @JsonProperty("client_x509_cert_url")
+    val clientX509CertUrl: String,
+    @JsonProperty("universe_domain")
+    val universeDomain: String
+) {
+
+    fun toInputStream(): InputStream {
+        return jacksonObjectMapper()
+            .writeValueAsString(this)
+            .byteInputStream(StandardCharsets.UTF_8)
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthAdminService.kt
@@ -3,8 +3,10 @@ package co.yappuworld.user.application
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.user.application.dto.request.SignUpApplicationApproveAppRequestDto
 import co.yappuworld.user.application.dto.request.SignUpApplicationRejectAppRequestDto
+import co.yappuworld.user.domain.model.UserDevice
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.ActivityUnitRepository
+import co.yappuworld.user.infrastructure.UserDeviceRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -15,7 +17,8 @@ import org.springframework.transaction.annotation.Transactional
 class UserAuthAdminService(
     private val userRepository: UserRepository,
     private val signUpApplicationRepository: UserSignUpApplicationRepository,
-    private val activityUnitRepository: ActivityUnitRepository
+    private val activityUnitRepository: ActivityUnitRepository,
+    private val userDeviceRepository: UserDeviceRepository
 ) {
 
     @Transactional
@@ -27,6 +30,7 @@ class UserAuthAdminService(
         signUpApplicationRepository.save(application)
         val user = userRepository.save(application.toUser(request.role))
         activityUnitRepository.saveAll(application.toActivityUnits(user))
+        userDeviceRepository.save(UserDevice(user.id, application.getFcmToken()))
     }
 
     @Transactional

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -13,10 +13,12 @@ import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
 import co.yappuworld.user.application.dto.request.UserSignUpAppRequestDto
 import co.yappuworld.user.application.dto.response.LatestSignUpApplicationAppResponseDto
 import co.yappuworld.user.domain.model.SignUpApplication
+import co.yappuworld.user.domain.model.UserDevice
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
 import co.yappuworld.user.infrastructure.ActivityUnitRepository
+import co.yappuworld.user.infrastructure.UserDeviceRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -33,6 +35,7 @@ class UserAuthService(
     private val userRepository: UserRepository,
     private val userSignUpApplicationRepository: UserSignUpApplicationRepository,
     private val activityUnitRepository: ActivityUnitRepository,
+    private val userDeviceRepository: UserDeviceRepository,
     private val jwtGenerator: JwtGenerator,
     private val jwtResolver: JwtResolver,
     private val configInquiryComponent: ConfigInquiryComponent
@@ -59,6 +62,7 @@ class UserAuthService(
         val user = request.toUser(role).also {
             activityUnitRepository.saveAll(request.toActivityUnits(it))
             userRepository.save(it)
+            userDeviceRepository.save(UserDevice(it.id, request.fcmToken))
         }
 
         return user.let {

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/UserSignUpAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/UserSignUpAppRequestDto.kt
@@ -10,7 +10,8 @@ data class UserSignUpAppRequestDto(
     val password: String,
     val name: String,
     val activityUnits: List<ActivityUnitAppRequestDto>,
-    val signUpCode: String
+    val signUpCode: String,
+    val fcmToken: String
 ) {
     fun toUser(role: UserRole): User {
         return User(
@@ -26,7 +27,8 @@ data class UserSignUpAppRequestDto(
             this.email,
             this.password,
             this.name,
-            this.activityUnits.map { it.toActivityUnitParam() }
+            this.activityUnits.map { it.toActivityUnitParam() },
+            this.fcmToken
         )
     }
 

--- a/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplicantDetails.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplicantDetails.kt
@@ -6,7 +6,8 @@ data class SignUpApplicantDetails(
     val email: String,
     val password: String,
     val name: String,
-    val activityUnits: List<ActivityUnitParam>
+    val activityUnits: List<ActivityUnitParam>,
+    val fcmToken: String
 ) {
     fun toUser(role: UserRole): User {
         return User(

--- a/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplication.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplication.kt
@@ -67,4 +67,8 @@ class SignUpApplication private constructor(
             it.toActivityUnit(user.id)
         }
     }
+
+    fun getFcmToken(): String {
+        return applicantDetails.fcmToken
+    }
 }

--- a/src/main/kotlin/co/yappuworld/user/domain/model/UserDevice.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/UserDevice.kt
@@ -1,0 +1,32 @@
+package co.yappuworld.user.domain.model
+
+import co.yappuworld.global.persistence.BaseEntity
+import com.github.f4b6a3.ulid.UlidCreator
+import org.springframework.data.annotation.Id
+import org.springframework.data.domain.Persistable
+import org.springframework.data.relational.core.mapping.Table
+import java.util.UUID
+
+@Table("user_devices")
+class UserDevice private constructor(
+    val userId: UUID,
+    val fcmToken: String,
+    @Id
+    @JvmField
+    val id: UUID
+) : BaseEntity(), Persistable<UUID> {
+
+    constructor(userId: UUID, fcmToken: String) : this(userId, fcmToken, UlidCreator.getMonotonicUlid().toUuid())
+
+    fun withId(id: UUID): UserDevice {
+        return UserDevice(this.userId, this.fcmToken, id)
+    }
+
+    override fun getId(): UUID {
+        return this.id
+    }
+
+    override fun isNew(): Boolean {
+        return !isCreatedAtInitialized()
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserDeviceRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserDeviceRepository.kt
@@ -1,0 +1,7 @@
+package co.yappuworld.user.infrastructure
+
+import co.yappuworld.user.domain.model.UserDevice
+import org.springframework.data.repository.CrudRepository
+import java.util.UUID
+
+interface UserDeviceRepository : CrudRepository<UserDevice, UUID>

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/UserSignUpApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/UserSignUpApiRequestDto.kt
@@ -24,7 +24,10 @@ data class UserSignUpApiRequestDto(
     @field:NotEmpty
     val activityUnits: List<ActivityUnitApiRequestDto>,
     @Schema(description = "가입코드, 6자리 숫자", example = "000000")
-    val signUpCode: String
+    val signUpCode: String,
+    @Schema(description = "FCM 토큰")
+    @field:NotEmpty(message = "FCM 토큰은 필수로 전달되어야 합니다.")
+    val fcmToken: String
 ) {
 
     fun toAppRequest(): UserSignUpAppRequestDto {
@@ -33,7 +36,8 @@ data class UserSignUpApiRequestDto(
             EncryptUtils.encrypt(this.password),
             this.name,
             this.activityUnits.map { it.toAppRequest() },
-            this.signUpCode
+            this.signUpCode,
+            this.fcmToken
         )
     }
 }

--- a/src/main/resources/application-fcm.yaml
+++ b/src/main/resources/application-fcm.yaml
@@ -1,0 +1,12 @@
+fcm:
+    type: service_account
+    project_id: yappu-world
+    private_key_id: ${FCM_PRIVATE_KEY_ID}
+    private_key: ${FCM_PRIVATE_KEY}
+    client_email: ${FCM_CLIENT_EMAIL}
+    client_id: ${FCM_CLIENT_ID}
+    auth_uri: https://accounts.google.com/o/oauth2/auth
+    token_uri: https://oauth2.googleapis.com/token
+    auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
+    client_x509_cert_url: ${FCM_X509_CERT_URL}
+    universe_domain: googleapis.com

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -27,14 +27,14 @@ jwt:
     refresh_token_expiration_times: 1209600000 # 2weeks = 1000(=1s) * 60 * 60 * 24 * 14
 
 fcm:
-    type: service_account
-    project_id: yappu-world
-    private_key_id: private-key-id
-    private_key: private-key
-    client_email: client-email
-    client_id: client-id
-    auth_uri: https://accounts.google.com/o/oauth2/auth
-    token_uri: https://oauth2.googleapis.com/token
-    auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
-    client_x509_cert_url: fcm-x509-cert-url
-    universe_domain: googleapis.com
+    type: test
+    project_id: test
+    private_key_id: test
+    private_key: test
+    client_email: test
+    client_id: test
+    auth_uri: test
+    token_uri: test
+    auth_provider_x509_cert_url: test
+    client_x509_cert_url: test
+    universe_domain: test

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -25,3 +25,16 @@ jwt:
     secret_key: thisisforlocalsecretkeyonlyusinginlocalenvironmentthisisforlocalsecretkeyonlyusinginlocalenvironment
     access_token_expiration_times: 3600000 # 1hour = 1000(=1s) * 60 * 60
     refresh_token_expiration_times: 1209600000 # 2weeks = 1000(=1s) * 60 * 60 * 24 * 14
+
+fcm:
+    type: service_account
+    project_id: yappu-world
+    private_key_id: private-key-id
+    private_key: private-key
+    client_email: client-email
+    client_id: client-id
+    auth_uri: https://accounts.google.com/o/oauth2/auth
+    token_uri: https://oauth2.googleapis.com/token
+    auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
+    client_x509_cert_url: fcm-x509-cert-url
+    universe_domain: googleapis.com

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,6 +4,6 @@ spring:
     profiles:
         active: local
         group:
-          local: console-logging
-          dev: console-logging, file-logging
-          prod: file-logging
+            local: console-logging, fcm-local
+            dev: console-logging, file-logging, fcm
+            prod: file-logging, fcm

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,5 +5,6 @@ spring:
         active: local
         group:
             local: console-logging, fcm-local
+            test: console-logging
             dev: console-logging, file-logging, fcm
             prod: file-logging, fcm

--- a/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/user/UserFixture.kt
@@ -33,13 +33,15 @@ object UserFixture {
         email: String = "email@email.com",
         password: String = "abcabC!!",
         name: String = "name",
-        activityUnitParams: List<ActivityUnitParam> = getActivityUnitParams()
+        activityUnitParams: List<ActivityUnitParam> = getActivityUnitParams(),
+        fcmToken: String = "bk3RNwTe3H0:CI2k_HHwgIpoDKCIZvvDMExUdFQ3P1"
     ): SignUpApplicantDetails {
         return SignUpApplicantDetails(
             email,
             password,
             name,
-            activityUnitParams
+            activityUnitParams,
+            fcmToken
         )
     }
 

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
@@ -14,6 +14,7 @@ import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.ActivityUnitRepository
+import co.yappuworld.user.infrastructure.UserDeviceRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -40,6 +41,7 @@ class UserAuthServiceTest {
     private val userRepository = mockk<UserRepository>()
     private val authApplicationRepository = mockk<UserSignUpApplicationRepository>()
     private val activityUnitRepository = mockk<ActivityUnitRepository>()
+    private val userDeviceRepository = mockk<UserDeviceRepository>()
     private val jwtGenerator = JwtGenerator(jwtProperty)
     private val jwtResolver = JwtResolver(jwtProperty)
     private val configInquiryComponent = mockk<ConfigInquiryComponent>()
@@ -47,6 +49,7 @@ class UserAuthServiceTest {
         userRepository,
         authApplicationRepository,
         activityUnitRepository,
+        userDeviceRepository,
         jwtGenerator,
         jwtResolver,
         configInquiryComponent
@@ -58,7 +61,8 @@ class UserAuthServiceTest {
         "password",
         "name",
         listOf(ActivityUnitAppRequestDto(1, Position.PM)),
-        ""
+        "",
+        "fcmToken"
     )
 
     @Test

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthSignUpApplicationServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthSignUpApplicationServiceTest.kt
@@ -11,6 +11,7 @@ import co.yappuworld.user.domain.model.SignUpApplication
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.domain.vo.UserSignUpApplicationStatus
 import co.yappuworld.user.infrastructure.ActivityUnitRepository
+import co.yappuworld.user.infrastructure.UserDeviceRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import io.mockk.every
@@ -33,6 +34,7 @@ class UserAuthSignUpApplicationServiceTest {
     private val userRepository = mockk<UserRepository>()
     private val authApplicationRepository = mockk<UserSignUpApplicationRepository>()
     private val activityUnitRepository = mockk<ActivityUnitRepository>()
+    private val userDeviceRepository = mockk<UserDeviceRepository>()
     private val jwtGenerator = JwtGenerator(jwtProperty)
     private val jwtResolver = JwtResolver(jwtProperty)
     private val configInquiryComponent = mockk<ConfigInquiryComponent>()
@@ -40,6 +42,7 @@ class UserAuthSignUpApplicationServiceTest {
         userRepository,
         authApplicationRepository,
         activityUnitRepository,
+        userDeviceRepository,
         jwtGenerator,
         jwtResolver,
         configInquiryComponent

--- a/src/test/kotlin/co/yappuworld/user/application/UserLoginServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserLoginServiceTest.kt
@@ -10,6 +10,7 @@ import co.yappuworld.support.fixture.user.UserDtoFixture.getLoginApiRequestDto
 import co.yappuworld.support.fixture.user.UserFixture.getUserFixture
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.ActivityUnitRepository
+import co.yappuworld.user.infrastructure.UserDeviceRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import io.mockk.every
@@ -24,6 +25,7 @@ class UserLoginServiceTest {
     private val userRepository = mockk<UserRepository>()
     private val userSignUpApplicationRepository = mockk<UserSignUpApplicationRepository>()
     private val activityUnitRepository = mockk<ActivityUnitRepository>()
+    private val userDeviceRepository = mockk<UserDeviceRepository>()
     private val jwtGenerator = JwtGenerator(getJwtProperty())
     private val jwtResolver = mockk<JwtResolver>()
     private val configInquiryComponent = mockk<ConfigInquiryComponent>()
@@ -31,6 +33,7 @@ class UserLoginServiceTest {
         userRepository,
         userSignUpApplicationRepository,
         activityUnitRepository,
+        userDeviceRepository,
         jwtGenerator,
         jwtResolver,
         configInquiryComponent

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicantDetailsRepositoryConverterTest.kt
@@ -31,7 +31,8 @@ class SignUpApplicantDetailsRepositoryConverterTest {
             "abc@abc.com",
             "abc",
             "abc",
-            listOf(ActivityUnitParam(0, Position.PM))
+            listOf(ActivityUnitParam(0, Position.PM)),
+            "fcmToken"
         ).let { userSignUpApplicationRepository.save(SignUpApplication(it)) }
 
         assertThat(checkNotNull(userSignUpApplicationRepository.findByIdOrNull(application.id)))
@@ -45,7 +46,8 @@ class SignUpApplicantDetailsRepositoryConverterTest {
             "abc@abc.com",
             "abc",
             "abc",
-            listOf(ActivityUnitParam(0, Position.PM))
+            listOf(ActivityUnitParam(0, Position.PM)),
+            "fcmToken"
         )
         val firstApplication = SignUpApplication(firstDetails).also { it.reject("거절") }
         val secondApplication = SignUpApplication(firstDetails)


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- FCM 연동


## ⭐️ 어떻게 해결했나요?
### FCM 연동
- FCM 연동 작업만 진행했습니다.
- FCM 메세지 발송하는 도메인에서 infrastructure에서 DI를 통해 적절히 구현하는 작업이 필요해보입니다.
- 당장에는 알람 발송하는 부분이 없어 따로 구현하지 않았습니다.

### FCM 토큰 저장
- FCM 연동을 진행하면서 토큰을 저장할 테이블이 없어서 별도로 생성하였습니다.
- User에 두지 않고 UserDevice 테이블을 따로 생성 및 저장한 이유는 다음과 같습니다.
	- 추후 여러 기기에 알람을 보낼 수 있으려면, 유저의 기기 정보를 담아둘 테이블이 따로 필요하다.
	- FCM 토큰은 기기에 종속적이므로 함께 보관하는 것이 좋다.

### FcmClientInTest
- CI 시에 test profile로 실행이 됩니다.
- test yaml에 FCM 연동 관련 정보를 노출할 수 없어서, CI 시에는 실제 연동이 필요하지 않도록 Stub 객체를 생성했습니다.
- FcmConfig도 test 환경에서는 Bean으로 등록되지 않습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
