### PR TITLE
fix: 프로필 조회 API 수정

### DIFF
--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/UserProfileAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/UserProfileAppResponseDto.kt
@@ -2,12 +2,13 @@ package co.yappuworld.user.application.dto.response
 
 import co.yappuworld.user.domain.model.ActivityUnit
 import co.yappuworld.user.domain.model.User
+import co.yappuworld.user.domain.vo.UserRole
 import java.util.UUID
 
 data class UserProfileAppResponseDto(
     val id: UUID,
     val name: String,
-    val role: String,
+    val role: UserRole,
     val activityUnits: List<ActivityUnitAppResponseDto>
 ) {
 
@@ -19,7 +20,7 @@ data class UserProfileAppResponseDto(
             return UserProfileAppResponseDto(
                 user.id,
                 user.name,
-                user.role.label,
+                user.role,
                 activityUnits.map { ActivityUnitAppResponseDto.of(it) }
             )
         }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserProfileApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserProfileApi.kt
@@ -33,7 +33,7 @@ interface UserProfileApi {
                                         "data": {
                                             "id": "79d52d77-6123-40f1-9f70-64bcbd6ca21a",
                                             "name": "홍길동",
-                                            "email": "abc@abc.com",
+                                            "role": "관리자",
                                             "activityUnits": [
                                                 {
                                                     "generation": "1",

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/response/UserProfileApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/response/UserProfileApiResponseDto.kt
@@ -20,8 +20,10 @@ data class UserProfileApiResponseDto(
             return UserProfileApiResponseDto(
                 response.id,
                 response.name,
-                response.role,
-                response.activityUnits.map { ActivityUnitApiResponseDto.of(it) }
+                response.role.label,
+                response.activityUnits
+                    .map { ActivityUnitApiResponseDto.of(it) }
+                    .sortedByDescending { it.generation }
             )
         }
     }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 프로필 조회 API 예시 Body 수정


## ⭐️ 어떻게 해결했나요?
- 아래 예시 사진처럼 Swagger 상에 예시 Body와 실제 응답이 상이해서 수정하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료
### Swagger 예시 Body
<img width="386" alt="image" src="https://github.com/user-attachments/assets/6dfa3170-4682-4903-b294-99f9ca0ca162" />

### 실제 실행 시 응답 Body
<img width="366" alt="image" src="https://github.com/user-attachments/assets/01b56e78-e343-478d-9822-335f9cc1d246" />


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
