### PR TITLE
Sentry 설정

### DIFF
--- a/.github/workflows/yappu-world-dev-cd.yaml
+++ b/.github/workflows/yappu-world-dev-cd.yaml
@@ -42,6 +42,7 @@ jobs:
                     fcm.client_id: ${{secrets.FCM_CLIENT_ID}}
                     fcm.client_x509_cert_url: ${{secrets.FCM_X509_CERT_URL}}
                     discord.webhook: ${{secrets.DISCORD_WEBHOOK_URL_IN_DEV}}
+                    sentry.dsn: ${{secrets.SENTRY_DSN}}
 
             -   name: Setup Sentry Auth Token
                 env:

--- a/.github/workflows/yappu-world-dev-cd.yaml
+++ b/.github/workflows/yappu-world-dev-cd.yaml
@@ -43,6 +43,10 @@ jobs:
                     fcm.client_x509_cert_url: ${{secrets.FCM_X509_CERT_URL}}
                     discord.webhook: ${{secrets.DISCORD_WEBHOOK_URL_IN_DEV}}
 
+            -   name: Setup Sentry Auth Token
+                run: |
+                    sudo export SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build -x test -Dspring.profiles.active=dev
 

--- a/.github/workflows/yappu-world-dev-cd.yaml
+++ b/.github/workflows/yappu-world-dev-cd.yaml
@@ -44,12 +44,6 @@ jobs:
                     discord.webhook: ${{secrets.DISCORD_WEBHOOK_URL_IN_DEV}}
                     sentry.dsn: ${{secrets.SENTRY_DSN}}
 
-            -   name: Setup Sentry Auth Token
-                env:
-                    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                run: |
-                    export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
-
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build -x test -Dspring.profiles.active=dev
 

--- a/.github/workflows/yappu-world-dev-cd.yaml
+++ b/.github/workflows/yappu-world-dev-cd.yaml
@@ -44,8 +44,10 @@ jobs:
                     discord.webhook: ${{secrets.DISCORD_WEBHOOK_URL_IN_DEV}}
 
             -   name: Setup Sentry Auth Token
+                env:
+                    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                 run: |
-                    sudo export SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+                    export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build -x test -Dspring.profiles.active=dev

--- a/.github/workflows/yappu-world-dev-ci.yaml
+++ b/.github/workflows/yappu-world-dev-ci.yaml
@@ -49,12 +49,6 @@ jobs:
                     discord.webhook: ${{ secrets.DISCORD_WEBHOOK_URL_IN_DEV }}
                     sentry.dsn: ${{secrets.SENTRY_DSN}}
 
-            -   name: Setup Sentry Auth Token
-                env:
-                    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                run: |
-                    export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
-
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build
                 env:

--- a/.github/workflows/yappu-world-dev-ci.yaml
+++ b/.github/workflows/yappu-world-dev-ci.yaml
@@ -48,9 +48,11 @@ jobs:
                     fcm.client_x509_cert_url: ${{ secrets.FCM_X509_CERT_URL }}
                     discord.webhook: ${{ secrets.DISCORD_WEBHOOK_URL_IN_DEV }}
 
-            -  name: Setup Sentry Auth Token
-               run: |
-                   sudo export SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            -   name: Setup Sentry Auth Token
+                env:
+                    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                run: |
+                    export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build

--- a/.github/workflows/yappu-world-dev-ci.yaml
+++ b/.github/workflows/yappu-world-dev-ci.yaml
@@ -48,6 +48,10 @@ jobs:
                     fcm.client_x509_cert_url: ${{ secrets.FCM_X509_CERT_URL }}
                     discord.webhook: ${{ secrets.DISCORD_WEBHOOK_URL_IN_DEV }}
 
+            -  name: Setup Sentry Auth Token
+               run: |
+                   sudo export SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build
                 env:

--- a/.github/workflows/yappu-world-dev-ci.yaml
+++ b/.github/workflows/yappu-world-dev-ci.yaml
@@ -47,13 +47,13 @@ jobs:
                     fcm.client_id: ${{ secrets.FCM_CLIENT_ID }}
                     fcm.client_x509_cert_url: ${{ secrets.FCM_X509_CERT_URL }}
                     discord.webhook: ${{ secrets.DISCORD_WEBHOOK_URL_IN_DEV }}
+                    sentry.dsn: ${{secrets.SENTRY_DSN}}
 
             -   name: Setup Sentry Auth Token
                 env:
                     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                 run: |
                     export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
-                    echo $SENTRY_AUTH_TOKEN
 
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build

--- a/.github/workflows/yappu-world-dev-ci.yaml
+++ b/.github/workflows/yappu-world-dev-ci.yaml
@@ -53,6 +53,7 @@ jobs:
                     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                 run: |
                     export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
+                    echo $SENTRY_AUTH_TOKEN
 
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build

--- a/.github/workflows/yappu-world-prod-cd.yaml
+++ b/.github/workflows/yappu-world-prod-cd.yaml
@@ -41,6 +41,7 @@ jobs:
                     fcm.client_id: ${{FCM_CLIENT_ID}}
                     fcm.client_x509_cert_url: ${{FCM_X509_CERT_URL}}
                     discord.webhook: ${{DISCORD_WEBHOOK_URL_IN_PROD}}
+                    sentry.dsn: ${{secrets.SENTRY_DSN}}
 
             -   name: Setup Sentry Auth Token
                 env:

--- a/.github/workflows/yappu-world-prod-cd.yaml
+++ b/.github/workflows/yappu-world-prod-cd.yaml
@@ -43,12 +43,6 @@ jobs:
                     discord.webhook: ${{DISCORD_WEBHOOK_URL_IN_PROD}}
                     sentry.dsn: ${{secrets.SENTRY_DSN}}
 
-            -   name: Setup Sentry Auth Token
-                env:
-                    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                run: |
-                    export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
-
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build -x test -Dspring.profiles.active=prod
 

--- a/.github/workflows/yappu-world-prod-cd.yaml
+++ b/.github/workflows/yappu-world-prod-cd.yaml
@@ -42,6 +42,10 @@ jobs:
                     fcm.client_x509_cert_url: ${{FCM_X509_CERT_URL}}
                     discord.webhook: ${{DISCORD_WEBHOOK_URL_IN_PROD}}
 
+            -   name: Setup Sentry Auth Token
+                run: |
+                    sudo export SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build -x test -Dspring.profiles.active=prod
 

--- a/.github/workflows/yappu-world-prod-cd.yaml
+++ b/.github/workflows/yappu-world-prod-cd.yaml
@@ -43,8 +43,10 @@ jobs:
                     discord.webhook: ${{DISCORD_WEBHOOK_URL_IN_PROD}}
 
             -   name: Setup Sentry Auth Token
+                env:
+                    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                 run: |
-                    sudo export SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+                    export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 
             -   name: Build with Gradle Wrapper
                 run: ./gradlew clean build -x test -Dspring.profiles.active=prod

--- a/.github/workflows/yappu-world-prod-ci.yaml
+++ b/.github/workflows/yappu-world-prod-ci.yaml
@@ -38,12 +38,6 @@ jobs:
                     jwt.refresh_token_expiration_times: ${{ secrets.DEV_REFRESH_TOKEN_EXPIRATION_TIMES }}
                     sentry.dsn: ${{secrets.SENTRY_DSN}}
 
-            -   name: Setup Sentry Auth Token
-                env:
-                    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                run: |
-                    export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
-
             # Github Action 실행 서버 IP 추출
             -   name: Get Github Actions IP
                 id: ip

--- a/.github/workflows/yappu-world-prod-ci.yaml
+++ b/.github/workflows/yappu-world-prod-ci.yaml
@@ -36,6 +36,7 @@ jobs:
                     jwt.secret_key: ${{ secrets.DEV_JWT_SECRET_KEY }}
                     jwt.access_token_expiration_times: ${{ secrets.DEV_ACCESS_TOKEN_EXPIRATION_TIMES }}
                     jwt.refresh_token_expiration_times: ${{ secrets.DEV_REFRESH_TOKEN_EXPIRATION_TIMES }}
+                    sentry.dsn: ${{secrets.SENTRY_DSN}}
 
             -   name: Setup Sentry Auth Token
                 env:

--- a/.github/workflows/yappu-world-prod-ci.yaml
+++ b/.github/workflows/yappu-world-prod-ci.yaml
@@ -37,6 +37,10 @@ jobs:
                     jwt.access_token_expiration_times: ${{ secrets.DEV_ACCESS_TOKEN_EXPIRATION_TIMES }}
                     jwt.refresh_token_expiration_times: ${{ secrets.DEV_REFRESH_TOKEN_EXPIRATION_TIMES }}
 
+            -   name: Setup Sentry Auth Token
+                run: |
+                    sudo export SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+
             # Github Action 실행 서버 IP 추출
             -   name: Get Github Actions IP
                 id: ip

--- a/.github/workflows/yappu-world-prod-ci.yaml
+++ b/.github/workflows/yappu-world-prod-ci.yaml
@@ -38,8 +38,10 @@ jobs:
                     jwt.refresh_token_expiration_times: ${{ secrets.DEV_REFRESH_TOKEN_EXPIRATION_TIMES }}
 
             -   name: Setup Sentry Auth Token
+                env:
+                    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                 run: |
-                    sudo export SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+                    export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 
             # Github Action 실행 서버 IP 추출
             -   name: Get Github Actions IP

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,6 @@ tasks {
         includeSourceContext = true
         org = "yapp-co"
         projectName = "yappu-world-server"
-//        authToken = System.getenv("SENTRY_AUTH_TOKEN")
+        authToken = System.getenv("SENTRY_AUTH_TOKEN")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     // ktlint
     id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
     // sentry
-    id("io.sentry.jvm.gradle") version "5.1.0"
+    id("io.sentry.jvm.gradle") version "5.2.0"
 }
 
 group = "co"
@@ -75,9 +75,12 @@ tasks {
         archiveFileName = "yappu-world-$profile.jar"
     }
     sentry {
+        debug = true
+        autoInstallation.enabled = true
+        includeDependenciesReport = true
+
         includeSourceContext = true
         org = "yapp-co"
         projectName = "yappu-world-server"
-        authToken = System.getenv("SENTRY_AUTH_TOKEN")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,5 @@ tasks {
         includeSourceContext = true
         org = "yapp-co"
         projectName = "yappu-world-server"
-        authToken = System.getenv("SENTRY_AUTH_TOKEN")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,5 +78,6 @@ tasks {
         includeSourceContext = true
         org = "yapp-co"
         projectName = "yappu-world-server"
+//        authToken = System.getenv("SENTRY_AUTH_TOKEN")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,10 +76,6 @@ tasks {
     }
     sentry {
         debug = true
-        autoInstallation.enabled = true
-        includeDependenciesReport = true
-
-        includeSourceContext = true
         org = "yapp-co"
         projectName = "yappu-world-server"
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
     // ktlint
     id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
+    // sentry
+    id("io.sentry.jvm.gradle") version "5.1.0"
 }
 
 group = "co"
@@ -71,5 +73,11 @@ tasks {
 
         val profile = System.getProperty("spring.profiles.active")
         archiveFileName = "yappu-world-$profile.jar"
+    }
+    sentry {
+        includeSourceContext = true
+        org = "yapp-co"
+        projectName = "yappu-world-server"
+        authToken = System.getenv("SENTRY_AUTH_TOKEN")
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "yappu-world"
+rootProject.name = "yappu-world-server"

--- a/src/main/kotlin/co/yappuworld/YappuWorldServerApplication.kt
+++ b/src/main/kotlin/co/yappuworld/YappuWorldServerApplication.kt
@@ -1,9 +1,10 @@
 package co.yappuworld
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
 import org.springframework.boot.runApplication
 
-@SpringBootApplication
+@SpringBootApplication(exclude = [UserDetailsServiceAutoConfiguration::class])
 class YappuWorldServerApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/co/yappuworld/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/co/yappuworld/global/exception/GlobalExceptionHandler.kt
@@ -15,7 +15,6 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException::class)
     fun handleBusinessException(e: BusinessException): ResponseEntity<ErrorResponse> {
-        logger.error { e.message }
         return ResponseEntity
             .status(getHttpStatusBy(e.error.type))
             .body(ErrorResponse.of(e.error))
@@ -23,8 +22,6 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
-        logger.error { e.message }
-
         return e.bindingResult.fieldErrors[0].defaultMessage?.let {
             ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/co/yappuworld/global/security/JwtResolver.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/JwtResolver.kt
@@ -19,20 +19,21 @@ class JwtResolver(
     fun extractSecurityUserOrNull(accessToken: String): SecurityUser? {
         return accessToken.let {
             val payload = parseToken(it).payload
-            SecurityUser.fromValidToken(payload as Map<String, String>)
+            SecurityUser.fromValidToken(payload as Map<*, *>)
         }
     }
 
     fun extractUserIdFrom(accessToken: String): UUID {
-        return UUID.fromString(getClaimsFrom(accessToken)["userId"].toString())
+        val userId = getClaimsFrom(accessToken)["userId"]
             ?: throw BusinessException(TokenError.INVALID_TOKEN)
+        return UUID.fromString(userId.toString())
     }
 
-    fun getClaimsFrom(accessToken: String): Map<String, Any> {
+    fun getClaimsFrom(accessToken: String): Map<*, *> {
         return try {
-            parseToken(accessToken).payload as Map<String, Any>
+            parseToken(accessToken).payload as Map<*, *>
         } catch (e: ExpiredJwtException) {
-            e.claims as Map<String, Any>
+            e.claims as Map<*, *>
         }
     }
 

--- a/src/main/kotlin/co/yappuworld/global/security/SecurityPathMatchersManager.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/SecurityPathMatchersManager.kt
@@ -17,7 +17,8 @@ object SecurityPathMatchersManager {
     )
 
     val userMatchers = RequestMatchers.anyOf(
-        antMatcher("/v1/users/fcm")
+        antMatcher("/v1/users/fcm"),
+        antMatcher("/v1/users/profile")
     )
 
     val adminMatchers = RequestMatchers.anyOf(

--- a/src/main/kotlin/co/yappuworld/global/security/SecurityUser.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/SecurityUser.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.global.security
 
-import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.domain.model.User
+import co.yappuworld.user.domain.vo.UserRole
 import java.util.UUID
 
 class SecurityUser(
@@ -15,11 +15,14 @@ class SecurityUser(
     )
 
     companion object {
-        fun fromValidToken(claims: Map<String, String>): SecurityUser? {
-            val roleValue = claims["role"] ?: return null
+        fun fromValidToken(claims: Map<*, *>): SecurityUser? {
+            if (claims["userId"] == null || claims["role"] == null) {
+                return null
+            }
+
             return SecurityUser(
-                UUID.fromString(claims["userId"]) ?: return null,
-                UserRole.valueOf(roleValue)
+                UUID.fromString(claims["userId"] as String),
+                UserRole.valueOf(claims["role"].toString())
             )
         }
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -37,3 +37,11 @@ fcm:
 
 discord:
     webhook: ${DISCORD_WEBHOOK_URL_IN_DEV}
+
+sentry:
+    dsn: ${SENTRY_DSN}
+    environment: dev
+    traces-sample-rate: 1.0
+    logging:
+        minimum-event-level: warn
+        minimum-breadcrumb-level: info

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -37,3 +37,11 @@ fcm:
 
 discord:
     webhook: ${DISCORD_WEBHOOK_URL_IN_PROD}
+
+sentry:
+    dsn: ${SENTRY_DSN}
+    environment: prod
+    traces-sample-rate: 1.0
+    logging:
+        minimum-event-level: warn
+        minimum-breadcrumb-level: info

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -41,3 +41,11 @@ fcm:
 
 discord:
     webhook: ${DISCORD_WEBHOOK_URL_IN_DEV}
+
+sentry:
+    dsn: ${SENTRY_DSN}
+    environment: test
+    traces-sample-rate: 1.0
+    logging:
+        minimum-event-level: warn
+        minimum-breadcrumb-level: info

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
     profiles:
         active: local
         group:
-            local: console-logging, secret-local
+            local: console-logging, secret-local, sentry-logging
             test: console-logging
-            dev: console-logging, file-logging
-            prod: file-logging
+            dev: console-logging, file-logging, sentry-logging
+            prod: file-logging, sentry-logging


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 개발 서버와 운영 서버에서 발생하는 예상치 못한 예외 상황을 빠르게 파악하기 위한 모니터링 툴 필요


## ⭐️ 어떻게 해결했나요?
- Sentry를 도입하였습니다.
	- Prometheus, Grafna 조합이나 Datadog도 있으나, 한 번 써보고 싶었습니다.
	- 무료 버전을 사용하는 경우 디스코드 웹훅을 받을 수 없어서, AWS API Gateway + Lambda 조합으로 훅을 전달합니다.
	- 아키텍처는 추후 다시 그려두도록 하겠습니다.
- Sentry를 통해 웹훅이 발생하는 경우는 다음과 같습니다.
	- error logging은 전달되는 메세지는 Discord로 전달됩니다.
	- warn logging의 경우 1분 동안 10개 이상 발생한다면 전달됩니다.
		- 다만 해당 옵션은 무료 버전으로 전환되는 경우에 유지되는지 확인이 필요합니다. (유지가 안 되는 것으로 확인하긴 했습니다.)
- #server-alert 채널로 에러 메세지가 전달됩니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료
<img width="420" alt="image" src="https://github.com/user-attachments/assets/cbdc9bc0-cd5f-4c60-8b99-26b6c75b0e96" />



## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
