### PR TITLE
docs: 공통 에러 스웨거 노출

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/config/SwaggerCommonResponse.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SwaggerCommonResponse.kt
@@ -1,0 +1,8 @@
+package co.yappuworld.global.config
+
+import io.swagger.v3.oas.models.responses.ApiResponse
+
+data class SwaggerCommonResponse(
+    val code: String,
+    val apiResponse: ApiResponse
+)

--- a/src/main/kotlin/co/yappuworld/global/config/SwaggerCommonResponses.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SwaggerCommonResponses.kt
@@ -1,0 +1,92 @@
+package co.yappuworld.global.config
+
+import io.swagger.v3.oas.models.examples.Example
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.responses.ApiResponse
+
+object SwaggerCommonResponses {
+    val values = listOf(
+        SwaggerCommonResponse(
+            "500",
+            ApiResponse().apply {
+                description = "예기치 못한 서버 에러"
+                content = Content().apply {
+                    addMediaType(
+                        "application/json",
+                        MediaType().apply {
+                            examples = mapOf(
+                                "예기치 못한 에러" to Example().apply {
+                                    value = """
+                                        {
+                                            "isSuccess": "false",
+                                            "message": "예기치 못한 에러가 발생했습니다. 서버 관리자에게 문의해주세요.",
+                                            "errorCode": "COM_0001"
+                                        }
+                                    """.trimIndent()
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+        ),
+        SwaggerCommonResponse(
+            "400",
+            ApiResponse().apply {
+                description = "잘못된 파라미터 요청"
+                content = Content().apply {
+                    addMediaType(
+                        "application/json",
+                        MediaType().apply {
+                            examples = mapOf(
+                                "잘못된 파라미터 요청" to Example().apply {
+                                    value = """
+                                        {
+                                            "isSuccess": "false",
+                                            "message": "요청된 인자에 잘못된 값이 있습니다.",
+                                            "errorCode": "COM_0002"
+                                        }
+                                    """.trimIndent()
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+        ),
+        SwaggerCommonResponse(
+            "403",
+            ApiResponse().apply {
+                description = "인증 실패"
+                content = Content().apply {
+                    addMediaType(
+                        "application/json",
+                        MediaType().apply {
+                            examples = mapOf(
+                                "토큰 만료" to Example().apply {
+                                    value = """
+                                        {
+                                            "isSuccess": "false",
+                                            "message": "만료된 토큰입니다.",
+                                            "errorCode": "TKN_0001"
+                                        }
+                                    """.trimIndent()
+                                },
+                                "비정상 토큰" to Example().apply {
+                                    value = """
+                                        {
+                                            "isSuccess": "false",
+                                            "message": "비정상 토큰입니다.",
+                                            "errorCode": "TKN_0002"
+                                        }
+                                    """.trimIndent()
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+        )
+    )
+}

--- a/src/main/kotlin/co/yappuworld/global/config/SwaggerConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SwaggerConfig.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -19,6 +20,20 @@ class SwaggerConfig {
         return OpenAPI().info(getInfo())
             .addSecurityItem(getSecurityRequirement())
             .components(Components().addSecuritySchemes(securitySchemeName, getSecurityScheme()))
+    }
+
+    @Bean
+    fun customGlobalResponses(): OpenApiCustomizer {
+        return OpenApiCustomizer { openApi ->
+            openApi.paths.values.forEach { item ->
+                item.readOperations().forEach { operation ->
+                    val responses = operation.responses
+                    SwaggerCommonResponses.values.forEach { value ->
+                        responses.addApiResponse(value.code, value.apiResponse)
+                    }
+                }
+            }
+        }
     }
 
     private fun getInfo(): Info {


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 공통 에러를 매번 어노테이션으로 처리하기가 어려운 상황


## ⭐️ 어떻게 해결했나요?
- `OpenApiCustomizer` Bean을 등록하여, 모든 경로에 대해 공통 에러를 추가하도록 함
- 다만, 403 토큰 관련 에러의 경우 인증을 요구하는 path에서만 처리가 되어야 하는데, 그 부분은 처리가 필요


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료

<img width="1311" alt="image" src="https://github.com/user-attachments/assets/64bd6d79-f6a3-4ddf-98ad-863f1ea16f16" />

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/8978cb6a-3b6d-4489-9fec-4ca45138b0d3" />

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/5a27c8cd-e285-4215-978c-dba6d3639709" />



## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
