### PR TITLE
fix: 회원가입 이메일 중복 검사

### DIFF
--- a/src/main/kotlin/co/yappuworld/user/application/SignUpService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/SignUpService.kt
@@ -61,6 +61,8 @@ class SignUpService(
         request: UserSignUpAppRequestDto,
         now: LocalDateTime
     ): Token {
+        checkEmailDuplication(request.email)
+
         val user = initializeUser(
             request.toApplication(),
             getUserRoleWithSignUpCode(request.signUpCode)
@@ -74,9 +76,7 @@ class SignUpService(
 
     @Transactional(readOnly = true)
     fun checkEmailAvailability(request: CheckingEmailAvailabilityAppRequestDto) {
-        if (userRepository.existsUserByEmail(request.email)) {
-            throw BusinessException(UserError.DUPLICATE_EMAIL)
-        }
+        checkEmailDuplication(request.email)
     }
 
     @Transactional(readOnly = true)
@@ -95,8 +95,10 @@ class SignUpService(
     @Transactional
     fun approveSignUpApplication(request: SignUpApplicationApproveAppRequestDto) {
         val application = signUpApplicationRepository.findByIdOrNull(request.applicationId)
-            ?.apply { approve() }
             ?: throw BusinessException(UserError.NOT_FOUND_SIGN_UP_APPLICATION)
+
+        checkEmailDuplication(application.applicantEmail)
+        application.approve()
 
         signUpApplicationRepository.save(application)
         initializeUser(application, request.role)
@@ -124,10 +126,7 @@ class SignUpService(
     }
 
     private fun checkApplication(email: String) {
-        if (userRepository.existsUserByEmail(email)) {
-            logger.error { "${email}은 이미 가입된 이메일입니다." }
-            throw BusinessException(UserError.ALREADY_SIGNED_UP_EMAIL)
-        }
+        checkEmailDuplication(email)
 
         val applications = signUpApplicationRepository.findByApplicantEmailAndStatus(
             email,
@@ -141,6 +140,13 @@ class SignUpService(
         if (applications.any { it.status == UserSignUpApplicationStatus.PENDING }) {
             logger.error { "${email}의 처리되지 않은 기존 신청이 존재합니다." }
             throw BusinessException(UserError.UNPROCESSED_APPLICATION_EXISTS)
+        }
+    }
+
+    private fun checkEmailDuplication(email: String) {
+        if (userRepository.existsUserByEmail(email)) {
+            logger.error { "${email}은 이미 가입된 이메일입니다." }
+            throw BusinessException(UserError.ALREADY_SIGNED_UP_EMAIL)
         }
     }
 

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
@@ -331,12 +331,12 @@ interface UserAuthApi {
                         schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
-                                name = "중복된 이메일입니다.",
+                                name = "이미 가입된 이메일",
                                 value = """
                                     {
                                         "isSuccess": "false",
-                                        "message": "중복된 이메일입니다.",
-                                        "errorCode": "USR_1005"
+                                        "message": "이미 가입된 이메일입니다.",
+                                        "errorCode": "USR_1002"
                                     }
                                 """
                             )


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 가입 코드를 이용한 회원가입 시 이메일 중복 검사를 하지 않는 이슈 존재


## ⭐️ 어떻게 해결했나요?
- 이메일 중복 검사 로직을 추가
- 회원가입 신청서 접수 뿐만 아니라, 신청된 회원가입을 승인할 때도 이메일 중복 검사 수행


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
