### PR TITLE
feat: 운영진 권한 및 직군 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
@@ -31,8 +31,8 @@ class SecurityConfig(
             .httpBasic { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(STATELESS) }
             .authorizeHttpRequests {
-                it.requestMatchers(adminMatchers).hasAnyRole("ADMIN")
-                    .requestMatchers(userMatchers).hasAnyRole("ADMIN", "ALUMNI", "GRADUATE", "ACTIVE")
+                it.requestMatchers(adminMatchers).hasAnyRole("ADMIN", "STAFF")
+                    .requestMatchers(userMatchers).hasAnyRole("ADMIN", "STAFF", "ALUMNI", "GRADUATE", "ACTIVE")
                     .requestMatchers(anyoneMatchers).permitAll()
             }
             .authorizeHttpRequests { it.anyRequest().permitAll() }

--- a/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.global.config
 
 import co.yappuworld.global.filter.JwtFilter
-import co.yappuworld.global.security.SecurityPathMatchersManager.adminMatchers
+import co.yappuworld.global.security.SecurityPathMatchersManager.staffOrAdminMatchers
 import co.yappuworld.global.security.SecurityPathMatchersManager.anyoneMatchers
 import co.yappuworld.global.security.SecurityPathMatchersManager.userMatchers
 import org.springframework.context.annotation.Bean
@@ -31,7 +31,7 @@ class SecurityConfig(
             .httpBasic { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(STATELESS) }
             .authorizeHttpRequests {
-                it.requestMatchers(adminMatchers).hasAnyRole("ADMIN", "STAFF")
+                it.requestMatchers(staffOrAdminMatchers).hasAnyRole("ADMIN", "STAFF")
                     .requestMatchers(userMatchers).hasAnyRole("ADMIN", "STAFF", "ALUMNI", "GRADUATE", "ACTIVE")
                     .requestMatchers(anyoneMatchers).permitAll()
             }

--- a/src/main/kotlin/co/yappuworld/global/security/SecurityPathMatchersManager.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/SecurityPathMatchersManager.kt
@@ -1,7 +1,10 @@
 package co.yappuworld.global.security
 
+import org.springframework.http.HttpMethod.DELETE
 import org.springframework.http.HttpMethod.GET
+import org.springframework.http.HttpMethod.PATCH
 import org.springframework.http.HttpMethod.POST
+import org.springframework.http.HttpMethod.PUT
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher
 import org.springframework.security.web.util.matcher.RequestMatchers
 
@@ -13,16 +16,25 @@ object SecurityPathMatchersManager {
         antMatcher("/v3/api-docs/**"),
         // api
         antMatcher(POST, "/v1/auth/sign-up"),
-        antMatcher(GET, "/v1/positions")
+        antMatcher(POST, "/v1/auth/login"),
+        antMatcher(POST, "/v1/auth/reissue-token"),
+        antMatcher(POST, "/v1/auth/check-email"),
+        antMatcher(GET, "/v1/auth/applications/latest"),
+        antMatcher(GET, "/v1/positions"),
+        antMatcher(GET, "/v1/operations/**")
     )
 
     val userMatchers = RequestMatchers.anyOf(
+        antMatcher(DELETE, "/v1/auth/user"),
         antMatcher("/v1/users/fcm"),
-        antMatcher("/v1/users/profile")
+        antMatcher("/v1/users/profile"),
+        antMatcher(PUT, "/v1/users/fcm"),
+        antMatcher(GET, "/v1/alarms"),
+        antMatcher(PUT, "/v1/alarms/device"),
+        antMatcher(PATCH, "/v1/alarms/master")
     )
 
-    val adminMatchers = RequestMatchers.anyOf(
-        antMatcher(POST, "/v1/admin/**"),
-        antMatcher(POST, "/v1/admin/auth/application/reject")
+    val staffOrAdminMatchers = RequestMatchers.anyOf(
+        antMatcher(POST, "/v1/admin/**")
     )
 }

--- a/src/main/kotlin/co/yappuworld/user/application/SignUpService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/SignUpService.kt
@@ -152,7 +152,12 @@ class SignUpService(
 
     private fun getUserRoleWithSignUpCode(signUpCode: String): UserRole {
         val configs = configInquiryComponent.findConfigsBy(
-            listOf("authenticationCodeAdmin", "authenticationCodeAlumni", "authenticationCodeActive")
+            listOf(
+                "authenticationCodeAdmin",
+                "authenticationCodeStaff",
+                "authenticationCodeAlumni",
+                "authenticationCodeActive"
+            )
         )
 
         val config = configs.singleOrNull { it.value == signUpCode }
@@ -160,6 +165,7 @@ class SignUpService(
 
         return when (config.id) {
             "authenticationCodeAdmin" -> UserRole.ADMIN
+            "authenticationCodeStaff" -> UserRole.STAFF
             "authenticationCodeAlumni" -> UserRole.ALUMNI
             else -> UserRole.ACTIVE
         }

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
@@ -9,5 +9,6 @@ enum class Position(
     ANDROID("Android"),
     IOS("iOS"),
     FLUTTER("Flutter"),
-    SERVER("Server")
+    SERVER("Server"),
+    STAFF("운영진")
 }

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
@@ -2,6 +2,7 @@ package co.yappuworld.user.domain.vo
 
 /**
  * @property ADMIN 관리자
+ * @property STAFF 운영진
  * @property ALUMNI 정회원
  * @property GRADUATE 수료회원
  * @property ACTIVE 활동회원
@@ -11,6 +12,7 @@ enum class UserRole(
     val label: String
 ) {
     ADMIN("ROLE_ADMIN", "관리자"),
+    STAFF("ROLE_STAFF", "운영진"),
     ALUMNI("ROLE_ALUMNI", "정회원"),
     GRADUATE("ROLE_GRADUATE", "수료회원"),
     ACTIVE("ROLE_ACTIVE", "활동회원")

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,8 @@
 INSERT INTO config (id, created_at, updated_at, value)
 VALUES ('authenticationCodeAdmin', now(), now(), '000000'),
-       ('authenticationCodeAlumni', now(), now(), '000001'),
-       ('authenticationCodeActive', now(), now(), '000002'),
+       ('authenticationCodeStaff', now(), now(), '000001'),
+       ('authenticationCodeAlumni', now(), now(), '000002'),
+       ('authenticationCodeActive', now(), now(), '000003'),
        ('needForceUpdate', now(), now(), 'false'),
        ('forceUpdateReason', now(), now(), null),
        ('activeGeneration', now(), now(), '25');


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 나의 프로필에서 역할(Role)을 표현하는데, 서버에서 내려주는 역할은 관리자로 내려가고 있음


## ⭐️ 어떻게 해결했나요?
- 실제로 관리자(앱 개발팀)와 운영진(기수 운영진)은 구분될 필요가 있음
- 따라서 Role을 상세히 분류
  - 현재 기능상으로 큰 차이는 없을 듯 함
- 추가적으로, 직군 정보에 운영진을 추가하여, 추후 `25기 운영진`을 표현할 수 있도록 하고자 함


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료

<img width="296" alt="image" src="https://github.com/user-attachments/assets/263f6a80-05f6-487e-8c87-9c8329910144" />



## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
