### PR TITLE
feature: 유저 어드민 가입코드, 기수 관리

### DIFF
--- a/src/main/kotlin/co/yappuworld/board/domain/model/Board.kt
+++ b/src/main/kotlin/co/yappuworld/board/domain/model/Board.kt
@@ -4,17 +4,11 @@ import co.yappuworld.board.domain.vo.BoardType
 import co.yappuworld.board.domain.vo.NoticeType
 import co.yappuworld.board.domain.vo.Writer
 import co.yappuworld.global.persistence.BaseEntity
-import org.springframework.data.annotation.Id
-import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.Table
-import java.util.UUID
 
 @Table(name = "boards")
 data class Board(
-    @Id
-    @JvmField
-    val id: UUID,
     val boardType: BoardType,
     val noticeType: NoticeType? = null,
     val title: String,
@@ -22,9 +16,4 @@ data class Board(
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val writer: Writer,
     val isActive: Boolean = true
-) : BaseEntity(),
-    Persistable<UUID> {
-    override fun getId() = id
-
-    override fun isNew() = !isCreatedAtInitialized()
-}
+) : BaseEntity()

--- a/src/main/kotlin/co/yappuworld/board/domain/model/Post.kt
+++ b/src/main/kotlin/co/yappuworld/board/domain/model/Post.kt
@@ -3,30 +3,16 @@ package co.yappuworld.board.domain.model
 import co.yappuworld.board.domain.vo.PostType
 import co.yappuworld.board.domain.vo.Writer
 import co.yappuworld.global.persistence.BaseEntity
-import com.github.f4b6a3.ulid.UlidCreator
-import org.springframework.data.annotation.Id
-import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Table
-import java.util.UUID
 
 @Table("boards")
-abstract class Post :
-    BaseEntity(),
-    Persistable<UUID> {
-
-    @Id
-    @JvmField
-    protected var id: UUID = UlidCreator.getMonotonicUlid().toUuid()
+abstract class Post : BaseEntity() {
 
     protected var isActive: Boolean = true
     abstract val postType: PostType
     abstract val title: String
     abstract val content: String
     abstract val writer: Writer
-
-    override fun getId(): UUID = this.id
-
-    override fun isNew(): Boolean = !isCreatedAtInitialized()
 
     fun delete() {
         this.isActive = false

--- a/src/main/kotlin/co/yappuworld/global/config/JdbcConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/JdbcConfig.kt
@@ -4,11 +4,16 @@ import co.yappuworld.global.persistence.UserApplicationReadingConverter
 import co.yappuworld.global.persistence.UserApplicationWritingConverter
 import co.yappuworld.global.persistence.UuidIdentifierReadingConverter
 import co.yappuworld.global.persistence.UuidIdentifierWritingConverter
+import co.yappuworld.operation.domain.Generation
+import org.springframework.context.ApplicationListener
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions
 import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration
 import org.springframework.data.jdbc.repository.config.EnableJdbcAuditing
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories
+import org.springframework.data.relational.core.mapping.event.AfterConvertEvent
+import org.springframework.data.relational.core.mapping.event.AfterSaveEvent
 
 @Configuration
 @EnableJdbcAuditing
@@ -24,4 +29,16 @@ class JdbcConfig : AbstractJdbcConfiguration() {
                 UserApplicationReadingConverter()
             )
         )
+
+    @Bean
+    fun onAfterSaveGeneration(): ApplicationListener<AfterSaveEvent<Generation>> =
+        ApplicationListener { e ->
+            e.entity.load()
+        }
+
+    @Bean
+    fun onAfterLoadGeneration(): ApplicationListener<AfterConvertEvent<Generation>> =
+        ApplicationListener { e ->
+            e.entity.load()
+        }
 }

--- a/src/main/kotlin/co/yappuworld/global/config/SwaggerCommonResponses.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SwaggerCommonResponses.kt
@@ -10,7 +10,7 @@ object SwaggerCommonResponses {
         SwaggerCommonResponse(
             "500",
             ApiResponse().apply {
-                description = "예기치 못한 서버 에러"
+                description = "Internal Server Error"
                 content = Content().apply {
                     addMediaType(
                         "application/json",
@@ -34,7 +34,7 @@ object SwaggerCommonResponses {
         SwaggerCommonResponse(
             "400",
             ApiResponse().apply {
-                description = "잘못된 파라미터 요청"
+                description = "Bad Request"
                 content = Content().apply {
                     addMediaType(
                         "application/json",
@@ -56,9 +56,9 @@ object SwaggerCommonResponses {
             }
         ),
         SwaggerCommonResponse(
-            "403",
+            "401",
             ApiResponse().apply {
-                description = "인증 실패"
+                description = "Unauthorized"
                 content = Content().apply {
                     addMediaType(
                         "application/json",

--- a/src/main/kotlin/co/yappuworld/global/persistence/BaseEntity.kt
+++ b/src/main/kotlin/co/yappuworld/global/persistence/BaseEntity.kt
@@ -1,10 +1,18 @@
 package co.yappuworld.global.persistence
 
+import com.github.f4b6a3.ulid.UlidCreator
 import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.domain.Persistable
 import java.time.LocalDateTime
+import java.util.UUID
 
-abstract class BaseEntity {
+abstract class BaseEntity : Persistable<UUID> {
+
+    @Id
+    @JvmField
+    protected var id: UUID = UlidCreator.getMonotonicUlid().toUuid()
 
     @CreatedDate
     lateinit var createdAt: LocalDateTime
@@ -13,4 +21,8 @@ abstract class BaseEntity {
     lateinit var updatedAt: LocalDateTime
 
     protected fun isCreatedAtInitialized(): Boolean = ::createdAt.isInitialized
+
+    override fun getId(): UUID = this.id
+
+    override fun isNew(): Boolean = !isCreatedAtInitialized()
 }

--- a/src/main/kotlin/co/yappuworld/global/response/OffsetPageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/global/response/OffsetPageResponse.kt
@@ -1,18 +1,16 @@
 package co.yappuworld.global.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import kotlin.math.ceil
 
 class OffsetPageResponse<T : Any>(
     @Schema(description = "데이터 목록")
     val data: List<T>,
     @Schema(description = "전체 개수")
     val totalCount: Long,
+    @Schema(description = "전체 페이지 수")
+    val totalPages: Int,
     @Schema(description = "현재 페이지 번호")
     val page: Int,
     @Schema(description = "페이지 당 조회 개수")
     val size: Int
-) {
-    @Schema(description = "전체 페이지 수")
-    val totalPage = ceil(totalCount.toDouble() / size).toInt()
-}
+)

--- a/src/main/kotlin/co/yappuworld/operation/application/AdminUserOperationService.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/AdminUserOperationService.kt
@@ -1,0 +1,19 @@
+package co.yappuworld.operation.application
+
+import co.yappuworld.operation.application.dto.request.AdminGenerationPageAppRequestDto
+import co.yappuworld.operation.application.dto.response.AdminGenerationsAppResponseDto
+import co.yappuworld.operation.infrastructure.GenerationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AdminUserOperationService(
+    private val generationRepository: GenerationRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun getGenerations(request: AdminGenerationPageAppRequestDto): AdminGenerationsAppResponseDto {
+        val pageResponse = generationRepository.findAll(request.toPageRequest())
+        return AdminGenerationsAppResponseDto(pageResponse)
+    }
+}

--- a/src/main/kotlin/co/yappuworld/operation/application/AdminUserOperationService.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/AdminUserOperationService.kt
@@ -3,6 +3,7 @@ package co.yappuworld.operation.application
 import co.yappuworld.operation.application.dto.request.AdminGenerationPageAppRequestDto
 import co.yappuworld.operation.application.dto.response.AdminGenerationsAppResponseDto
 import co.yappuworld.operation.infrastructure.GenerationRepository
+import co.yappuworld.operation.presentation.dto.request.AdminGenerationRegisterAppRequestDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,5 +16,17 @@ class AdminUserOperationService(
     fun getGenerations(request: AdminGenerationPageAppRequestDto): AdminGenerationsAppResponseDto {
         val pageResponse = generationRepository.findAll(request.toPageRequest())
         return AdminGenerationsAppResponseDto(pageResponse)
+    }
+
+    @Transactional
+    fun registerGeneration(request: AdminGenerationRegisterAppRequestDto) {
+        if (request.isActive) {
+            generationRepository
+                .findGenerationByIsActiveIsTrue()
+                ?.apply { done() }
+                ?.also { generationRepository.save(it) }
+        }
+
+        generationRepository.save(request.toDomain())
     }
 }

--- a/src/main/kotlin/co/yappuworld/operation/application/AdminUserOperationService.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/AdminUserOperationService.kt
@@ -1,32 +1,77 @@
 package co.yappuworld.operation.application
 
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.operation.application.dto.request.AdminGenerationActiveUpdateAppRequestDto
 import co.yappuworld.operation.application.dto.request.AdminGenerationPageAppRequestDto
-import co.yappuworld.operation.application.dto.response.AdminGenerationsAppResponseDto
+import co.yappuworld.operation.application.dto.response.AdminGenerationActiveUpdateAppResponseDto
+import co.yappuworld.operation.application.dto.response.AdminGenerationsAppParamDto
+import co.yappuworld.operation.domain.Generation
+import co.yappuworld.operation.domain.OperationError
 import co.yappuworld.operation.infrastructure.GenerationRepository
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationRegisterAppRequestDto
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class AdminUserOperationService(
+    private val generationActivator: GenerationActivator,
     private val generationRepository: GenerationRepository
 ) {
 
     @Transactional(readOnly = true)
-    fun getGenerations(request: AdminGenerationPageAppRequestDto): AdminGenerationsAppResponseDto {
+    fun getGenerations(request: AdminGenerationPageAppRequestDto): AdminGenerationsAppParamDto {
         val pageResponse = generationRepository.findAll(request.toPageRequest())
-        return AdminGenerationsAppResponseDto(pageResponse)
+        return AdminGenerationsAppParamDto(pageResponse)
     }
 
     @Transactional
     fun registerGeneration(request: AdminGenerationRegisterAppRequestDto) {
         if (request.isActive) {
-            generationRepository
-                .findGenerationByIsActiveIsTrue()
-                ?.apply { done() }
-                ?.also { generationRepository.save(it) }
+            deactivateGeneration()
         }
 
         generationRepository.save(request.toDomain())
     }
+
+    @Transactional
+    fun updateGenerationActiveStatus(
+        request: AdminGenerationActiveUpdateAppRequestDto
+    ): AdminGenerationActiveUpdateAppResponseDto =
+        AdminGenerationActiveUpdateAppResponseDto(
+            when (request.targetActive) {
+                true -> generationActivator.activate(request.generation)
+                false -> generationActivator.deactivate(request.generation)
+            }
+        )
+
+    private fun activateGeneration(generation: Int): Generation {
+        if (generationRepository.existsGenerationByIsActiveIsTrue()) {
+            deactivateGeneration()
+        }
+
+        return generationRepository
+            .findByIdOrNull(generation)
+            ?.apply { activate() }
+            ?.also { generationRepository.save(it) }
+            ?: throw BusinessException(OperationError.NOT_EXIST_GENERATION)
+    }
+
+    private fun deactivateGeneration(targetGeneration: Int? = null): Generation? {
+        val activeGenerationsOrEmpty = generationRepository.findAllByIsActiveIsTrue()
+
+        if (activeGenerationsOrEmpty.isEmpty()) return null
+        if (activeGenerationsOrEmpty.size > 1) throw BusinessException(OperationError.GENERATION_INCONSISTENCY)
+
+        val generation = activeGenerationsOrEmpty.single()
+
+        if (targetGeneration != null && generation.value != targetGeneration) {
+            throw BusinessException(OperationError.GENERATION_INCONSISTENCY)
+        }
+
+        return generation
+            .apply { deactivate() }
+            .also { generationRepository.save(it) }
+    }
+
 }

--- a/src/main/kotlin/co/yappuworld/operation/application/ConfigInquiryComponent.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/ConfigInquiryComponent.kt
@@ -17,4 +17,6 @@ class ConfigInquiryComponent(
             ?: throw NoSuchElementException("해당하는 값을 찾을 수 없습니다.")
 
     fun findConfigsBy(keys: List<String>): List<Config> = configRepository.findAllByIdIn(keys)
+
+    fun findConfigsBy(vararg keys: String): List<Config> = configRepository.findAllByIdIn(keys.toList())
 }

--- a/src/main/kotlin/co/yappuworld/operation/application/GenerationActivator.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/GenerationActivator.kt
@@ -1,0 +1,82 @@
+package co.yappuworld.operation.application
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.operation.application.dto.param.GenerationActivationControlResult
+import co.yappuworld.operation.domain.Generation
+import co.yappuworld.operation.domain.OperationError
+import co.yappuworld.operation.infrastructure.GenerationRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger { }
+
+@Component
+class GenerationActivator(
+    private val generationRepository: GenerationRepository
+) {
+
+    @Transactional
+    fun activate(targetGenerationValue: Int): GenerationActivationControlResult {
+        // 기존에 활성화 되어 있는 기수를 비활성화 시키고 활성화를 진행합니다.
+        val deactivatedGeneration: Int? = deactivateGeneration()
+        val targetGeneration = generationRepository.findByIdOrNull(targetGenerationValue)
+            ?: throw BusinessException(OperationError.NOT_EXIST_GENERATION)
+
+        return targetGeneration
+            .apply { activate() }
+            .also { generationRepository.save(it) }
+            .let { GenerationActivationControlResult(it.value, deactivatedGeneration) }
+    }
+
+    @Transactional
+    fun deactivate(targetGenerationValue: Int): GenerationActivationControlResult =
+        GenerationActivationControlResult(
+            deactivatedGeneration = deactivateGeneration(targetGenerationValue)
+        )
+
+    private fun deactivateGeneration(targetGenerationValue: Int? = null): Int? {
+        if (!generationRepository.existsGenerationByIsActiveIsTrue()) return null
+
+        val activeGenerations = generationRepository.findAllByIsActiveIsTrue()
+        checkDeactivatingConsistency(activeGenerations, targetGenerationValue)
+
+        return activeGenerations
+            .single()
+            .apply { deactivate() }
+            .also { generationRepository.save(it) }
+            .value
+    }
+
+    private fun checkDeactivatingConsistency(
+        activeGenerations: List<Generation>,
+        deactivateTargetGeneration: Int? = null
+    ) {
+        if (deactivateTargetGeneration != null && activeGenerations.isEmpty()) {
+            logger.error {
+                """
+                활성화 된 기수는 없으나, 비활성화 요청이 들어왔습니다.
+                비활성화 요청 기수: $deactivateTargetGeneration
+                """.trimIndent()
+            }
+            throw BusinessException(OperationError.GENERATION_INCONSISTENCY)
+        }
+
+        if (activeGenerations.size > 1) {
+            logger.error { "활성화 된 기수: ${activeGenerations.map { it.value }.joinToString(", ")}}" }
+            throw BusinessException(OperationError.GENERATION_INCONSISTENCY)
+        }
+
+        val activeGeneration = activeGenerations.single()
+        if (deactivateTargetGeneration != null && deactivateTargetGeneration != activeGeneration.value) {
+            logger.error {
+                """
+                    활성화 해제 목표: $deactivateTargetGeneration
+                    현재 활성화 된 기수: ${activeGeneration.value}
+                """.trimIndent()
+            }
+            throw BusinessException(OperationError.GENERATION_INCONSISTENCY)
+        }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/operation/application/dto/param/GenerationActivationControlResult.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/dto/param/GenerationActivationControlResult.kt
@@ -1,0 +1,6 @@
+package co.yappuworld.operation.application.dto.param
+
+data class GenerationActivationControlResult(
+    val activatedGeneration: Int? = null,
+    val deactivatedGeneration: Int? = null
+)

--- a/src/main/kotlin/co/yappuworld/operation/application/dto/request/AdminGenerationActiveUpdateAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/dto/request/AdminGenerationActiveUpdateAppRequestDto.kt
@@ -1,0 +1,6 @@
+package co.yappuworld.operation.application.dto.request
+
+data class AdminGenerationActiveUpdateAppRequestDto(
+    val generation: Int,
+    val targetActive: Boolean
+)

--- a/src/main/kotlin/co/yappuworld/operation/application/dto/request/AdminGenerationPageAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/dto/request/AdminGenerationPageAppRequestDto.kt
@@ -1,0 +1,15 @@
+package co.yappuworld.operation.application.dto.request
+
+import org.springframework.data.domain.PageRequest
+
+data class AdminGenerationPageAppRequestDto(
+    val page: Int,
+    val limit: Int
+) {
+
+    fun toPageRequest(): PageRequest =
+        PageRequest.of(
+            page - 1,
+            limit
+        )
+}

--- a/src/main/kotlin/co/yappuworld/operation/application/dto/response/AdminGenerationActiveUpdateAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/dto/response/AdminGenerationActiveUpdateAppResponseDto.kt
@@ -1,0 +1,14 @@
+package co.yappuworld.operation.application.dto.response
+
+import co.yappuworld.operation.application.dto.param.GenerationActivationControlResult
+
+data class AdminGenerationActiveUpdateAppResponseDto(
+    val activatedGeneration: Int? = null,
+    val deactivatedGeneration: Int? = null
+) {
+
+    constructor(response: GenerationActivationControlResult) : this(
+        activatedGeneration = response.activatedGeneration,
+        deactivatedGeneration = response.deactivatedGeneration
+    )
+}

--- a/src/main/kotlin/co/yappuworld/operation/application/dto/response/AdminGenerationsAppParamDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/dto/response/AdminGenerationsAppParamDto.kt
@@ -4,7 +4,7 @@ import co.yappuworld.operation.domain.Generation
 import org.springframework.data.domain.Page
 import java.time.LocalDate
 
-data class AdminGenerationsAppResponseDto(
+data class AdminGenerationsAppParamDto(
     val generations: List<AdminGenerationAppResponseDto>,
     val totalElements: Long,
     val totalPages: Int

--- a/src/main/kotlin/co/yappuworld/operation/application/dto/response/AdminGenerationsAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/dto/response/AdminGenerationsAppResponseDto.kt
@@ -1,0 +1,33 @@
+package co.yappuworld.operation.application.dto.response
+
+import co.yappuworld.operation.domain.Generation
+import org.springframework.data.domain.Page
+import java.time.LocalDate
+
+data class AdminGenerationsAppResponseDto(
+    val generations: List<AdminGenerationAppResponseDto>,
+    val totalElements: Long,
+    val totalPages: Int
+) {
+
+    constructor(response: Page<Generation>) : this(
+        generations = response.content.map { AdminGenerationAppResponseDto(it) },
+        totalElements = response.totalElements,
+        totalPages = response.totalPages
+    )
+}
+
+data class AdminGenerationAppResponseDto(
+    val generation: Int,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val isActive: Boolean
+) {
+
+    constructor(generation: Generation) : this(
+        generation = generation.value,
+        startDate = generation.startDate,
+        endDate = generation.endDate,
+        isActive = generation.isActive
+    )
+}

--- a/src/main/kotlin/co/yappuworld/operation/domain/Config.kt
+++ b/src/main/kotlin/co/yappuworld/operation/domain/Config.kt
@@ -9,5 +9,12 @@ class Config(
     val id: String,
     val label: String,
     val category: ConfigCategory,
-    val value: String?
-)
+    value: String?
+) {
+    var value: String? = value
+        private set
+
+    fun updateValue(value: String?) {
+        this.value = value
+    }
+}

--- a/src/main/kotlin/co/yappuworld/operation/domain/ConfigError.kt
+++ b/src/main/kotlin/co/yappuworld/operation/domain/ConfigError.kt
@@ -9,5 +9,11 @@ enum class ConfigError : Error {
         override val message = "올바르지 않은 버전 형태입니다. 버전은 x.y.z 형태여야 합니다."
         override val code = "CFG_0001"
         override val type = ErrorType.WRONG_ARGUMENT
+    },
+
+    CONFIG_KEY_ERROR {
+        override val message = "환경 변수 세팅에 오류가 발생했습니다. 요청 데이터를 확인해주세요."
+        override val code = "CFG_9000"
+        override val type = ErrorType.WRONG_ARGUMENT
     }
 }

--- a/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
+++ b/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
@@ -1,0 +1,37 @@
+package co.yappuworld.operation.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.Transient
+import org.springframework.data.domain.Persistable
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDate
+
+@Table("generations")
+class Generation(
+    value: Int,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    isActive: Boolean
+) : Persistable<Int> {
+
+    @Id
+    private var value: Int = value
+
+    var startDate = startDate
+        private set
+    var endDate = endDate
+        private set
+    var isActive = false
+        private set
+
+    @Transient
+    private var isNew = true
+
+    override fun getId(): Int = this.value
+
+    override fun isNew(): Boolean = isNew
+
+    fun load() {
+        this.isNew = false
+    }
+}

--- a/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
+++ b/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
@@ -15,8 +15,8 @@ class Generation(
 ) : Persistable<Int> {
 
     @Id
-    private var value: Int = value
-
+    var value: Int = value
+        private set
     var startDate = startDate
         private set
     var endDate = endDate

--- a/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
+++ b/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
@@ -21,7 +21,7 @@ class Generation(
         private set
     var endDate = endDate
         private set
-    var isActive = false
+    var isActive = isActive
         private set
 
     @Transient
@@ -33,5 +33,9 @@ class Generation(
 
     fun load() {
         this.isNew = false
+    }
+
+    fun done() {
+        this.isActive = false
     }
 }

--- a/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
+++ b/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
@@ -35,7 +35,11 @@ class Generation(
         this.isNew = false
     }
 
-    fun done() {
+    fun activate() {
+        this.isActive = true
+    }
+
+    fun deactivate() {
         this.isActive = false
     }
 }

--- a/src/main/kotlin/co/yappuworld/operation/domain/OperationError.kt
+++ b/src/main/kotlin/co/yappuworld/operation/domain/OperationError.kt
@@ -1,0 +1,19 @@
+package co.yappuworld.operation.domain
+
+import co.yappuworld.global.exception.Error
+import co.yappuworld.global.exception.ErrorType
+
+enum class OperationError : Error {
+
+    // 1000 - Generation (기수)
+    NOT_EXIST_GENERATION {
+        override val message: String = "존재하지 않는 기수입니다."
+        override val code: String = "OPR_1000"
+        override val type: ErrorType = ErrorType.WRONG_ARGUMENT
+    },
+    GENERATION_INCONSISTENCY {
+        override val message: String = "기수 활성상태의 정합성이 맞지 않습니다. 데이터를 확인해주세요."
+        override val code: String = "OPR_1001"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    }
+}

--- a/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
@@ -8,5 +8,7 @@ interface GenerationRepository :
     CrudRepository<Generation, Int>,
     PagingAndSortingRepository<Generation, Int> {
 
-    fun findGenerationByIsActiveIsTrue(): Generation?
+    fun existsGenerationByIsActiveIsTrue(): Boolean
+
+    fun findAllByIsActiveIsTrue(): List<Generation>
 }

--- a/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
@@ -1,0 +1,6 @@
+package co.yappuworld.operation.infrastructure
+
+import co.yappuworld.operation.domain.Generation
+import org.springframework.data.repository.CrudRepository
+
+interface GenerationRepository : CrudRepository<Generation, Int>

--- a/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
@@ -6,4 +6,7 @@ import org.springframework.data.repository.PagingAndSortingRepository
 
 interface GenerationRepository :
     CrudRepository<Generation, Int>,
-    PagingAndSortingRepository<Generation, Int>
+    PagingAndSortingRepository<Generation, Int> {
+
+    fun findGenerationByIsActiveIsTrue(): Generation?
+}

--- a/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
@@ -2,5 +2,8 @@ package co.yappuworld.operation.infrastructure
 
 import co.yappuworld.operation.domain.Generation
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.PagingAndSortingRepository
 
-interface GenerationRepository : CrudRepository<Generation, Int>
+interface GenerationRepository :
+    CrudRepository<Generation, Int>,
+    PagingAndSortingRepository<Generation, Int>

--- a/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
@@ -3,6 +3,7 @@ package co.yappuworld.operation.presentation
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationPageApiRequestDto
+import co.yappuworld.operation.presentation.dto.request.AdminGenerationRegisterApiRequestDto
 import co.yappuworld.operation.presentation.dto.response.AdminGenerationApiResponseDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -11,9 +12,12 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 
 @Tag(name = "어드민 유저 관련 운영 데이터 API")
 interface AdminUserOperationApi {
@@ -61,4 +65,20 @@ interface AdminUserOperationApi {
     fun getGenerations(
         @ParameterObject request: AdminGenerationPageApiRequestDto
     ): ResponseEntity<SuccessResponse<OffsetPageResponse<AdminGenerationApiResponseDto>>>
+
+    @Operation(summary = "신규 기수 등록")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                description = "성공",
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = []
+            )
+        ]
+    )
+    @PostMapping("/admin/v1/operations/generations")
+    fun registerGeneration(
+        @Valid @RequestBody request: AdminGenerationRegisterApiRequestDto
+    ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
@@ -1,0 +1,64 @@
+package co.yappuworld.operation.presentation
+
+import co.yappuworld.global.response.OffsetPageResponse
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.operation.presentation.dto.request.AdminGenerationPageApiRequestDto
+import co.yappuworld.operation.presentation.dto.response.AdminGenerationApiResponseDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+
+@Tag(name = "어드민 유저 관련 운영 데이터 API")
+interface AdminUserOperationApi {
+
+    @Operation(summary = "기수 목록")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                description = "성공",
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = OffsetPageResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "직군 데이터 조회",
+                                value = """
+                                    {
+                                        "data": {
+                                            "data": [
+                                                {
+                                                    "generation": 24,
+                                                    "startDate": "2024-05-03",
+                                                    "endDate": "2024-09-14",
+                                                    "isActive": false
+                                                }
+                                            ],
+                                            "totalCount": 2,
+                                            "totalPages": 2,
+                                            "page": 1,
+                                            "size": 1
+                                        },
+                                        "isSuccess": true
+                                    }                                    
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/admin/v1/operations/generations")
+    fun getGenerations(
+        @ParameterObject request: AdminGenerationPageApiRequestDto
+    ): ResponseEntity<SuccessResponse<OffsetPageResponse<AdminGenerationApiResponseDto>>>
+}

--- a/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
@@ -2,9 +2,13 @@ package co.yappuworld.operation.presentation
 
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.operation.presentation.dto.request.AdminGenerationActiveUpdateApiRequestDto
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationPageApiRequestDto
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationRegisterApiRequestDto
+import co.yappuworld.operation.presentation.dto.response.AdminGenerationActiveUpdateApiResponseDto
 import co.yappuworld.operation.presentation.dto.response.AdminGenerationApiResponseDto
+import co.yappuworld.user.presentation.dto.request.AdminSignUpCodeUpdateApiRequestDto
+import co.yappuworld.user.presentation.dto.response.AdminSignUpCodesApiResponseDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -16,10 +20,11 @@ import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 
-@Tag(name = "어드민 유저 관련 운영 데이터 API")
+@Tag(name = "회원 운영 API")
 interface AdminUserOperationApi {
 
     @Operation(summary = "기수 목록")
@@ -71,14 +76,188 @@ interface AdminUserOperationApi {
         value = [
             ApiResponse(
                 description = "성공",
-                responseCode = "200",
+                responseCode = "201",
                 useReturnTypeSchema = true,
-                content = []
+                content = [Content()]
             )
         ]
     )
     @PostMapping("/admin/v1/operations/generations")
     fun registerGeneration(
         @Valid @RequestBody request: AdminGenerationRegisterApiRequestDto
+    ): ResponseEntity<Unit>
+
+    @Operation(summary = "기수 활성화 상태 변경")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                description = "OK",
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "활성화 된 기수가 없을 때 활성화",
+                                value = """
+                                    {
+                                        "data": {
+                                            "activatedGeneration": 25,
+                                            "deactivatedGeneration": null
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "활성화 된 기수가 있을 때 활성화",
+                                value = """
+                                    {
+                                        "data": {
+                                            "activatedGeneration": 25,
+                                            "deactivatedGeneration": 24
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "특정 기수 비활성화",
+                                value = """
+                                    {
+                                        "data": {
+                                            "activatedGeneration": null,
+                                            "deactivatedGeneration": 24
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                description = "Not Found",
+                responseCode = "404",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "존재하지 않는 기수",
+                                value = """
+                                    {
+                                        "errorCode": "OPR_1000",
+                                        "message": "존재하지 않는 기수입니다.",
+                                        "isSuccess": false
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                description = "Conflict",
+                responseCode = "409",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "활성화 정합성 오류",
+                                value = """
+                                    {
+                                        "errorCode": "OPR_1001",
+                                        "message": "기수 활성상태의 정합성이 맞지 않습니다. 데이터를 확인해주세요.",
+                                        "isSuccess": false
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @PatchMapping("/admin/v1/operations/generations/active")
+    fun updateActiveGeneration(
+        @Valid @RequestBody request: AdminGenerationActiveUpdateApiRequestDto
+    ): ResponseEntity<SuccessResponse<AdminGenerationActiveUpdateApiResponseDto>>
+
+    @Operation(summary = "회원가입 인증번호 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                description = "성공",
+                responseCode = "200",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                value = """
+                                    {
+                                        "data": {
+                                            "codes": [
+                                                {
+                                                  "code": "000000",
+                                                  "role": {
+                                                    "name": "ADMIN",
+                                                    "label": "관리자"
+                                                  }
+                                                },
+                                                {
+                                                  "code": "000001",
+                                                  "role": {
+                                                    "name": "STAFF",
+                                                    "label": "운영진"
+                                                  }
+                                                },
+                                                {
+                                                  "code": "000002",
+                                                  "role": {
+                                                    "name": "ALUMNI",
+                                                    "label": "정회원"
+                                                  }
+                                                },
+                                                {
+                                                  "code": "",
+                                                  "role": {
+                                                    "name": "GRADUATE",
+                                                    "label": "수료회원"
+                                                  }
+                                                },
+                                                {
+                                                  "code": "000003",
+                                                  "role": {
+                                                    "name": "ACTIVE",
+                                                    "label": "활동회원"
+                                                  }
+                                                }
+                                            ]
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/admin/v1/auth/authentication-codes")
+    fun getSignUpAuthenticationCode(): ResponseEntity<SuccessResponse<AdminSignUpCodesApiResponseDto>>
+
+    @Operation(summary = "인증번호 수정")
+    @ApiResponse(
+        responseCode = "204",
+        description = "No Content",
+        content = [Content()]
+    )
+    @PatchMapping("/admin/v1/auth/authentication-codes")
+    fun updateSignUpAuthenticationCode(
+        @Valid @RequestBody request: AdminSignUpCodeUpdateApiRequestDto
     ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationController.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationController.kt
@@ -4,9 +4,11 @@ import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.operation.application.AdminUserOperationService
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationPageApiRequestDto
+import co.yappuworld.operation.presentation.dto.request.AdminGenerationRegisterApiRequestDto
 import co.yappuworld.operation.presentation.dto.response.AdminGenerationApiResponseDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 @RestController
 class AdminUserOperationController(
@@ -28,5 +30,10 @@ class AdminUserOperationController(
                 )
             )
         )
+    }
+
+    override fun registerGeneration(request: AdminGenerationRegisterApiRequestDto): ResponseEntity<Unit> {
+        adminUserOperationService.registerGeneration(request.toAppRequest())
+        return ResponseEntity.created(URI("/admin/v1/operations")).build()
     }
 }

--- a/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationController.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationController.kt
@@ -3,16 +3,26 @@ package co.yappuworld.operation.presentation
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.operation.application.AdminUserOperationService
+import co.yappuworld.operation.application.ConfigInquiryComponent
+import co.yappuworld.operation.presentation.dto.request.AdminGenerationActiveUpdateApiRequestDto
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationPageApiRequestDto
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationRegisterApiRequestDto
+import co.yappuworld.operation.presentation.dto.response.AdminGenerationActiveUpdateApiResponseDto
 import co.yappuworld.operation.presentation.dto.response.AdminGenerationApiResponseDto
+import co.yappuworld.user.application.UserAdminService
+import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.presentation.dto.request.AdminSignUpCodeUpdateApiRequestDto
+import co.yappuworld.user.presentation.dto.response.AdminSignUpCodeApiResponseDto
+import co.yappuworld.user.presentation.dto.response.AdminSignUpCodesApiResponseDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
 @RestController
 class AdminUserOperationController(
-    private val adminUserOperationService: AdminUserOperationService
+    private val adminUserOperationService: AdminUserOperationService,
+    private val userAdminService: UserAdminService,
+    private val configInquiryComponent: ConfigInquiryComponent
 ) : AdminUserOperationApi {
 
     override fun getGenerations(
@@ -35,5 +45,37 @@ class AdminUserOperationController(
     override fun registerGeneration(request: AdminGenerationRegisterApiRequestDto): ResponseEntity<Unit> {
         adminUserOperationService.registerGeneration(request.toAppRequest())
         return ResponseEntity.created(URI("/admin/v1/operations")).build()
+    }
+
+    override fun updateActiveGeneration(
+        request: AdminGenerationActiveUpdateApiRequestDto
+    ): ResponseEntity<SuccessResponse<AdminGenerationActiveUpdateApiResponseDto>> =
+        ResponseEntity.ok(
+            SuccessResponse(
+                AdminGenerationActiveUpdateApiResponseDto(
+                    adminUserOperationService.updateGenerationActiveStatus(request.toAppRequest())
+                )
+            )
+        )
+
+    override fun getSignUpAuthenticationCode(): ResponseEntity<SuccessResponse<AdminSignUpCodesApiResponseDto>> {
+        val responseByKey = configInquiryComponent
+            .findConfigsBy(UserRole.entries.map { it.signUpCodeKey })
+            .associateBy { it.id }
+
+        val codes = UserRole.entries.map { role ->
+            AdminSignUpCodeApiResponseDto(responseByKey[role.signUpCodeKey], role)
+        }
+
+        return ResponseEntity.ok(
+            SuccessResponse(
+                AdminSignUpCodesApiResponseDto(codes)
+            )
+        )
+    }
+
+    override fun updateSignUpAuthenticationCode(request: AdminSignUpCodeUpdateApiRequestDto): ResponseEntity<Unit> {
+        userAdminService.updateSignUpCode(request.toAppRequest())
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationController.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationController.kt
@@ -1,0 +1,32 @@
+package co.yappuworld.operation.presentation
+
+import co.yappuworld.global.response.OffsetPageResponse
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.operation.application.AdminUserOperationService
+import co.yappuworld.operation.presentation.dto.request.AdminGenerationPageApiRequestDto
+import co.yappuworld.operation.presentation.dto.response.AdminGenerationApiResponseDto
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AdminUserOperationController(
+    private val adminUserOperationService: AdminUserOperationService
+) : AdminUserOperationApi {
+
+    override fun getGenerations(
+        request: AdminGenerationPageApiRequestDto
+    ): ResponseEntity<SuccessResponse<OffsetPageResponse<AdminGenerationApiResponseDto>>> {
+        val response = adminUserOperationService.getGenerations(request.toAppRequest())
+        return ResponseEntity.ok(
+            SuccessResponse(
+                OffsetPageResponse(
+                    data = response.generations.map { AdminGenerationApiResponseDto(it) },
+                    totalCount = response.totalElements,
+                    totalPages = response.totalPages,
+                    page = request.page,
+                    size = request.size
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/operation/presentation/OperationController.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/OperationController.kt
@@ -48,15 +48,16 @@ class OperationController(
     }
 
     override fun getActiveGeneration(): ResponseEntity<SuccessResponse<ActiveGenerationApiResponseDto>> {
-        val activeGenerationResponse = configInquiryComponent.findConfigBy("activeGeneration").let {
-            when (it.value?.isNotBlank()) {
-                true -> ActiveGenerationApiResponseDto(true, it.value.toInt())
-                null, false -> ActiveGenerationApiResponseDto(false, null)
-            }
-        }
+        val response = configInquiryComponent
+            .findConfigBy("activeGeneration")
+            .value
+            .takeUnless { it.isNullOrBlank() }
+            ?.let {
+                ActiveGenerationApiResponseDto(true, it.toInt())
+            } ?: ActiveGenerationApiResponseDto(false, null)
 
         return ResponseEntity.ok(
-            SuccessResponse(activeGenerationResponse)
+            SuccessResponse(response)
         )
     }
 

--- a/src/main/kotlin/co/yappuworld/operation/presentation/dto/request/AdminGenerationActiveUpdateApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/dto/request/AdminGenerationActiveUpdateApiRequestDto.kt
@@ -1,0 +1,18 @@
+package co.yappuworld.operation.presentation.dto.request
+
+import co.yappuworld.operation.application.dto.request.AdminGenerationActiveUpdateAppRequestDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AdminGenerationActiveUpdateApiRequestDto(
+    @Schema(description = "변경하려는 기수")
+    val generation: Int,
+    @Schema(description = "목표 상태")
+    val targetActive: Boolean
+) {
+
+    fun toAppRequest(): AdminGenerationActiveUpdateAppRequestDto =
+        AdminGenerationActiveUpdateAppRequestDto(
+            generation = generation,
+            targetActive = targetActive
+        )
+}

--- a/src/main/kotlin/co/yappuworld/operation/presentation/dto/request/AdminGenerationPageApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/dto/request/AdminGenerationPageApiRequestDto.kt
@@ -1,0 +1,21 @@
+package co.yappuworld.operation.presentation.dto.request
+
+import co.yappuworld.operation.application.dto.request.AdminGenerationPageAppRequestDto
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+
+data class AdminGenerationPageApiRequestDto(
+    @field:Schema(description = "페이지 번호", required = true)
+    @field:Min(value = 1L, message = "페이지 번호는 1 이상이어야 합니다.")
+    val page: Int,
+    @field:Schema(description = "페이지 당 데이터 개수", required = true)
+    @field:Min(value = 1L, message = "데이터는 1개 이상이어야 합니다.")
+    val size: Int
+) {
+
+    fun toAppRequest(): AdminGenerationPageAppRequestDto =
+        AdminGenerationPageAppRequestDto(
+            page = page,
+            limit = size
+        )
+}

--- a/src/main/kotlin/co/yappuworld/operation/presentation/dto/request/AdminGenerationRegisterApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/dto/request/AdminGenerationRegisterApiRequestDto.kt
@@ -1,0 +1,30 @@
+package co.yappuworld.operation.presentation.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class AdminGenerationRegisterApiRequestDto(
+    @Schema(description = "기수")
+    @field:Min(value = 1L, message = "기수는 1 이상이어야 합니다.")
+    val generation: Int,
+    @Schema(description = "시작일")
+    @field:NotNull(message = "시작일은 필수 값입니다.")
+    val startDate: LocalDate,
+    @Schema(description = "종료일")
+    @field:NotNull(message = "종료일은 필수 값입니다.")
+    val endDate: LocalDate,
+    @Schema(description = "활동 중 여부")
+    @field:NotNull(message = "활동 중 여부는 필수 값입니다.")
+    val isActive: Boolean
+) {
+
+    fun toAppRequest(): AdminGenerationRegisterAppRequestDto =
+        AdminGenerationRegisterAppRequestDto(
+            generation = generation,
+            startDate = startDate,
+            endDate = endDate,
+            isActive = isActive
+        )
+}

--- a/src/main/kotlin/co/yappuworld/operation/presentation/dto/request/AdminGenerationRegisterAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/dto/request/AdminGenerationRegisterAppRequestDto.kt
@@ -1,0 +1,20 @@
+package co.yappuworld.operation.presentation.dto.request
+
+import co.yappuworld.operation.domain.Generation
+import java.time.LocalDate
+
+data class AdminGenerationRegisterAppRequestDto(
+    val generation: Int,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val isActive: Boolean
+) {
+
+    fun toDomain(): Generation =
+        Generation(
+            value = generation,
+            startDate = startDate,
+            endDate = endDate,
+            isActive = isActive
+        )
+}

--- a/src/main/kotlin/co/yappuworld/operation/presentation/dto/response/AdminGenerationActiveUpdateApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/dto/response/AdminGenerationActiveUpdateApiResponseDto.kt
@@ -1,0 +1,17 @@
+package co.yappuworld.operation.presentation.dto.response
+
+import co.yappuworld.operation.application.dto.response.AdminGenerationActiveUpdateAppResponseDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AdminGenerationActiveUpdateApiResponseDto(
+    @Schema(description = "활성화 된 기수", nullable = true)
+    val activatedGeneration: Int? = null,
+    @Schema(description = "비활성화 된 기수", nullable = true)
+    val deactivatedGeneration: Int? = null
+) {
+
+    constructor(response: AdminGenerationActiveUpdateAppResponseDto) : this(
+        activatedGeneration = response.activatedGeneration,
+        deactivatedGeneration = response.deactivatedGeneration
+    )
+}

--- a/src/main/kotlin/co/yappuworld/operation/presentation/dto/response/AdminGenerationApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/dto/response/AdminGenerationApiResponseDto.kt
@@ -1,0 +1,24 @@
+package co.yappuworld.operation.presentation.dto.response
+
+import co.yappuworld.operation.application.dto.response.AdminGenerationAppResponseDto
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+data class AdminGenerationApiResponseDto(
+    @Schema(description = "기수")
+    val generation: Int,
+    @Schema(description = "시작일")
+    val startDate: LocalDate,
+    @Schema(description = "종료일")
+    val endDate: LocalDate,
+    @Schema(description = "현재 활동 중인지")
+    val isActive: Boolean
+) {
+
+    constructor(response: AdminGenerationAppResponseDto) : this(
+        generation = response.generation,
+        startDate = response.startDate,
+        endDate = response.endDate,
+        isActive = response.isActive
+    )
+}

--- a/src/main/kotlin/co/yappuworld/schedule/domain/Schedule.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/Schedule.kt
@@ -1,21 +1,14 @@
 package co.yappuworld.schedule.domain
 
 import co.yappuworld.global.persistence.BaseEntity
-import com.github.f4b6a3.ulid.UlidCreator
-import org.springframework.data.annotation.Id
-import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 
 @Table("schedules")
-abstract class Schedule :
-    BaseEntity(),
-    Persistable<UUID> {
-    @Id
-    @JvmField
-    protected var id: UUID = UlidCreator.getMonotonicUlid().toUuid()
+abstract class Schedule : BaseEntity() {
+
     protected var isDeleted: Boolean = false
 
     protected abstract val name: String

--- a/src/main/kotlin/co/yappuworld/user/application/UserAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAdminService.kt
@@ -24,6 +24,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
+import kotlin.math.ceil
 
 @Service
 class UserAdminService(
@@ -61,7 +62,8 @@ class UserAdminService(
 
         return UserOverviewBundleAppResponseDto(
             data = userWithActivityUnit.map { UserOverviewAppResponseDto(it) },
-            totalCount = totalCount
+            totalCount = totalCount,
+            totalPages = ceil(totalCount.toDouble() / request.limit).toInt()
         )
     }
 

--- a/src/main/kotlin/co/yappuworld/user/application/UserAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAdminService.kt
@@ -2,8 +2,11 @@ package co.yappuworld.user.application
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.util.ifNotEmpty
+import co.yappuworld.operation.domain.ConfigError
+import co.yappuworld.operation.infrastructure.ConfigRepository
 import co.yappuworld.user.application.dto.request.AdminActivityUnitUpdateAppRequestDto
 import co.yappuworld.user.application.dto.request.AdminSignUpApplicationPageAppRequestDto
+import co.yappuworld.user.application.dto.request.AdminSignUpCodeUpdateAppRequestDto
 import co.yappuworld.user.application.dto.request.AdminUserPageAppRequestDto
 import co.yappuworld.user.application.dto.request.AdminUserUpdateAppRequestDto
 import co.yappuworld.user.application.dto.request.UserRoleUpdateAppRequestDto
@@ -26,7 +29,8 @@ import java.util.UUID
 class UserAdminService(
     private val userRepository: UserRepository,
     private val userSignUpApplicationRepository: UserSignUpApplicationRepository,
-    private val activityUnitRepository: ActivityUnitRepository
+    private val activityUnitRepository: ActivityUnitRepository,
+    private val configRepository: ConfigRepository
 ) {
 
     @Transactional
@@ -66,6 +70,7 @@ class UserAdminService(
         handleActivityUnitRequest(request.userId, request.activityUnits)
     }
 
+    @Transactional(readOnly = true)
     fun getSignUpApplicationDetails(applicationId: UUID): AdminSignUpApplicationAppResponseDto {
         val application = userSignUpApplicationRepository.findByIdOrNull(applicationId)
             ?: throw BusinessException(UserError.NOT_FOUND_SIGN_UP_APPLICATION)
@@ -79,12 +84,22 @@ class UserAdminService(
         }
     }
 
+    @Transactional(readOnly = true)
     fun getSignUpApplications(
         request: AdminSignUpApplicationPageAppRequestDto
     ): AdminSignUpApplicationBundleAppResponse =
         userSignUpApplicationRepository.findAll(request.toPageRequest()).let {
             AdminSignUpApplicationBundleAppResponse(it)
         }
+
+    @Transactional
+    fun updateSignUpCode(request: AdminSignUpCodeUpdateAppRequestDto) {
+        val config = configRepository.findByIdOrNull(request.role.signUpCodeKey)?.apply {
+            updateValue(request.code)
+        } ?: throw BusinessException(ConfigError.CONFIG_KEY_ERROR)
+
+        configRepository.save(config)
+    }
 
     private fun updateUser(request: AdminUserUpdateAppRequestDto) {
         val user = userRepository.findByIdOrNull(request.userId)

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/AdminSignUpCodeUpdateAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/AdminSignUpCodeUpdateAppRequestDto.kt
@@ -1,0 +1,8 @@
+package co.yappuworld.user.application.dto.request
+
+import co.yappuworld.user.domain.vo.UserRole
+
+data class AdminSignUpCodeUpdateAppRequestDto(
+    val role: UserRole,
+    val code: String
+)

--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/AdminSignUpApplicationBundleAppResponse.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/AdminSignUpApplicationBundleAppResponse.kt
@@ -5,11 +5,13 @@ import org.springframework.data.domain.Page
 
 data class AdminSignUpApplicationBundleAppResponse(
     val data: List<AdminSignUpApplicationOverviewAppResponseDto>,
-    val totalCount: Long
+    val totalCount: Long,
+    val totalPages: Int
 ) {
 
     constructor(page: Page<SignUpApplication>) : this(
         data = page.content.map { AdminSignUpApplicationOverviewAppResponseDto(it) },
-        totalCount = page.totalElements
+        totalCount = page.totalElements,
+        totalPages = page.totalPages
     )
 }

--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/UserOverviewBundleAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/UserOverviewBundleAppResponseDto.kt
@@ -2,5 +2,6 @@ package co.yappuworld.user.application.dto.response
 
 data class UserOverviewBundleAppResponseDto(
     val data: List<UserOverviewAppResponseDto>,
-    val totalCount: Long
+    val totalCount: Long,
+    val totalPages: Int
 )

--- a/src/main/kotlin/co/yappuworld/user/domain/model/ActivityUnit.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/ActivityUnit.kt
@@ -2,9 +2,6 @@ package co.yappuworld.user.domain.model
 
 import co.yappuworld.global.persistence.BaseEntity
 import co.yappuworld.user.domain.vo.Position
-import com.github.f4b6a3.ulid.UlidCreator
-import org.springframework.data.annotation.Id
-import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Table
 import java.util.UUID
 
@@ -13,32 +10,18 @@ import java.util.UUID
  * @property position 직군
  */
 @Table("activity_units")
-class ActivityUnit private constructor(
+class ActivityUnit(
     generation: Int,
     position: Position,
-    val userId: UUID,
-    @Id
-    @JvmField
-    val id: UUID
-) : BaseEntity(),
-    Persistable<UUID> {
+    val userId: UUID
+) : BaseEntity() {
 
     var generation: Int = generation
         private set
     var position: Position = position
         private set
 
-    constructor(
-        generation: Int,
-        position: Position,
-        userId: UUID
-    ) : this(generation, position, userId, UlidCreator.getMonotonicUlid().toUuid())
-
-    fun withId(id: UUID): ActivityUnit = ActivityUnit(generation, position, userId, id)
-
-    override fun getId(): UUID = this.id
-
-    override fun isNew(): Boolean = !isCreatedAtInitialized()
+    fun withId(id: UUID): ActivityUnit = ActivityUnit(generation, position, userId).apply { this.id = id }
 
     fun updateActivityUnit(
         generation: Int,

--- a/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplication.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/SignUpApplication.kt
@@ -2,26 +2,19 @@ package co.yappuworld.user.domain.model
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.persistence.BaseEntity
+import co.yappuworld.user.domain.vo.SignUpApplicationStatus
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.domain.vo.UserRole
-import co.yappuworld.user.domain.vo.SignUpApplicationStatus
-import com.github.f4b6a3.ulid.UlidCreator
-import org.springframework.data.annotation.Id
-import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Table
 import java.util.UUID
 
 @Table("sign_up_application")
-class SignUpApplication private constructor(
-    @Id
-    @JvmField
-    val id: UUID,
+class SignUpApplication(
     val applicantEmail: String,
     val details: ApplicationDetails,
     status: SignUpApplicationStatus,
     rejectReason: String?
-) : BaseEntity(),
-    Persistable<UUID> {
+) : BaseEntity() {
 
     var status: SignUpApplicationStatus = status
         private set
@@ -29,7 +22,6 @@ class SignUpApplication private constructor(
         private set
 
     constructor(application: ApplicationDetails) : this(
-        UlidCreator.getMonotonicUlid().toUuid(),
         application.email,
         application,
         SignUpApplicationStatus.PENDING,
@@ -52,10 +44,6 @@ class SignUpApplication private constructor(
             throw BusinessException(UserError.MISMATCH_REQUEST_AND_SIGN_UP_APPLICATION)
         }
     }
-
-    override fun getId(): UUID = this.id
-
-    override fun isNew(): Boolean = !isCreatedAtInitialized()
 
     fun toActivityUnits(userId: UUID): List<ActivityUnit> =
         this.details.activityUnits.map {

--- a/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/User.kt
@@ -5,9 +5,6 @@ import co.yappuworld.global.persistence.BaseEntity
 import co.yappuworld.global.util.EncryptUtils
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.domain.vo.UserRole
-import com.github.f4b6a3.ulid.UlidCreator
-import org.springframework.data.annotation.Id
-import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Table
 import java.util.UUID
 
@@ -17,12 +14,8 @@ class User private constructor(
     password: String,
     name: String,
     role: UserRole,
-    isActive: Boolean = true,
-    @Id
-    @JvmField
-    val id: UUID
-) : BaseEntity(),
-    Persistable<UUID> {
+    isActive: Boolean = true
+) : BaseEntity() {
 
     var isActive: Boolean = isActive
         private set
@@ -41,9 +34,10 @@ class User private constructor(
         password: String,
         name: String,
         role: UserRole
-    ) : this(email, password, name, role, true, UlidCreator.getMonotonicUlid().toUuid())
+    ) : this(email, password, name, role, true)
 
-    fun withId(id: UUID): User = User(this.email, this.password, this.name, this.role, this.isActive, id)
+    fun withId(id: UUID): User =
+        User(this.email, this.password, this.name, this.role, this.isActive).apply { this.id = id }
 
     override fun getId(): UUID = this.id
 

--- a/src/main/kotlin/co/yappuworld/user/domain/model/UserAlarmSetting.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/UserAlarmSetting.kt
@@ -1,9 +1,6 @@
 package co.yappuworld.user.domain.model
 
 import co.yappuworld.global.persistence.BaseEntity
-import com.github.f4b6a3.ulid.UlidCreator
-import org.springframework.data.annotation.Id
-import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Table
 import java.util.UUID
 
@@ -11,12 +8,8 @@ import java.util.UUID
 class UserAlarmSetting private constructor(
     val userId: UUID,
     device: Boolean,
-    master: Boolean,
-    @Id
-    @JvmField
-    val id: UUID = UlidCreator.getMonotonicUlid().toUuid()
-) : BaseEntity(),
-    Persistable<UUID> {
+    master: Boolean
+) : BaseEntity() {
 
     var device: Boolean = device
         private set
@@ -26,15 +19,11 @@ class UserAlarmSetting private constructor(
     constructor(userId: UUID, deviceToggle: Boolean) : this(
         userId = userId,
         device = deviceToggle,
-        master = true,
-        id = UlidCreator.getMonotonicUlid().toUuid()
+        master = true
     )
 
-    fun withId(id: UUID): UserAlarmSetting = UserAlarmSetting(this.userId, this.device, this.master, id)
-
-    override fun getId(): UUID = this.id
-
-    override fun isNew(): Boolean = !this.isCreatedAtInitialized()
+    fun withId(id: UUID): UserAlarmSetting =
+        UserAlarmSetting(this.userId, this.device, this.master).apply { this.id = id }
 
     fun toggleMaster() {
         this.master = !this.master

--- a/src/main/kotlin/co/yappuworld/user/domain/model/UserDevice.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/UserDevice.kt
@@ -1,32 +1,19 @@
 package co.yappuworld.user.domain.model
 
 import co.yappuworld.global.persistence.BaseEntity
-import com.github.f4b6a3.ulid.UlidCreator
-import org.springframework.data.annotation.Id
-import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Table
 import java.util.UUID
 
 @Table("user_devices")
-class UserDevice private constructor(
+class UserDevice(
     val userId: UUID,
-    fcmToken: String?,
-    @Id
-    @JvmField
-    val id: UUID
-) : BaseEntity(),
-    Persistable<UUID> {
+    fcmToken: String?
+) : BaseEntity() {
 
     var fcmToken: String? = fcmToken
         private set
 
-    constructor(userId: UUID, fcmToken: String) : this(userId, fcmToken, UlidCreator.getMonotonicUlid().toUuid())
-
-    fun withId(id: UUID): UserDevice = UserDevice(this.userId, this.fcmToken, id)
-
-    override fun getId(): UUID = this.id
-
-    override fun isNew(): Boolean = !isCreatedAtInitialized()
+    fun withId(id: UUID): UserDevice = UserDevice(this.userId, this.fcmToken).apply { this.id = id }
 
     fun updateFcmToken(fcmToken: String) {
         this.fcmToken = fcmToken

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
@@ -10,7 +10,7 @@ package co.yappuworld.user.domain.vo
 enum class UserRole(
     val authority: String,
     val label: String,
-    val authenticationCodeKey: String
+    val signUpCodeKey: String
 ) {
     ADMIN("ROLE_ADMIN", "관리자", "authenticationCodeAdmin"),
     STAFF("ROLE_STAFF", "운영진", "authenticationCodeStaff"),

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
@@ -9,11 +9,12 @@ package co.yappuworld.user.domain.vo
  */
 enum class UserRole(
     val authority: String,
-    val label: String
+    val label: String,
+    val authenticationCodeKey: String
 ) {
-    ADMIN("ROLE_ADMIN", "관리자"),
-    STAFF("ROLE_STAFF", "운영진"),
-    ALUMNI("ROLE_ALUMNI", "정회원"),
-    GRADUATE("ROLE_GRADUATE", "수료회원"),
-    ACTIVE("ROLE_ACTIVE", "활동회원")
+    ADMIN("ROLE_ADMIN", "관리자", "authenticationCodeAdmin"),
+    STAFF("ROLE_STAFF", "운영진", "authenticationCodeStaff"),
+    ALUMNI("ROLE_ALUMNI", "정회원", "authenticationCodeAlumni"),
+    GRADUATE("ROLE_GRADUATE", "수료회원", "authenticationCodeGraduate"),
+    ACTIVE("ROLE_ACTIVE", "활동회원", "authenticationCodeActive")
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAdminController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAdminController.kt
@@ -30,6 +30,7 @@ class UserAdminController(
             OffsetPageResponse(
                 data = response.data.map { AdminUserOverviewApiResponseDto(it) },
                 totalCount = response.totalCount,
+                totalPages = response.totalPages,
                 page = request.page,
                 size = request.size
             )

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
@@ -9,6 +9,7 @@ import co.yappuworld.user.presentation.dto.request.SignUpApplicationRejectApiReq
 import co.yappuworld.user.presentation.dto.request.UserRoleUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationApiResponseDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationOverviewApiResponseDto
+import co.yappuworld.user.presentation.dto.response.AdminSignUpAuthenticationCodesApiResponseDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -211,4 +212,68 @@ interface UserAuthAdminApi {
     fun getSignUpApplication(
         @PathVariable applicationId: UUID
     ): ResponseEntity<SuccessResponse<AdminSignUpApplicationApiResponseDto>>
+
+    @Operation(summary = "회원가입 인증번호 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                description = "성공",
+                responseCode = "200",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                value = """
+                                    {
+                                        "data": {
+                                            "codes": [
+                                                {
+                                                  "code": "000000",
+                                                  "role": {
+                                                    "name": "ADMIN",
+                                                    "label": "관리자"
+                                                  }
+                                                },
+                                                {
+                                                  "code": "000001",
+                                                  "role": {
+                                                    "name": "STAFF",
+                                                    "label": "운영진"
+                                                  }
+                                                },
+                                                {
+                                                  "code": "000002",
+                                                  "role": {
+                                                    "name": "ALUMNI",
+                                                    "label": "정회원"
+                                                  }
+                                                },
+                                                {
+                                                  "code": "",
+                                                  "role": {
+                                                    "name": "GRADUATE",
+                                                    "label": "수료회원"
+                                                  }
+                                                },
+                                                {
+                                                  "code": "000003",
+                                                  "role": {
+                                                    "name": "ACTIVE",
+                                                    "label": "활동회원"
+                                                  }
+                                                }
+                                            ]
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/admin/v1/auth/authentication-codes")
+    fun getSignUpAuthenticationCode(): ResponseEntity<SuccessResponse<AdminSignUpAuthenticationCodesApiResponseDto>>
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
@@ -4,13 +4,11 @@ import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.user.presentation.dto.request.AdminSignUpApplicationPageApiRequestDto
-import co.yappuworld.user.presentation.dto.request.AdminSignUpCodeUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationApproveApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationRejectApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserRoleUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationApiResponseDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationOverviewApiResponseDto
-import co.yappuworld.user.presentation.dto.response.AdminSignUpCodesApiResponseDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -213,74 +211,4 @@ interface UserAuthAdminApi {
     fun getSignUpApplication(
         @PathVariable applicationId: UUID
     ): ResponseEntity<SuccessResponse<AdminSignUpApplicationApiResponseDto>>
-
-    @Operation(summary = "회원가입 인증번호 조회")
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                description = "성공",
-                responseCode = "200",
-                content = [
-                    Content(
-                        examples = [
-                            ExampleObject(
-                                value = """
-                                    {
-                                        "data": {
-                                            "codes": [
-                                                {
-                                                  "code": "000000",
-                                                  "role": {
-                                                    "name": "ADMIN",
-                                                    "label": "관리자"
-                                                  }
-                                                },
-                                                {
-                                                  "code": "000001",
-                                                  "role": {
-                                                    "name": "STAFF",
-                                                    "label": "운영진"
-                                                  }
-                                                },
-                                                {
-                                                  "code": "000002",
-                                                  "role": {
-                                                    "name": "ALUMNI",
-                                                    "label": "정회원"
-                                                  }
-                                                },
-                                                {
-                                                  "code": "",
-                                                  "role": {
-                                                    "name": "GRADUATE",
-                                                    "label": "수료회원"
-                                                  }
-                                                },
-                                                {
-                                                  "code": "000003",
-                                                  "role": {
-                                                    "name": "ACTIVE",
-                                                    "label": "활동회원"
-                                                  }
-                                                }
-                                            ]
-                                        },
-                                        "isSuccess": true
-                                    }
-                                """
-                            )
-                        ]
-                    )
-                ]
-            )
-        ]
-    )
-    @GetMapping("/admin/v1/auth/authentication-codes")
-    fun getSignUpAuthenticationCode(): ResponseEntity<SuccessResponse<AdminSignUpCodesApiResponseDto>>
-
-    @Operation(summary = "인증번호 수정")
-    @PatchMapping("/admin/v1/auth/authentication-codes")
-    fun updateSignUpAuthenticationCode(
-        @Valid @RequestBody request: AdminSignUpCodeUpdateApiRequestDto
-    ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
@@ -4,12 +4,13 @@ import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.user.presentation.dto.request.AdminSignUpApplicationPageApiRequestDto
+import co.yappuworld.user.presentation.dto.request.AdminSignUpCodeUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationApproveApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationRejectApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserRoleUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationApiResponseDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationOverviewApiResponseDto
-import co.yappuworld.user.presentation.dto.response.AdminSignUpAuthenticationCodesApiResponseDto
+import co.yappuworld.user.presentation.dto.response.AdminSignUpCodesApiResponseDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -275,5 +276,11 @@ interface UserAuthAdminApi {
         ]
     )
     @GetMapping("/admin/v1/auth/authentication-codes")
-    fun getSignUpAuthenticationCode(): ResponseEntity<SuccessResponse<AdminSignUpAuthenticationCodesApiResponseDto>>
+    fun getSignUpAuthenticationCode(): ResponseEntity<SuccessResponse<AdminSignUpCodesApiResponseDto>>
+
+    @Operation(summary = "인증번호 수정")
+    @PatchMapping("/admin/v1/auth/authentication-codes")
+    fun updateSignUpAuthenticationCode(
+        @Valid @RequestBody request: AdminSignUpCodeUpdateApiRequestDto
+    ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
@@ -50,6 +50,7 @@ class UserAuthAdminController(
                     OffsetPageResponse(
                         data = it.data.map { d -> AdminSignUpApplicationOverviewApiResponseDto(d) },
                         totalCount = it.totalCount,
+                        totalPages = it.totalPages,
                         page = request.page,
                         size = request.size
                     )

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
@@ -2,14 +2,18 @@ package co.yappuworld.user.presentation
 
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.operation.application.ConfigInquiryComponent
 import co.yappuworld.user.application.SignUpService
 import co.yappuworld.user.application.UserAdminService
+import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.presentation.dto.request.AdminSignUpApplicationPageApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationApproveApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationRejectApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserRoleUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationApiResponseDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationOverviewApiResponseDto
+import co.yappuworld.user.presentation.dto.response.AdminSignUpAuthenticationCodeApiResponseDto
+import co.yappuworld.user.presentation.dto.response.AdminSignUpAuthenticationCodesApiResponseDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -17,7 +21,8 @@ import java.util.UUID
 @RestController
 class UserAuthAdminController(
     private val userAdminService: UserAdminService,
-    private val signUpService: SignUpService
+    private val signUpService: SignUpService,
+    private val configInquiryComponent: ConfigInquiryComponent
 ) : UserAuthAdminApi {
 
     override fun updateUserRole(request: UserRoleUpdateApiRequestDto): ResponseEntity<Unit> {
@@ -61,4 +66,21 @@ class UserAuthAdminController(
                 )
             )
         )
+
+    override fun getSignUpAuthenticationCode():
+        ResponseEntity<SuccessResponse<AdminSignUpAuthenticationCodesApiResponseDto>> {
+        val responseByKey = configInquiryComponent
+            .findConfigsBy(UserRole.entries.map { it.authenticationCodeKey })
+            .associateBy { it.id }
+
+        val codes = UserRole.entries.map { role ->
+            AdminSignUpAuthenticationCodeApiResponseDto(responseByKey[role.authenticationCodeKey], role)
+        }
+
+        return ResponseEntity.ok(
+            SuccessResponse(
+                AdminSignUpAuthenticationCodesApiResponseDto(codes)
+            )
+        )
+    }
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
@@ -7,13 +7,14 @@ import co.yappuworld.user.application.SignUpService
 import co.yappuworld.user.application.UserAdminService
 import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.presentation.dto.request.AdminSignUpApplicationPageApiRequestDto
+import co.yappuworld.user.presentation.dto.request.AdminSignUpCodeUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationApproveApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationRejectApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserRoleUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationApiResponseDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationOverviewApiResponseDto
-import co.yappuworld.user.presentation.dto.response.AdminSignUpAuthenticationCodeApiResponseDto
-import co.yappuworld.user.presentation.dto.response.AdminSignUpAuthenticationCodesApiResponseDto
+import co.yappuworld.user.presentation.dto.response.AdminSignUpCodeApiResponseDto
+import co.yappuworld.user.presentation.dto.response.AdminSignUpCodesApiResponseDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -67,20 +68,24 @@ class UserAuthAdminController(
             )
         )
 
-    override fun getSignUpAuthenticationCode():
-        ResponseEntity<SuccessResponse<AdminSignUpAuthenticationCodesApiResponseDto>> {
+    override fun getSignUpAuthenticationCode(): ResponseEntity<SuccessResponse<AdminSignUpCodesApiResponseDto>> {
         val responseByKey = configInquiryComponent
-            .findConfigsBy(UserRole.entries.map { it.authenticationCodeKey })
+            .findConfigsBy(UserRole.entries.map { it.signUpCodeKey })
             .associateBy { it.id }
 
         val codes = UserRole.entries.map { role ->
-            AdminSignUpAuthenticationCodeApiResponseDto(responseByKey[role.authenticationCodeKey], role)
+            AdminSignUpCodeApiResponseDto(responseByKey[role.signUpCodeKey], role)
         }
 
         return ResponseEntity.ok(
             SuccessResponse(
-                AdminSignUpAuthenticationCodesApiResponseDto(codes)
+                AdminSignUpCodesApiResponseDto(codes)
             )
         )
+    }
+
+    override fun updateSignUpAuthenticationCode(request: AdminSignUpCodeUpdateApiRequestDto): ResponseEntity<Unit> {
+        userAdminService.updateSignUpCode(request.toAppRequest())
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
@@ -5,16 +5,12 @@ import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.operation.application.ConfigInquiryComponent
 import co.yappuworld.user.application.SignUpService
 import co.yappuworld.user.application.UserAdminService
-import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.presentation.dto.request.AdminSignUpApplicationPageApiRequestDto
-import co.yappuworld.user.presentation.dto.request.AdminSignUpCodeUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationApproveApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationRejectApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserRoleUpdateApiRequestDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationApiResponseDto
 import co.yappuworld.user.presentation.dto.response.AdminSignUpApplicationOverviewApiResponseDto
-import co.yappuworld.user.presentation.dto.response.AdminSignUpCodeApiResponseDto
-import co.yappuworld.user.presentation.dto.response.AdminSignUpCodesApiResponseDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -68,25 +64,4 @@ class UserAuthAdminController(
                 )
             )
         )
-
-    override fun getSignUpAuthenticationCode(): ResponseEntity<SuccessResponse<AdminSignUpCodesApiResponseDto>> {
-        val responseByKey = configInquiryComponent
-            .findConfigsBy(UserRole.entries.map { it.signUpCodeKey })
-            .associateBy { it.id }
-
-        val codes = UserRole.entries.map { role ->
-            AdminSignUpCodeApiResponseDto(responseByKey[role.signUpCodeKey], role)
-        }
-
-        return ResponseEntity.ok(
-            SuccessResponse(
-                AdminSignUpCodesApiResponseDto(codes)
-            )
-        )
-    }
-
-    override fun updateSignUpAuthenticationCode(request: AdminSignUpCodeUpdateApiRequestDto): ResponseEntity<Unit> {
-        userAdminService.updateSignUpCode(request.toAppRequest())
-        return ResponseEntity.noContent().build()
-    }
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/request/AdminSignUpCodeUpdateApiRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/request/AdminSignUpCodeUpdateApiRequestDto.kt
@@ -1,0 +1,23 @@
+package co.yappuworld.user.presentation.dto.request
+
+import co.yappuworld.user.application.dto.request.AdminSignUpCodeUpdateAppRequestDto
+import co.yappuworld.user.domain.vo.UserRole
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+
+data class AdminSignUpCodeUpdateApiRequestDto(
+    @Schema(description = "가입코드 업데이트 할 역할")
+    val role: UserRole,
+    @Schema(description = "가입코드 (000000~999999 / Int, String 어떤 형태든 상관 X)")
+    @field:Min(value = 0L, message = "가입코드는 0보다 커야 합니다.")
+    @field:Max(value = 999999L, message = "가입코드는 999999보다 작아야 합니다.")
+    val code: Int
+) {
+
+    fun toAppRequest(): AdminSignUpCodeUpdateAppRequestDto =
+        AdminSignUpCodeUpdateAppRequestDto(
+            role = role,
+            code = code.toString().padStart(6, '0')
+        )
+}

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/response/AdminSignUpAuthenticationCodesApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/response/AdminSignUpAuthenticationCodesApiResponseDto.kt
@@ -1,0 +1,26 @@
+package co.yappuworld.user.presentation.dto.response
+
+import co.yappuworld.operation.domain.Config
+import co.yappuworld.user.domain.vo.UserRole
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+data class AdminSignUpAuthenticationCodesApiResponseDto(
+    @Schema(description = "인증 번호 목록")
+    val codes: List<AdminSignUpAuthenticationCodeApiResponseDto>
+)
+
+data class AdminSignUpAuthenticationCodeApiResponseDto(
+    @Schema(description = "인증 번호")
+    @field:NotNull
+    val code: String,
+    @Schema(description = "역할")
+    @field:NotNull
+    val role: UserRoleApiResponseDto
+) {
+
+    constructor(config: Config?, role: UserRole) : this(
+        code = config?.value ?: "",
+        role = UserRoleApiResponseDto(role)
+    )
+}

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/response/AdminSignUpCodesApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/response/AdminSignUpCodesApiResponseDto.kt
@@ -5,12 +5,12 @@ import co.yappuworld.user.domain.vo.UserRole
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
 
-data class AdminSignUpAuthenticationCodesApiResponseDto(
+data class AdminSignUpCodesApiResponseDto(
     @Schema(description = "인증 번호 목록")
-    val codes: List<AdminSignUpAuthenticationCodeApiResponseDto>
+    val codes: List<AdminSignUpCodeApiResponseDto>
 )
 
-data class AdminSignUpAuthenticationCodeApiResponseDto(
+data class AdminSignUpCodeApiResponseDto(
     @Schema(description = "인증 번호")
     @field:NotNull
     val code: String,

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -42,3 +42,7 @@ VALUES (uuid(), now(), now(), 'NOTICE', 'SESSION', '제목입니다1', '## 안�
         '01954809-38fd-1268-e0d6-d3fda39f6b4c', true),
        (uuid(), now(), now(), 'NOTICE', 'OPERATION', '제목입니다5', '## 안녕하세요 만나서 반갑습니다', '몰라?',
         '01954809-38fd-1268-e0d6-d3fda39f6b4c', true);
+
+INSERT INTO generations (value, start_date, end_date, is_active)
+VALUES (24, '2024-05-03', '2024-09-14', false),
+       (25, '2024-11-16', '2025-03-08', true)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -3,7 +3,8 @@ INSERT INTO config (id, created_at, updated_at, label, category, value)
 VALUES ('authenticationCodeAdmin', now(), now(), '어드민 가입코드', 'AUTHENTICATION_CODE', '000000'),
        ('authenticationCodeStaff', now(), now(), '운영진 가입코드', 'AUTHENTICATION_CODE', '000001'),
        ('authenticationCodeAlumni', now(), now(), '정회원 가입코드', 'AUTHENTICATION_CODE', '000002'),
-       ('authenticationCodeActive', now(), now(), '활동회원 가입코드', 'AUTHENTICATION_CODE', '000003');
+       ('authenticationCodeGraduate', now(), now(), '수료회원 가입코드', 'AUTHENTICATION_CODE', '000003'),
+       ('authenticationCodeActive', now(), now(), '활동회원 가입코드', 'AUTHENTICATION_CODE', '000004');
 
 -- 최소 지원 버전
 INSERT INTO config (id, created_at, updated_at, label, category, value)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -98,3 +98,12 @@ CREATE TABLE boards
     writer_id      varchar(36) NOT NULL,
     is_active      tinyint(1)  NOT NULL
 );
+
+DROP TABLE IF EXISTS generations;
+CREATE TABLE generations
+(
+    value      int PRIMARY KEY,
+    start_date date,
+    end_date   date,
+    is_active  tinyint(1)  NOT NULL
+)

--- a/src/test/kotlin/co/yappuworld/operation/infrastructure/GenerationRepositoryCallbackTest.kt
+++ b/src/test/kotlin/co/yappuworld/operation/infrastructure/GenerationRepositoryCallbackTest.kt
@@ -1,0 +1,36 @@
+package co.yappuworld.operation.infrastructure
+
+import co.yappuworld.support.fixture.operation.OperationFixture
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.data.repository.findByIdOrNull
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@DataJdbcTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class GenerationRepositoryCallbackTest {
+
+    @Autowired
+    private lateinit var generationRepository: GenerationRepository
+
+    @Test
+    fun `저장 전과 후에 isNew 필드가 다르다`() {
+        val generation = OperationFixture.getGenerationFixture()
+        assertTrue { generation.isNew }
+
+        generationRepository.save(generation)
+        assertFalse { generation.isNew }
+    }
+
+    @Test
+    fun `조회 해온 것도 isNew가 False로 되어 있다`() {
+        val generation = OperationFixture.getGenerationFixture()
+        generationRepository.save(generation)
+
+        val findGeneration = generationRepository.findByIdOrNull(generation.id)!!
+        assertFalse { findGeneration.isNew }
+    }
+}

--- a/src/test/kotlin/co/yappuworld/support/fixture/operation/OperationFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/operation/OperationFixture.kt
@@ -1,0 +1,19 @@
+package co.yappuworld.support.fixture.operation
+
+import co.yappuworld.operation.domain.Generation
+import java.time.LocalDate
+
+object OperationFixture {
+
+    fun getGenerationFixture(
+        value: Int = 2,
+        startDate: LocalDate = LocalDate.of(2025, 11, 13),
+        endDate: LocalDate = LocalDate.of(2025, 3, 8),
+        isActive: Boolean = true
+    ) = Generation(
+        value = value,
+        startDate = startDate,
+        endDate = endDate,
+        isActive = isActive
+    )
+}


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 유저 어드민에서 가입코드와 기수관리를 할 수 있는 기능이 필요합니다.


## ⭐️ 어떻게 해결했나요?
### 가입 코드
- 가입코드 조회
- 가입코드 수정
- 별도 테이블 분리 없이, config 테이블에서 진행

### 기수 관리
- Generation 테이블 생성
  - row가 적을 것이라 예상되긴 하지만, 테이블로 들고 있는게 관리 측면에서 용이할 거라 생각했습니다.
- 페이지네이션 조회 기능
  - 데이터가 많지 않아 페이지네이션까지 필요는 없겠지만, 일단 만들어는 뒀습니다.
- 수정 기능
  - Activator를 따로 생성하여, activate(), deactivate()에 따르는 정합성 관리를 한 곳으로 분리하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
