### PR TITLE
fix: 공지사항 작성자 이름 필드 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/board/application/dto/response/NoticeAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/board/application/dto/response/NoticeAppResponseDto.kt
@@ -3,7 +3,6 @@ package co.yappuworld.board.application.dto.response
 import co.yappuworld.board.domain.model.Notice
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.infrastructure.model.UserWithLastActivityUnit
-import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.util.UUID
 
@@ -18,13 +17,9 @@ data class NoticeAppResponseDto(
 }
 
 data class NoticeDetailsAppResponseDto(
-    @Schema(description = "공지사항 ID")
     val id: UUID,
-    @Schema(description = "공지사항 제목")
     val title: String,
-    @Schema(description = "공지사항 내용")
     val content: String,
-    @Schema(description = "공지사항 작성일")
     val createdAt: LocalDate
 ) {
 
@@ -37,16 +32,15 @@ data class NoticeDetailsAppResponseDto(
 }
 
 data class NoticeDetailsWriterAppResponseDto(
-    @Schema(description = "작성자 ID")
     val id: UUID,
-    @Schema(description = "작성자 가장 최근 활동 기수")
+    val name: String,
     val activityUnitGeneration: Int,
-    @Schema(description = "작성자 직군")
     val activityUnitPosition: Position
 ) {
 
     constructor(user: UserWithLastActivityUnit) : this(
         id = user.userId,
+        name = user.name,
         activityUnitGeneration = user.activityUnit.generation,
         activityUnitPosition = user.activityUnit.position
     )

--- a/src/main/kotlin/co/yappuworld/board/application/dto/response/NoticeOverviewAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/board/application/dto/response/NoticeOverviewAppResponseDto.kt
@@ -37,12 +37,14 @@ data class NoticeSimpleAppResponseDto(
 
 data class NoticeOverviewWriterAppResponseDto(
     val userId: UUID,
+    val name: String,
     val activityUnitGeneration: Int,
     val activityUnitPosition: Position
 ) {
 
     constructor(user: UserWithLastActivityUnit) : this(
         userId = user.userId,
+        name = user.name,
         activityUnitGeneration = user.activityUnit.generation,
         activityUnitPosition = user.activityUnit.position
     )

--- a/src/main/kotlin/co/yappuworld/board/presentation/NoticeApi.kt
+++ b/src/main/kotlin/co/yappuworld/board/presentation/NoticeApi.kt
@@ -47,6 +47,7 @@ interface NoticeApi {
                                                     },
                                                     "writer": {
                                                         "userId": "01954809-38fd-1268-e0d6-d3fda39f6b4c",
+                                                        "name": "홍길동",
                                                         "activityUnitGeneration": 1,
                                                         "activityUnitPosition": {
                                                             "name": "PM",
@@ -97,6 +98,7 @@ interface NoticeApi {
                                             },
                                             "writer": {
                                                 "id": "01954809-38fd-1268-e0d6-d3fda39f6b4c",
+                                                "name": "홍길동",
                                                 "activityUnitGeneration": 1,
                                                 "activityUnitPosition": {
                                                     "name": "PM",

--- a/src/main/kotlin/co/yappuworld/board/presentation/dto/response/NoticeApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/board/presentation/dto/response/NoticeApiResponseDto.kt
@@ -42,6 +42,8 @@ data class NoticeDetailsApiResponseDto(
 data class NoticeDetailsWriterApiResponseDto(
     @Schema(description = "작성자 ID")
     val id: UUID,
+    @Schema(description = "작성자 이름")
+    val name: String,
     @Schema(description = "작성자 가장 최근 활동 기수")
     val activityUnitGeneration: Int,
     @Schema(description = "작성자 직군")
@@ -50,6 +52,7 @@ data class NoticeDetailsWriterApiResponseDto(
 
     constructor(writer: NoticeDetailsWriterAppResponseDto) : this(
         id = writer.id,
+        name = writer.name,
         activityUnitGeneration = writer.activityUnitGeneration,
         activityUnitPosition = PositionApiResponseDto(writer.activityUnitPosition)
     )

--- a/src/main/kotlin/co/yappuworld/board/presentation/dto/response/NoticeOverviewApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/board/presentation/dto/response/NoticeOverviewApiResponseDto.kt
@@ -45,6 +45,8 @@ data class NoticeSimpleApiResponseDto(
 data class NoticeOverviewWriterApiResponseDto(
     @Schema(description = "작성자 ID")
     val userId: UUID,
+    @Schema(description = "작성자 이름")
+    val name: String,
     @Schema(description = "작성자 가장 최근 활동 기수")
     val activityUnitGeneration: Int,
     @Schema(description = "작성자 직군")
@@ -53,6 +55,7 @@ data class NoticeOverviewWriterApiResponseDto(
 
     constructor(writer: NoticeOverviewWriterAppResponseDto) : this(
         userId = writer.userId,
+        name = writer.name,
         activityUnitGeneration = writer.activityUnitGeneration,
         activityUnitPosition = PositionApiResponseDto(writer.activityUnitPosition)
     )


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 공지사항 목록, 상세 조회에 작성자의 이름이 전달되지 않았습니다.


## ⭐️ 어떻게 해결했나요?
- writer 하위에 name 필드를 추가했습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료
### AS IS
![image](https://github.com/user-attachments/assets/af659d16-d950-49c6-b618-4e46615276b2)
### TO BE
![image](https://github.com/user-attachments/assets/33b0fe5a-8d46-4849-81eb-1ffdeebcf714)



## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
