### PR TITLE
feat: 유저 활동 내역 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/operation/application/dto/response/AdminGenerationsAppParamDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/dto/response/AdminGenerationsAppParamDto.kt
@@ -19,8 +19,8 @@ data class AdminGenerationsAppParamDto(
 
 data class AdminGenerationAppResponseDto(
     val generation: Int,
-    val startDate: LocalDate,
-    val endDate: LocalDate,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
     val isActive: Boolean
 ) {
 

--- a/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
+++ b/src/main/kotlin/co/yappuworld/operation/domain/Generation.kt
@@ -9,8 +9,8 @@ import java.time.LocalDate
 @Table("generations")
 class Generation(
     value: Int,
-    startDate: LocalDate,
-    endDate: LocalDate,
+    startDate: LocalDate?,
+    endDate: LocalDate?,
     isActive: Boolean
 ) : Persistable<Int> {
 

--- a/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationRepository.kt
@@ -13,4 +13,6 @@ interface GenerationRepository :
     fun getGenerationOrNullByIsActiveIsTrue(): Generation?
 
     fun findAllByIsActiveIsTrue(): List<Generation>
+
+    fun findAllByValueIn(values: List<Int>): List<Generation>
 }

--- a/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
@@ -45,16 +45,22 @@ interface AdminUserOperationApi {
                                         "data": {
                                             "data": [
                                                 {
-                                                    "generation": 24,
+                                                    "generation": 25,
                                                     "startDate": "2024-05-03",
                                                     "endDate": "2024-09-14",
                                                     "isActive": false
+                                                },
+                                                {
+                                                    "generation": 3,
+                                                    "startDate": null,
+                                                    "endDate": null,
+                                                    "isActive": false
                                                 }
                                             ],
-                                            "totalCount": 2,
+                                            "totalCount": 3,
                                             "totalPages": 2,
                                             "page": 1,
-                                            "size": 1
+                                            "size": 2
                                         },
                                         "isSuccess": true
                                     }                                    

--- a/src/main/kotlin/co/yappuworld/operation/presentation/dto/response/AdminGenerationApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/dto/response/AdminGenerationApiResponseDto.kt
@@ -7,10 +7,10 @@ import java.time.LocalDate
 data class AdminGenerationApiResponseDto(
     @Schema(description = "기수")
     val generation: Int,
-    @Schema(description = "시작일")
-    val startDate: LocalDate,
-    @Schema(description = "종료일")
-    val endDate: LocalDate,
+    @Schema(description = "시작일", nullable = true)
+    val startDate: LocalDate?,
+    @Schema(description = "종료일", nullable = true)
+    val endDate: LocalDate?,
     @Schema(description = "현재 활동 중인지")
     val isActive: Boolean
 ) {

--- a/src/main/kotlin/co/yappuworld/user/application/UserProfileService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserProfileService.kt
@@ -1,6 +1,8 @@
 package co.yappuworld.user.application
 
 import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.operation.infrastructure.GenerationRepository
+import co.yappuworld.user.application.dto.response.UserActivityHistoriesAppResponseDto
 import co.yappuworld.user.application.dto.response.UserProfileAppResponseDto
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.ActivityUnitRepository
@@ -13,7 +15,8 @@ import java.util.UUID
 @Service
 class UserProfileService(
     private val userRepository: UserRepository,
-    private val activityUnitRepository: ActivityUnitRepository
+    private val activityUnitRepository: ActivityUnitRepository,
+    private val generationRepository: GenerationRepository
 ) {
 
     @Transactional(readOnly = true)
@@ -21,5 +24,15 @@ class UserProfileService(
         val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(UserError.USER_NOT_FOUND)
         val activityUnits = activityUnitRepository.findAllByUserId(userId)
         return UserProfileAppResponseDto.of(user, activityUnits)
+    }
+
+    @Transactional(readOnly = true)
+    fun findUserActivityHistories(userId: UUID): UserActivityHistoriesAppResponseDto {
+        val activityUnits = activityUnitRepository.findAllByUserId(userId)
+        val generationByValue = generationRepository
+            .findAllByValueIn(activityUnits.map { it.generation })
+            .associateBy { it.id }
+
+        return UserActivityHistoriesAppResponseDto.from(activityUnits, generationByValue)
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/UserActivityHistoriesAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/UserActivityHistoriesAppResponseDto.kt
@@ -1,0 +1,43 @@
+package co.yappuworld.user.application.dto.response
+
+import co.yappuworld.operation.domain.Generation
+import co.yappuworld.user.domain.model.ActivityUnit
+import java.time.LocalDate
+
+data class UserActivityHistoriesAppResponseDto(
+    val activityUnits: List<UserActivityHistoryAppResponseDto>
+) {
+
+    companion object {
+        fun from(
+            activityUnits: List<ActivityUnit>,
+            generations: Map<Int, Generation>
+        ): UserActivityHistoriesAppResponseDto =
+            UserActivityHistoriesAppResponseDto(
+                activityUnits.map {
+                    UserActivityHistoryAppResponseDto(
+                        it,
+                        generations[it.generation]
+                    )
+                }
+            )
+    }
+}
+
+data class UserActivityHistoryAppResponseDto(
+    val generation: Int,
+    val position: String,
+    val activityStartDate: LocalDate?,
+    val activityEndDate: LocalDate?
+) {
+
+    constructor(
+        activityUnit: ActivityUnit,
+        generation: Generation?
+    ) : this(
+        generation = activityUnit.generation,
+        position = activityUnit.position.label,
+        activityStartDate = generation?.startDate,
+        activityEndDate = generation?.endDate
+    )
+}

--- a/src/main/kotlin/co/yappuworld/user/application/dto/response/UserActivityHistoriesAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/response/UserActivityHistoriesAppResponseDto.kt
@@ -14,12 +14,14 @@ data class UserActivityHistoriesAppResponseDto(
             generations: Map<Int, Generation>
         ): UserActivityHistoriesAppResponseDto =
             UserActivityHistoriesAppResponseDto(
-                activityUnits.map {
-                    UserActivityHistoryAppResponseDto(
-                        it,
-                        generations[it.generation]
-                    )
-                }
+                activityUnits
+                    .sortedByDescending { it.generation }
+                    .map {
+                        UserActivityHistoryAppResponseDto(
+                            it,
+                            generations[it.generation]
+                        )
+                    }
             )
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserProfileApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserProfileApi.kt
@@ -2,6 +2,7 @@ package co.yappuworld.user.presentation
 
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
+import co.yappuworld.user.presentation.dto.response.UserActivityHistoriesApiResponseDto
 import co.yappuworld.user.presentation.dto.response.UserProfileApiResponseDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -64,4 +65,48 @@ interface UserProfileApi {
     fun getProfile(
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<SuccessResponse<UserProfileApiResponseDto>>
+
+    @Operation(summary = "활동이력 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "활동 이력",
+                                value = """
+                                    {
+                                        "isSuccess": "true",
+                                        "data": {
+                                            "activityUnits": [
+                                                {
+                                                    "generation": 25,
+                                                    "position": "Android",
+                                                    "activityStartDate": "2024-11-01",
+                                                    "activityEndDate": "2025-03-12"
+                                                },
+                                                {
+                                                    "generation": 4,
+                                                    "position": "운영진",
+                                                    "activityStartDate": null,
+                                                    "activityEndDate": null
+                                                }
+                                            ]
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/v1/users/activity-histories")
+    fun getUserActivityHistories(
+        @AuthenticationPrincipal securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<UserActivityHistoriesApiResponseDto>>
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserProfileController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserProfileController.kt
@@ -3,6 +3,7 @@ package co.yappuworld.user.presentation
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.user.application.UserProfileService
+import co.yappuworld.user.presentation.dto.response.UserActivityHistoriesApiResponseDto
 import co.yappuworld.user.presentation.dto.response.UserProfileApiResponseDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -18,6 +19,15 @@ class UserProfileController(
                 UserProfileApiResponseDto.of(
                     userProfileService.findUserProfile(securityUser.userId)
                 )
+            )
+        )
+
+    override fun getUserActivityHistories(
+        securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<UserActivityHistoriesApiResponseDto>> =
+        ResponseEntity.ok(
+            SuccessResponse(
+                UserActivityHistoriesApiResponseDto(userProfileService.findUserActivityHistories(securityUser.userId))
             )
         )
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/dto/response/UserActivityHistoriesApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/dto/response/UserActivityHistoriesApiResponseDto.kt
@@ -1,0 +1,36 @@
+package co.yappuworld.user.presentation.dto.response
+
+import co.yappuworld.user.application.dto.response.UserActivityHistoriesAppResponseDto
+import co.yappuworld.user.application.dto.response.UserActivityHistoryAppResponseDto
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+data class UserActivityHistoriesApiResponseDto(
+    val activityUnits: List<UserActivityHistoryApiResponseDto>
+) {
+
+    constructor(response: UserActivityHistoriesAppResponseDto) : this(
+        response.activityUnits.map { UserActivityHistoryApiResponseDto(it) }
+    )
+}
+
+data class UserActivityHistoryApiResponseDto(
+    @Schema(description = "기수")
+    val generation: Int,
+    @Schema(
+        description = "직군",
+        allowableValues = ["PM", "Design", "Web", "Android", "iOS", "Flutter", "Server", "Staff"]
+    )
+    val position: String,
+    @Schema(description = "활동 시작일", nullable = true)
+    val activityStartDate: LocalDate?,
+    @Schema(description = "활동 종료일", nullable = true)
+    val activityEndDate: LocalDate?
+) {
+    constructor(response: UserActivityHistoryAppResponseDto) : this(
+        generation = response.generation,
+        position = response.position,
+        activityStartDate = response.activityStartDate,
+        activityEndDate = response.activityEndDate
+    )
+}

--- a/src/test/kotlin/co/yappuworld/support/fixture/operation/OperationFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/operation/OperationFixture.kt
@@ -7,8 +7,8 @@ object OperationFixture {
 
     fun getGenerationFixture(
         value: Int = 2,
-        startDate: LocalDate = LocalDate.of(2025, 11, 13),
-        endDate: LocalDate = LocalDate.of(2025, 3, 8),
+        startDate: LocalDate? = LocalDate.of(2025, 11, 13),
+        endDate: LocalDate? = LocalDate.of(2025, 3, 8),
         isActive: Boolean = true
     ) = Generation(
         value = value,

--- a/src/test/kotlin/co/yappuworld/support/fixture/user/ActivityUnitFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/user/ActivityUnitFixture.kt
@@ -1,0 +1,18 @@
+package co.yappuworld.support.fixture.user
+
+import co.yappuworld.user.domain.model.ActivityUnit
+import co.yappuworld.user.domain.vo.Position
+import java.util.UUID
+
+object ActivityUnitFixture {
+
+    fun getActivityUnitFixture(
+        generation: Int = 23,
+        position: Position = Position.SERVER,
+        userId: UUID = UUID.randomUUID()
+    ) = ActivityUnit(
+        generation = generation,
+        position = position,
+        userId = userId
+    )
+}

--- a/src/test/kotlin/co/yappuworld/user/application/UserProfileServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserProfileServiceTest.kt
@@ -1,0 +1,63 @@
+package co.yappuworld.user.application
+
+import co.yappuworld.operation.infrastructure.GenerationRepository
+import co.yappuworld.support.fixture.operation.OperationFixture.getGenerationFixture
+import co.yappuworld.support.fixture.user.ActivityUnitFixture.getActivityUnitFixture
+import co.yappuworld.support.fixture.user.UserFixture.getUserFixture
+import co.yappuworld.user.infrastructure.ActivityUnitRepository
+import co.yappuworld.user.infrastructure.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
+import java.util.UUID
+
+class UserProfileServiceTest {
+
+    private val userRepository = mockk<UserRepository>()
+    private val activityUnitRepository = mockk<ActivityUnitRepository>()
+    private val generationRepository = mockk<GenerationRepository>()
+
+    private val userProfileService = UserProfileService(
+        userRepository = userRepository,
+        activityUnitRepository = activityUnitRepository,
+        generationRepository = generationRepository
+    )
+
+    @Test
+    fun `활동 기수의 시작일과 종료일은 Generation 데이터 등록 여부에 따라 달라진다`() {
+        every { userRepository.findByIdOrNull(any()) } returns getUserFixture()
+        every { activityUnitRepository.findAllByUserId(any()) } returns listOf(
+            getActivityUnitFixture(generation = 23),
+            getActivityUnitFixture(generation = 25)
+        )
+
+        val startOfTwentyFive = LocalDate.of(2019, 12, 31)
+        val endOfTwentyFive = LocalDate.of(2020, 3, 20)
+        every {
+            generationRepository.findAllByValueIn(listOf(23, 25))
+        } returns listOf(
+            getGenerationFixture(
+                value = 23,
+                startDate = null,
+                endDate = null
+            ),
+            getGenerationFixture(
+                value = 25,
+                startDate = startOfTwentyFive,
+                endDate = endOfTwentyFive
+            )
+        )
+
+        val response = userProfileService.findUserActivityHistories(UUID.randomUUID())
+        val twentyThree = response.activityUnits.single { it.generation == 23 }
+        val twentyFive = response.activityUnits.single { it.generation == 25 }
+
+        assertThat(twentyThree.activityStartDate).isNull()
+        assertThat(twentyThree.activityEndDate).isNull()
+        assertThat(twentyFive.activityStartDate).isEqualTo(startOfTwentyFive)
+        assertThat(twentyFive.activityEndDate).isEqualTo(endOfTwentyFive)
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 마이페이지 유저 활동 내역 표시를 위한 API


## ⭐️ 어떻게 해결했나요?
- 유저 활동 내역을 제공하는 API를 구현했습니다.
- ActivityUnit 테이블에서 활동 내역을 조회하고, Generation 테이블에서 활동 기간을 조회합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
