### PR TITLE
fix: notices content

### DIFF
--- a/src/main/kotlin/co/yappuworld/board/application/dto/response/NoticeOverviewAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/board/application/dto/response/NoticeOverviewAppResponseDto.kt
@@ -30,7 +30,7 @@ data class NoticeSimpleAppResponseDto(
         id = notice.id,
         createdAt = LocalDate.now(),
         title = notice.title,
-        content = notice.content.take(200),
+        content = notice.contentSummary.take(200),
         noticeType = notice.noticeType
     )
 }

--- a/src/main/kotlin/co/yappuworld/board/domain/model/Notice.kt
+++ b/src/main/kotlin/co/yappuworld/board/domain/model/Notice.kt
@@ -12,9 +12,13 @@ import java.util.UUID
 class Notice(
     override var title: String,
     override var content: String,
+    contentSummary: String,
     writer: Writer,
     noticeType: NoticeType
 ) : Post() {
+
+    var contentSummary: String = contentSummary
+        private set
 
     var noticeType: NoticeType = noticeType
         private set
@@ -30,6 +34,7 @@ class Notice(
             title = title,
             content = content,
             writer = writer,
-            noticeType = noticeType
+            noticeType = noticeType,
+            contentSummary = contentSummary
         ).apply { this.id = id }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -93,8 +93,9 @@ CREATE TABLE boards
     updated_at     datetime,
     board_type     varchar(255),
     notice_type    varchar(255),
-    title          varchar(255),
+    title          varchar(64),
     content        varchar(4000),
+    content_summary varchar(255),
     display_target varchar(255),
     writer_id      varchar(36) NOT NULL,
     is_active      tinyint(1)  NOT NULL


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 현재 공지사항 목록에서 미리보기 형태로 제공되는 텍스트를 적절히 제공하지 못하고 있습니다.


## ⭐️ 어떻게 해결했나요?
- 현재 게시물에 마크다운 형태의 데이터만 저장하고 있는데, 목록에서 미리보기 노출을 위한 텍스트를 별도로 저장합니다.
- 마크다운 데이터를 목록 API 제공 시에 정제하는 것보다, 미리 정제하여 저장해두는 방식을 선택했습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
