### PR TITLE
fix: 공지사항 조회에 타입 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/board/application/dto/response/NoticeAppResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/board/application/dto/response/NoticeAppResponseDto.kt
@@ -1,6 +1,7 @@
 package co.yappuworld.board.application.dto.response
 
 import co.yappuworld.board.domain.model.Notice
+import co.yappuworld.board.domain.vo.NoticeType
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.infrastructure.model.UserWithLastActivityUnit
 import java.time.LocalDate
@@ -20,14 +21,16 @@ data class NoticeDetailsAppResponseDto(
     val id: UUID,
     val title: String,
     val content: String,
-    val createdAt: LocalDate
+    val createdAt: LocalDate,
+    val type: NoticeType
 ) {
 
     constructor(notice: Notice) : this(
         id = notice.id,
         title = notice.title,
         content = notice.content,
-        createdAt = notice.createdAt.toLocalDate()
+        createdAt = notice.createdAt.toLocalDate(),
+        type = notice.noticeType
     )
 }
 

--- a/src/main/kotlin/co/yappuworld/board/presentation/NoticeApi.kt
+++ b/src/main/kotlin/co/yappuworld/board/presentation/NoticeApi.kt
@@ -46,7 +46,7 @@ interface NoticeApi {
                                                         "noticeType": "OPERATION"
                                                     },
                                                     "writer": {
-                                                        "userId": "01954809-38fd-1268-e0d6-d3fda39f6b4c",
+                                                        "id": "01954809-38fd-1268-e0d6-d3fda39f6b4c",
                                                         "name": "홍길동",
                                                         "activityUnitGeneration": 1,
                                                         "activityUnitPosition": {
@@ -94,7 +94,8 @@ interface NoticeApi {
                                                 "id": "ad8750bf-fa3e-11ef-ba22-0242ac120002",
                                                 "title": "제목입니다5",
                                                 "content": "## 안녕하세요 만나서 반갑습니다",
-                                                "createdAt": "2025-03-06"
+                                                "createdAt": "2025-03-06",
+                                                "noticeType": "OPERATION"
                                             },
                                             "writer": {
                                                 "id": "01954809-38fd-1268-e0d6-d3fda39f6b4c",

--- a/src/main/kotlin/co/yappuworld/board/presentation/dto/response/NoticeApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/board/presentation/dto/response/NoticeApiResponseDto.kt
@@ -3,6 +3,7 @@ package co.yappuworld.board.presentation.dto.response
 import co.yappuworld.board.application.dto.response.NoticeAppResponseDto
 import co.yappuworld.board.application.dto.response.NoticeDetailsAppResponseDto
 import co.yappuworld.board.application.dto.response.NoticeDetailsWriterAppResponseDto
+import co.yappuworld.board.domain.vo.NoticeType
 import co.yappuworld.operation.presentation.dto.response.PositionApiResponseDto
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
@@ -28,14 +29,17 @@ data class NoticeDetailsApiResponseDto(
     @Schema(description = "공지사항 내용")
     val content: String,
     @Schema(description = "공지사항 작성일")
-    val createdAt: LocalDate
+    val createdAt: LocalDate,
+    @Schema(description = "공지사항 종류")
+    val noticeType: NoticeType
 ) {
 
     constructor(notice: NoticeDetailsAppResponseDto) : this(
         id = notice.id,
         title = notice.title,
         content = notice.content,
-        createdAt = notice.createdAt
+        createdAt = notice.createdAt,
+        noticeType = notice.type
     )
 }
 

--- a/src/main/kotlin/co/yappuworld/board/presentation/dto/response/NoticeOverviewApiResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/board/presentation/dto/response/NoticeOverviewApiResponseDto.kt
@@ -44,7 +44,7 @@ data class NoticeSimpleApiResponseDto(
 
 data class NoticeOverviewWriterApiResponseDto(
     @Schema(description = "작성자 ID")
-    val userId: UUID,
+    val id: UUID,
     @Schema(description = "작성자 이름")
     val name: String,
     @Schema(description = "작성자 가장 최근 활동 기수")
@@ -54,7 +54,7 @@ data class NoticeOverviewWriterApiResponseDto(
 ) {
 
     constructor(writer: NoticeOverviewWriterAppResponseDto) : this(
-        userId = writer.userId,
+        id = writer.userId,
         name = writer.name,
         activityUnitGeneration = writer.activityUnitGeneration,
         activityUnitPosition = PositionApiResponseDto(writer.activityUnitPosition)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -36,17 +36,18 @@ VALUES (uuid(), now(), now(), '01954809-38fd-1268-e0d6-d3fda39f6b4c', 'fcm_token
 INSERT INTO user_alarm_settings (id, created_at, updated_at, user_id, device, master)
 VALUES (uuid(), now(), now(), '01954809-38fd-1268-e0d6-d3fda39f6b4c', true, true);
 
-INSERT INTO boards (id, created_at, updated_at, board_type, notice_type, title, content, display_target, writer_id,
+INSERT INTO boards (id, created_at, updated_at, board_type, notice_type, title, content, content_summary,
+                    display_target, writer_id,
                     is_active)
-VALUES (uuid(), now(), now(), 'NOTICE', 'SESSION', '제목입니다1', '## 안녕하세요 만나서 반갑습니다', '몰라?',
+VALUES (uuid(), now(), now(), 'NOTICE', 'SESSION', '제목입니다1', '## 안녕하세요 만나서 반갑습니다', '아', '몰라?',
         '01954809-38fd-1268-e0d6-d3fda39f6b4c', true),
-       (uuid(), now(), now(), 'NOTICE', 'SESSION', '제목입니다2', '## 안녕하세요 만나서 반갑습니다', '몰라?',
+       (uuid(), now(), now(), 'NOTICE', 'SESSION', '제목입니다2', '## 안녕하세요 만나서 반갑습니다', '아', '몰라?',
         '01954809-38fd-1268-e0d6-d3fda39f6b4c', true),
-       (uuid(), now(), now(), 'NOTICE', 'SESSION', '제목입니다3', '## 안녕하세요 만나서 반갑습니다', '몰라?',
+       (uuid(), now(), now(), 'NOTICE', 'SESSION', '제목입니다3', '## 안녕하세요 만나서 반갑습니다', '아', '몰라?',
         '01954809-38fd-1268-e0d6-d3fda39f6b4c', true),
-       (uuid(), now(), now(), 'NOTICE', 'OPERATION', '제목입니다4', '## 안녕하세요 만나서 반갑습니다', '몰라?',
+       (uuid(), now(), now(), 'NOTICE', 'OPERATION', '제목입니다4', '## 안녕하세요 만나서 반갑습니다', '아', '몰라?',
         '01954809-38fd-1268-e0d6-d3fda39f6b4c', true),
-       (uuid(), now(), now(), 'NOTICE', 'OPERATION', '제목입니다5', '## 안녕하세요 만나서 반갑습니다', '몰라?',
+       (uuid(), now(), now(), 'NOTICE', 'OPERATION', '제목입니다5', '## 안녕하세요 만나서 반갑습니다', '아', '몰라?',
         '01954809-38fd-1268-e0d6-d3fda39f6b4c', true);
 
 INSERT INTO generations (value, start_date, end_date, is_active)


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?


## ⭐️ 어떻게 해결했나요?
- 공지사항 응답에 타입 추가
- 작성자 응답에 userId를 id로 통일
	- 작성자 응답 객체 안에 있으므로, id로 변경


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
