### PR TITLE
feat: 어드민 로그인

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
@@ -32,12 +32,12 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(STATELESS) }
             .authorizeHttpRequests {
                 it
-                    .requestMatchers(staffOrAdminMatchers)
-                    .hasAnyRole("ADMIN", "STAFF")
-                    .requestMatchers(userMatchers)
-                    .hasAnyRole("ADMIN", "STAFF", "ALUMNI", "GRADUATE", "ACTIVE")
                     .requestMatchers(anyoneMatchers)
                     .permitAll()
+                    .requestMatchers(userMatchers)
+                    .hasAnyRole("ADMIN", "STAFF", "ALUMNI", "GRADUATE", "ACTIVE")
+                    .requestMatchers(staffOrAdminMatchers)
+                    .hasAnyRole("ADMIN", "STAFF")
             }.authorizeHttpRequests { it.anyRequest().permitAll() }
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()

--- a/src/main/kotlin/co/yappuworld/global/exception/ErrorType.kt
+++ b/src/main/kotlin/co/yappuworld/global/exception/ErrorType.kt
@@ -3,7 +3,8 @@ package co.yappuworld.global.exception
 /**
  * @property WRONG_ARGUMENT 잘못된 파라미터, 요청값
  * @property BAD_REQUEST 요청 자체가 오류 (번지 수 잘못 찾아오셨네요..?)
- * @property UNAUTHORIZED 인증, 인가 오류
+ * @property UNAUTHORIZED 인증 오류
+ * @property FORBIDDEN 권한 오류
  * @property NOT_FOUND 리소스를 찾지 못하는 모든 상황에 해당
  * @property WRONG_STATE 요청을 처리할 수 없는 상태 (데이터 정합성 문제, 비즈니스 요구사항 문제)
  * @property UNEXPECTED_ERROR 예기치 못한 에러의 발생 (Internal Server Error)
@@ -12,6 +13,7 @@ enum class ErrorType {
     WRONG_ARGUMENT,
     BAD_REQUEST,
     UNAUTHORIZED,
+    FORBIDDEN,
     NOT_FOUND,
     WRONG_STATE,
     UNEXPECTED_ERROR

--- a/src/main/kotlin/co/yappuworld/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/co/yappuworld/global/exception/GlobalExceptionHandler.kt
@@ -65,6 +65,7 @@ class GlobalExceptionHandler {
             ErrorType.WRONG_ARGUMENT -> HttpStatus.BAD_REQUEST
             ErrorType.BAD_REQUEST -> HttpStatus.BAD_REQUEST
             ErrorType.UNAUTHORIZED -> HttpStatus.UNAUTHORIZED
+            ErrorType.FORBIDDEN -> HttpStatus.FORBIDDEN
             ErrorType.NOT_FOUND -> HttpStatus.NOT_FOUND
             ErrorType.WRONG_STATE -> HttpStatus.CONFLICT
             ErrorType.UNEXPECTED_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR

--- a/src/main/kotlin/co/yappuworld/global/security/SecurityPathMatchersManager.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/SecurityPathMatchersManager.kt
@@ -22,7 +22,9 @@ object SecurityPathMatchersManager {
         antMatcher(POST, "/v1/auth/check-email"),
         antMatcher(GET, "/v1/auth/applications/latest"),
         antMatcher(GET, "/v1/positions"),
-        antMatcher(GET, "/v1/operations/**")
+        antMatcher(GET, "/v1/operations/**"),
+        // admin
+        antMatcher(POST, "/admin/**/login")
     )
 
     val userMatchers: RequestMatcher = RequestMatchers.anyOf(

--- a/src/main/kotlin/co/yappuworld/user/application/UserAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAdminService.kt
@@ -1,10 +1,14 @@
 package co.yappuworld.user.application
 
 import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.global.security.JwtGenerator
+import co.yappuworld.global.security.SecurityUser
+import co.yappuworld.global.security.Token
 import co.yappuworld.global.util.ifNotEmpty
 import co.yappuworld.operation.domain.ConfigError
 import co.yappuworld.operation.infrastructure.ConfigRepository
 import co.yappuworld.user.application.dto.request.AdminActivityUnitUpdateAppRequestDto
+import co.yappuworld.user.application.dto.request.LoginRequest
 import co.yappuworld.user.application.dto.request.AdminSignUpApplicationPageAppRequestDto
 import co.yappuworld.user.application.dto.request.AdminSignUpCodeUpdateAppRequestDto
 import co.yappuworld.user.application.dto.request.AdminUserPageAppRequestDto
@@ -23,6 +27,7 @@ import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.math.ceil
 
@@ -31,8 +36,26 @@ class UserAdminService(
     private val userRepository: UserRepository,
     private val userSignUpApplicationRepository: UserSignUpApplicationRepository,
     private val activityUnitRepository: ActivityUnitRepository,
-    private val configRepository: ConfigRepository
+    private val configRepository: ConfigRepository,
+    private val jwtGenerator: JwtGenerator,
+    private val userLoginPermissionChecker: UserLoginPermissionChecker
 ) {
+
+    @Transactional
+    fun login(
+        request: LoginRequest,
+        now: LocalDateTime
+    ): Token {
+        val user = userRepository
+            .findUserOrNullByEmail(request.email)
+            .let { userLoginPermissionChecker.checkPermissionAndGetUser(it, request.email, request.password) }
+
+        if (!user.role.canAccessAdminPage()) {
+            throw BusinessException(UserError.NO_AUTH_FOR_ADMIN_PAGE)
+        }
+
+        return jwtGenerator.generateToken(SecurityUser.from(user), now)
+    }
 
     @Transactional
     fun updateUserRole(request: UserRoleUpdateAppRequestDto) {

--- a/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAuthService.kt
@@ -5,40 +5,32 @@ import co.yappuworld.global.security.JwtGenerator
 import co.yappuworld.global.security.JwtResolver
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.security.Token
-import co.yappuworld.user.application.dto.request.LoginAppRequestDto
+import co.yappuworld.user.application.dto.request.LoginRequest
 import co.yappuworld.user.application.dto.request.ReissueTokenAppRequestDto
-import co.yappuworld.user.domain.checkLoginAvailability
 import co.yappuworld.user.domain.vo.UserError
-import co.yappuworld.user.domain.vo.SignUpApplicationStatus
 import co.yappuworld.user.infrastructure.UserRepository
-import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
-import org.springframework.data.domain.Limit
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import java.util.UUID
 
-private val logger = KotlinLogging.logger { }
-
 @Service
 class UserAuthService(
     private val userRepository: UserRepository,
-    private val signUpApplicationRepository: UserSignUpApplicationRepository,
     private val jwtGenerator: JwtGenerator,
-    private val jwtResolver: JwtResolver
+    private val jwtResolver: JwtResolver,
+    private val userLoginPermissionChecker: UserLoginPermissionChecker
 ) {
 
     @Transactional
     fun login(
-        request: LoginAppRequestDto,
+        request: LoginRequest,
         now: LocalDateTime
     ): Token {
         val user = userRepository
             .findUserOrNullByEmail(request.email)
-            ?.apply { this.checkLoginAvailability(request.password) }
-            ?: processLoginException(request.email)
+            .let { userLoginPermissionChecker.checkPermissionAndGetUser(it, request.email, request.password) }
 
         return jwtGenerator.generateToken(SecurityUser.from(user), now)
     }
@@ -63,32 +55,5 @@ class UserAuthService(
             ?.apply { withdraw() }
             ?.let(userRepository::save)
             ?: throw BusinessException(UserError.USER_NOT_FOUND)
-    }
-
-    private fun processLoginException(email: String): Nothing {
-        val recentApplication = signUpApplicationRepository.findByApplicantEmailOrderByUpdatedAtDesc(
-            email,
-            Limit.of(1)
-        )
-
-        if (recentApplication == null) {
-            logger.error { "${email}로 가입 시도조차 없습니다." }
-            throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
-        }
-
-        throw when (recentApplication.status) {
-            SignUpApplicationStatus.PENDING -> {
-                logger.error { "${email}의 기존 가입 신청이 처리되지 않았습니다." }
-                BusinessException(UserError.CANNOT_LOGIN_WITH_UNPROCESSED_SIGN_UP_APPLICATION)
-            }
-            SignUpApplicationStatus.REJECTED -> {
-                logger.error { "${email}의 기존 가입 신청이 처리되지 않았습니다." }
-                BusinessException(UserError.RECENT_SIGN_UP_APPLICATION_REJECTED)
-            }
-            SignUpApplicationStatus.APPROVED -> {
-                logger.error { "${email}의 가입 프로세스에 문제가 생겼습니다." }
-                BusinessException(UserError.CANNOT_LOGIN_WRONG_USER_STATE)
-            }
-        }
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/UserLoginPermissionChecker.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserLoginPermissionChecker.kt
@@ -1,0 +1,62 @@
+package co.yappuworld.user.application
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.user.domain.model.User
+import co.yappuworld.user.domain.vo.SignUpApplicationStatus
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.domain.Limit
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger { }
+
+@Component
+class UserLoginPermissionChecker(
+    private val signUpApplicationRepository: UserSignUpApplicationRepository
+) {
+
+    fun checkPermissionAndGetUser(
+        user: User?,
+        email: String,
+        plainPassword: String
+    ): User {
+        if (user == null) processException(email)
+
+        requireNotNull(user)
+
+        user.checkPassword(plainPassword)
+        if (user.isWithdrawn()) {
+            throw BusinessException(UserError.WITHDRAWN_USER)
+        }
+
+        return user
+    }
+
+    private fun processException(email: String) {
+        val recentApplication = signUpApplicationRepository.findByApplicantEmailOrderByUpdatedAtDesc(
+            email,
+            Limit.of(1)
+        )
+
+        if (recentApplication == null) {
+            logger.error { "${email}로 가입 시도조차 없습니다." }
+            throw BusinessException(UserError.FAIL_LOGIN_NOT_FOUND_USER)
+        }
+
+        throw when (recentApplication.status) {
+            SignUpApplicationStatus.PENDING -> {
+                logger.error { "${email}의 기존 가입 신청이 처리되지 않았습니다." }
+                BusinessException(UserError.CANNOT_LOGIN_WITH_UNPROCESSED_SIGN_UP_APPLICATION)
+            }
+            SignUpApplicationStatus.REJECTED -> {
+                logger.error { "${email}의 기존 가입 신청이 처리되지 않았습니다." }
+                BusinessException(UserError.RECENT_SIGN_UP_APPLICATION_REJECTED)
+            }
+            SignUpApplicationStatus.APPROVED -> {
+                logger.error { "${email}의 가입 프로세스에 문제가 생겼습니다." }
+                BusinessException(UserError.CANNOT_LOGIN_WRONG_USER_STATE)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/LoginAppRequestDto.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/LoginAppRequestDto.kt
@@ -1,6 +1,0 @@
-package co.yappuworld.user.application.dto.request
-
-data class LoginAppRequestDto(
-    val email: String,
-    val password: String
-)

--- a/src/main/kotlin/co/yappuworld/user/application/dto/request/LoginRequest.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/dto/request/LoginRequest.kt
@@ -1,12 +1,11 @@
-package co.yappuworld.user.presentation.dto.request
+package co.yappuworld.user.application.dto.request
 
-import co.yappuworld.user.application.dto.request.LoginAppRequestDto
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotEmpty
 import org.hibernate.validator.constraints.Length
 
-data class LoginApiRequestDto(
+data class LoginRequest(
     @Schema(description = "이메일", example = "admin@admin.com")
     @field:Email(message = "이메일 형식이 아닙니다.")
     @field:NotEmpty(message = "이메일은 필수로 입력해야 합니다.")
@@ -14,10 +13,4 @@ data class LoginApiRequestDto(
     @Schema(description = "비밀번호", example = "abcabC!!")
     @field:Length(min = 8, max = 20, message = "올바르지 않은 비밀번호입니다.")
     val password: String
-) {
-    fun toAppRequest(): LoginAppRequestDto =
-        LoginAppRequestDto(
-            this.email,
-            this.password
-        )
-}
+)

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
@@ -90,6 +90,11 @@ enum class UserError : Error {
         override val code: String = "USR_1122"
         override val type: ErrorType = ErrorType.NOT_FOUND
     },
+    NO_AUTH_FOR_ADMIN_PAGE {
+        override val message: String = "어드민 페이지에 로그인할 권한이 없습니다."
+        override val code: String = "USR_1190"
+        override val type: ErrorType = ErrorType.FORBIDDEN
+    },
 
     // 1200번대 - 회원탈퇴 에러
     ALREADY_WITHDRAWN_USER {

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserRole.kt
@@ -16,5 +16,7 @@ enum class UserRole(
     STAFF("ROLE_STAFF", "운영진", "authenticationCodeStaff"),
     ALUMNI("ROLE_ALUMNI", "정회원", "authenticationCodeAlumni"),
     GRADUATE("ROLE_GRADUATE", "수료회원", "authenticationCodeGraduate"),
-    ACTIVE("ROLE_ACTIVE", "활동회원", "authenticationCodeActive")
+    ACTIVE("ROLE_ACTIVE", "활동회원", "authenticationCodeActive");
+
+    fun canAccessAdminPage(): Boolean = this == ADMIN || this == STAFF
 }

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminApi.kt
@@ -3,6 +3,8 @@ package co.yappuworld.user.presentation
 import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.global.security.Token
+import co.yappuworld.user.application.dto.request.LoginRequest
 import co.yappuworld.user.presentation.dto.request.AdminSignUpApplicationPageApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationApproveApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationRejectApiRequestDto
@@ -28,6 +30,123 @@ import java.util.UUID
 
 @Tag(name = "회원 인증/인가 API", description = "회원 권한/가입신청 관리")
 interface UserAuthAdminApi {
+
+    @Operation(summary = "로그인")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = SuccessResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "로그인 성공",
+                                value = """
+                                    {
+                                        "isSuccess": "true",
+                                        "data": {
+                                            "accessToken": "accessToken...",
+                                            "refreshToken": "refreshToken..."
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "401",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "비밀번호 오류",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "로그인에 실패했습니다. 계정 정보를 다시 확인하세요.",
+                                        "errorCode": "USR_1105"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "이메일과 매칭되는 유저 정보를 찾을 수 없음",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "계정 정보를 찾을 수 없습니다.",
+                                        "errorCode": "USR_1101"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "409",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "회원가입 처리가 진행 중입니다",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "회원가입 처리가 진행 중입니다.",
+                                        "errorCode": "USR_1102"
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "최근의 회원가입 신청은 거절되었습니다.",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "최근의 회원가입 신청은 거절되었습니다.",
+                                        "errorCode": "USR_1103"
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "회원가입 승인은 되었으나, 유저 데이터가 생성되지 않음.",
+                                description = "해당 예외는 서버 에러이므로 노티 필요",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "로그인이 불가능한 회원 상태입니다.",
+                                        "errorCode": "USR_1104"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @PostMapping("/admin/v1/auth/login")
+    fun login(
+        @Valid @RequestBody request: LoginRequest
+    ): ResponseEntity<SuccessResponse<Token>>
 
     @Operation(summary = "유저 역할 변경")
     @ApiResponses(

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthAdminController.kt
@@ -2,9 +2,11 @@ package co.yappuworld.user.presentation
 
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
-import co.yappuworld.operation.application.ConfigInquiryComponent
+import co.yappuworld.global.security.Token
+import co.yappuworld.global.util.TimeUtils.getCurrentDateTimeInKST
 import co.yappuworld.user.application.SignUpService
 import co.yappuworld.user.application.UserAdminService
+import co.yappuworld.user.application.dto.request.LoginRequest
 import co.yappuworld.user.presentation.dto.request.AdminSignUpApplicationPageApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationApproveApiRequestDto
 import co.yappuworld.user.presentation.dto.request.SignUpApplicationRejectApiRequestDto
@@ -18,9 +20,15 @@ import java.util.UUID
 @RestController
 class UserAuthAdminController(
     private val userAdminService: UserAdminService,
-    private val signUpService: SignUpService,
-    private val configInquiryComponent: ConfigInquiryComponent
+    private val signUpService: SignUpService
 ) : UserAuthAdminApi {
+
+    override fun login(request: LoginRequest): ResponseEntity<SuccessResponse<Token>> =
+        ResponseEntity.ok(
+            SuccessResponse(
+                userAdminService.login(request, getCurrentDateTimeInKST())
+            )
+        )
 
     override fun updateUserRole(request: UserRoleUpdateApiRequestDto): ResponseEntity<Unit> {
         userAdminService.updateUserRole(request.toAppRequest())

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthApi.kt
@@ -4,9 +4,9 @@ import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.security.Token
+import co.yappuworld.user.application.dto.request.LoginRequest
 import co.yappuworld.user.presentation.dto.request.CheckingEmailAvailabilityApiRequestDto
 import co.yappuworld.user.presentation.dto.request.LatestSignUpApplicationApiRequestDto
-import co.yappuworld.user.presentation.dto.request.LoginApiRequestDto
 import co.yappuworld.user.presentation.dto.request.ReissueTokenApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserSignUpApiRequestDto
 import co.yappuworld.user.presentation.dto.response.LatestSignUpApplicationApiResponseDto
@@ -209,7 +209,7 @@ interface UserAuthApi {
     )
     @PostMapping("/v1/auth/login")
     fun login(
-        @Valid @RequestBody request: LoginApiRequestDto
+        @Valid @RequestBody request: LoginRequest
     ): ResponseEntity<SuccessResponse<Token>>
 
     @Operation(summary = "토큰 재발급")

--- a/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
+++ b/src/main/kotlin/co/yappuworld/user/presentation/UserAuthController.kt
@@ -6,9 +6,9 @@ import co.yappuworld.global.security.Token
 import co.yappuworld.global.util.TimeUtils.getCurrentDateTimeInKST
 import co.yappuworld.user.application.SignUpService
 import co.yappuworld.user.application.UserAuthService
+import co.yappuworld.user.application.dto.request.LoginRequest
 import co.yappuworld.user.presentation.dto.request.CheckingEmailAvailabilityApiRequestDto
 import co.yappuworld.user.presentation.dto.request.LatestSignUpApplicationApiRequestDto
-import co.yappuworld.user.presentation.dto.request.LoginApiRequestDto
 import co.yappuworld.user.presentation.dto.request.ReissueTokenApiRequestDto
 import co.yappuworld.user.presentation.dto.request.UserSignUpApiRequestDto
 import co.yappuworld.user.presentation.dto.response.LatestSignUpApplicationApiResponseDto
@@ -35,11 +35,11 @@ class UserAuthController(
         )
     }
 
-    override fun login(request: LoginApiRequestDto): ResponseEntity<SuccessResponse<Token>> {
+    override fun login(request: LoginRequest): ResponseEntity<SuccessResponse<Token>> {
         val now = getCurrentDateTimeInKST()
         return ResponseEntity.ok(
             SuccessResponse(
-                userAuthService.login(request.toAppRequest(), now)
+                userAuthService.login(request, now)
             )
         )
     }

--- a/src/test/kotlin/co/yappuworld/support/fixture/user/UserDtoFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/user/UserDtoFixture.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.support.fixture.user
 
+import co.yappuworld.user.application.dto.request.LoginRequest
 import co.yappuworld.user.presentation.dto.request.LatestSignUpApplicationApiRequestDto
-import co.yappuworld.user.presentation.dto.request.LoginApiRequestDto
 
 object UserDtoFixture {
 
@@ -14,12 +14,11 @@ object UserDtoFixture {
             password
         )
 
-    fun getLoginApiRequestDto(
+    fun getLoginRequest(
         email: String = "abc@abc.com",
         password: String = "abcabcabC!!"
-    ): LoginApiRequestDto =
-        LoginApiRequestDto(
-            email,
-            password
-        )
+    ) = LoginRequest(
+        email,
+        password
+    )
 }

--- a/src/test/kotlin/co/yappuworld/user/application/AuthServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/AuthServiceTest.kt
@@ -1,18 +1,14 @@
 package co.yappuworld.user.application
 
-import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.security.JwtGenerator
 import co.yappuworld.global.security.JwtResolver
 import co.yappuworld.global.util.EncryptUtils
 import co.yappuworld.support.fixture.property.PropertyFixture.getJwtProperty
 import co.yappuworld.support.fixture.user.UserDtoFixture.getLoginRequest
 import co.yappuworld.support.fixture.user.UserFixture.getUserFixture
-import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.UserRepository
-import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
 import io.mockk.every
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.time.LocalDateTime
@@ -20,14 +16,14 @@ import java.time.LocalDateTime
 class AuthServiceTest {
 
     private val userRepository = mockk<UserRepository>()
-    private val userSignUpApplicationRepository = mockk<UserSignUpApplicationRepository>()
+    private val userLoginPermissionChecker = mockk<UserLoginPermissionChecker>()
     private val jwtGenerator = JwtGenerator(getJwtProperty())
     private val jwtResolver = mockk<JwtResolver>()
     private val userAuthService = UserAuthService(
-        userRepository,
-        userSignUpApplicationRepository,
-        jwtGenerator,
-        jwtResolver
+        userRepository = userRepository,
+        jwtGenerator = jwtGenerator,
+        jwtResolver = jwtResolver,
+        userLoginPermissionChecker = userLoginPermissionChecker
     )
 
     @Test
@@ -35,6 +31,7 @@ class AuthServiceTest {
         val plainPassword = "abcabC!!"
         val user = getUserFixture(password = EncryptUtils.encrypt(plainPassword))
         every { userRepository.findUserOrNullByEmail(user.email) } returns user
+        every { userLoginPermissionChecker.checkPermissionAndGetUser(user, user.email, plainPassword) } returns user
 
         assertDoesNotThrow {
             userAuthService.login(
@@ -45,23 +42,5 @@ class AuthServiceTest {
                 LocalDateTime.now()
             )
         }
-    }
-
-    @Test
-    fun `비밀번호가 다르면 로그인에 실패한다`() {
-        val plainPassword = "abcabC!!"
-        val user = getUserFixture(password = EncryptUtils.encrypt(plainPassword))
-        every { userRepository.findUserOrNullByEmail(user.email) } returns user
-
-        assertThatThrownBy {
-            userAuthService.login(
-                getLoginRequest(
-                    user.email,
-                    "abcabcabaB!!"
-                ),
-                LocalDateTime.now()
-            )
-        }.isInstanceOf(BusinessException::class.java)
-            .hasMessageMatching(UserError.WRONG_LOGIN_USER_INFORMATION.message)
     }
 }

--- a/src/test/kotlin/co/yappuworld/user/application/AuthServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/AuthServiceTest.kt
@@ -5,7 +5,7 @@ import co.yappuworld.global.security.JwtGenerator
 import co.yappuworld.global.security.JwtResolver
 import co.yappuworld.global.util.EncryptUtils
 import co.yappuworld.support.fixture.property.PropertyFixture.getJwtProperty
-import co.yappuworld.support.fixture.user.UserDtoFixture.getLoginApiRequestDto
+import co.yappuworld.support.fixture.user.UserDtoFixture.getLoginRequest
 import co.yappuworld.support.fixture.user.UserFixture.getUserFixture
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.UserRepository
@@ -38,10 +38,10 @@ class AuthServiceTest {
 
         assertDoesNotThrow {
             userAuthService.login(
-                getLoginApiRequestDto(
+                getLoginRequest(
                     user.email,
                     plainPassword
-                ).toAppRequest(),
+                ),
                 LocalDateTime.now()
             )
         }
@@ -55,10 +55,10 @@ class AuthServiceTest {
 
         assertThatThrownBy {
             userAuthService.login(
-                getLoginApiRequestDto(
+                getLoginRequest(
                     user.email,
                     "abcabcabaB!!"
-                ).toAppRequest(),
+                ),
                 LocalDateTime.now()
             )
         }.isInstanceOf(BusinessException::class.java)

--- a/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserAuthServiceTest.kt
@@ -45,11 +45,12 @@ class UserAuthServiceTest {
     private val jwtResolver = JwtResolver(jwtProperty)
     private val configInquiryComponent = mockk<ConfigInquiryComponent>()
     private val userSystemNotifier = mockk<UserSystemNotifier>()
+    private val userLoginPermissionChecker = mockk<UserLoginPermissionChecker>()
     private val userAuthService = UserAuthService(
-        userRepository,
-        authApplicationRepository,
-        jwtGenerator,
-        jwtResolver
+        userRepository = userRepository,
+        jwtGenerator = jwtGenerator,
+        jwtResolver = jwtResolver,
+        userLoginPermissionChecker = userLoginPermissionChecker
     )
     private val signUpService = SignUpService(
         userRepository,

--- a/src/test/kotlin/co/yappuworld/user/application/UserLoginPermissionCheckerTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserLoginPermissionCheckerTest.kt
@@ -1,0 +1,28 @@
+package co.yappuworld.user.application
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.global.util.EncryptUtils
+import co.yappuworld.support.fixture.user.UserFixture.getUserFixture
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class UserLoginPermissionCheckerTest {
+
+    private val authApplicationRepository = mockk<UserSignUpApplicationRepository>()
+    private val userLoginPermissionChecker = UserLoginPermissionChecker(authApplicationRepository)
+
+    @Test
+    fun `비밀번호가 다르면 로그인에 실패한다`() {
+        val plainPassword = "abcabC!!"
+        val wrongPassword = "abcabCC!!"
+        val user = getUserFixture(password = EncryptUtils.encrypt(plainPassword))
+
+        assertThatThrownBy {
+            userLoginPermissionChecker.checkPermissionAndGetUser(user, user.email, wrongPassword)
+        }.isInstanceOf(BusinessException::class.java)
+            .hasMessageMatching(UserError.WRONG_LOGIN_USER_INFORMATION.message)
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 어드민에서 제공하는 로그인 API가 없었습니다.


## ⭐️ 어떻게 해결했나요?
- 유저 쪽에서 사용하는 로그인과 어드민에서 사용하는 로그인의 공통 체크 로직을 분리하였습니다.
	-> UserLoginPermissionChecker
- 어드민 로그인은 ADMIN, STAFF 권한 중 하나인지 추가 검사를 진행합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
