### PR TITLE
feat: 어드민 가입 코드 삭제

### DIFF
--- a/src/main/kotlin/co/yappuworld/operation/application/dto/request/AdminSignupCodeDeleteRequest.kt
+++ b/src/main/kotlin/co/yappuworld/operation/application/dto/request/AdminSignupCodeDeleteRequest.kt
@@ -1,0 +1,9 @@
+package co.yappuworld.operation.application.dto.request
+
+import co.yappuworld.user.domain.vo.UserRole
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AdminSignupCodeDeleteRequest(
+    @Schema(description = "가입 코드 삭제할 역할")
+    val role: UserRole
+)

--- a/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationApi.kt
@@ -2,6 +2,7 @@ package co.yappuworld.operation.presentation
 
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.operation.application.dto.request.AdminSignupCodeDeleteRequest
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationActiveUpdateApiRequestDto
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationPageApiRequestDto
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationRegisterApiRequestDto
@@ -19,6 +20,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -265,5 +267,16 @@ interface AdminUserOperationApi {
     @PatchMapping("/admin/v1/auth/authentication-codes")
     fun updateSignUpAuthenticationCode(
         @Valid @RequestBody request: AdminSignUpCodeUpdateApiRequestDto
+    ): ResponseEntity<Unit>
+
+    @Operation(summary = "인증번호 삭제")
+    @ApiResponse(
+        responseCode = "204",
+        description = "No Content",
+        content = [Content()]
+    )
+    @DeleteMapping("/admin/v1/auth/authentication-codes")
+    fun deleteSignUpAuthenticationCode(
+        @Valid @RequestBody request: AdminSignupCodeDeleteRequest
     ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationController.kt
+++ b/src/main/kotlin/co/yappuworld/operation/presentation/AdminUserOperationController.kt
@@ -4,6 +4,7 @@ import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.operation.application.AdminUserOperationService
 import co.yappuworld.operation.application.ConfigInquiryComponent
+import co.yappuworld.operation.application.dto.request.AdminSignupCodeDeleteRequest
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationActiveUpdateApiRequestDto
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationPageApiRequestDto
 import co.yappuworld.operation.presentation.dto.request.AdminGenerationRegisterApiRequestDto
@@ -76,6 +77,11 @@ class AdminUserOperationController(
 
     override fun updateSignUpAuthenticationCode(request: AdminSignUpCodeUpdateApiRequestDto): ResponseEntity<Unit> {
         userAdminService.updateSignUpCode(request.toAppRequest())
+        return ResponseEntity.noContent().build()
+    }
+
+    override fun deleteSignUpAuthenticationCode(request: AdminSignupCodeDeleteRequest): ResponseEntity<Unit> {
+        userAdminService.deleteSignupCode(request)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/application/UserAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/user/application/UserAdminService.kt
@@ -7,6 +7,7 @@ import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.security.Token
 import co.yappuworld.global.util.ifNotEmpty
 import co.yappuworld.operation.application.GenerationActiveStateManager
+import co.yappuworld.operation.application.dto.request.AdminSignupCodeDeleteRequest
 import co.yappuworld.operation.domain.ConfigError
 import co.yappuworld.operation.infrastructure.ConfigRepository
 import co.yappuworld.operation.infrastructure.GenerationRepository
@@ -18,6 +19,7 @@ import co.yappuworld.user.application.dto.request.AdminUserUpdateAppRequestDto
 import co.yappuworld.user.application.dto.request.LoginRequest
 import co.yappuworld.user.application.dto.request.UserRoleUpdateAppRequestDto
 import co.yappuworld.user.application.dto.response.AdminSignUpApplicationAppResponseDto
+import co.yappuworld.user.application.dto.response.AdminSignUpApplicationOverviewResponse
 import co.yappuworld.user.application.dto.response.AdminUserDetailResponse
 import co.yappuworld.user.application.dto.response.UserOverviewAppResponseDto
 import co.yappuworld.user.application.dto.response.UserOverviewBundleAppResponseDto
@@ -26,7 +28,6 @@ import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.ActivityUnitRepository
 import co.yappuworld.user.infrastructure.UserRepository
 import co.yappuworld.user.infrastructure.UserSignUpApplicationRepository
-import co.yappuworld.user.application.dto.response.AdminSignUpApplicationOverviewResponse
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -131,9 +132,16 @@ class UserAdminService(
 
     @Transactional
     fun updateSignUpCode(request: AdminSignUpCodeUpdateAppRequestDto) {
-        val config = configRepository.findByIdOrNull(request.role.signUpCodeKey)?.apply {
-            update(request.code)
-        } ?: throw BusinessException(ConfigError.CONFIG_KEY_ERROR)
+        val config = configRepository.findByIdOrNull(request.role.signUpCodeKey)?.apply { update(request.code) }
+            ?: throw BusinessException(ConfigError.CONFIG_KEY_ERROR)
+
+        configRepository.save(config)
+    }
+
+    @Transactional
+    fun deleteSignupCode(request: AdminSignupCodeDeleteRequest) {
+        val config = configRepository.findByIdOrNull(request.role.signUpCodeKey)?.apply { update(null) }
+            ?: throw BusinessException(ConfigError.CONFIG_KEY_ERROR)
 
         configRepository.save(config)
     }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 역할별로 지정된 가입 코드를 이용하면 즉시 가입이 가능
- 특정 역할에 대해 아예 가입 코드를 이용한 가입이 불가능하도록 처리 하고 싶음


## ⭐️ 어떻게 해결했나요?
- 기존에는 공백으로 처리하고자 하였으나, 삭제 기능을 도입하여 가입 코드를 null 처리
- 기존 가입 프로세스에 따르면, 
	- 가입 코드를 인자로 넘긴 경우, 가입 코드를 통한 즉시 가입 프로세스 진행
	- 가입 코드 목록을 순회하며 일치하는 값을 찾으나, 가입 불가한 역할은 값이 null 이므로 일치하는 경우가 발생하지 않음


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
