### PR TITLE
fix: 공지사항 여러개 삭제

### DIFF
--- a/src/main/kotlin/co/yappuworld/post/client/application/AdminNoticeService.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/application/AdminNoticeService.kt
@@ -9,12 +9,11 @@ import co.yappuworld.post.client.dto.request.AdminNoticeUpdateRequest
 import co.yappuworld.post.client.dto.response.AdminNoticeDetailResponse
 import co.yappuworld.post.client.dto.response.AdminNoticeDetailWriterResponse
 import co.yappuworld.post.client.dto.response.AdminNoticeSummaryResponse
-import co.yappuworld.post.domain.BoardError
 import co.yappuworld.post.domain.NoticeEntity
 import co.yappuworld.post.domain.NoticeType
+import co.yappuworld.post.domain.PostError
 import co.yappuworld.post.infrastructure.PostRepository
 import co.yappuworld.user.infrastructure.UserRepository
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -39,7 +38,7 @@ class AdminNoticeService(
         return OffsetPageResponse(
             data = page.content.map { notice ->
                 userById
-                    .getOrElse(notice.writerId) { throw BusinessException(BoardError.NOTICE_WRITER_NOT_FOUND) }
+                    .getOrElse(notice.writerId) { throw BusinessException(PostError.NOTICE_WRITER_NOT_FOUND) }
                     .let { user -> AdminNoticeSummaryResponse(notice as NoticeEntity, user) }
             },
             page = request.page,
@@ -53,11 +52,11 @@ class AdminNoticeService(
     fun getNotice(noticeId: UUID): AdminNoticeDetailResponse {
         val notice = postRepository
             .findById(noticeId)
-            .orElseThrow { BusinessException(BoardError.NOTICE_NOT_FOUND) }
+            .orElseThrow { BusinessException(PostError.NOTICE_NOT_FOUND) }
             as NoticeEntity
         val writer = userRepository
             .findById(notice.writerId)
-            .orElseThrow { BusinessException(BoardError.NOTICE_WRITER_NOT_FOUND) }
+            .orElseThrow { BusinessException(PostError.NOTICE_WRITER_NOT_FOUND) }
 
         return AdminNoticeDetailResponse(
             noticeId = notice.id,
@@ -89,7 +88,7 @@ class AdminNoticeService(
     fun updateNotice(request: AdminNoticeUpdateRequest) {
         val notice = postRepository
             .findById(request.id)
-            .orElseThrow { BusinessException(BoardError.NOTICE_NOT_FOUND) }
+            .orElseThrow { BusinessException(PostError.NOTICE_NOT_FOUND) }
             as NoticeEntity
 
         notice.update(
@@ -102,9 +101,11 @@ class AdminNoticeService(
 
     @Transactional
     fun deleteNotice(request: AdminNoticeDeleteRequest) {
-        val post = postRepository.findByIdOrNull(request.id)
-            ?: throw BusinessException(BoardError.NOTICE_NOT_FOUND)
+        val notices = postRepository.findAllByIdIn(request.noticeIds)
+        if (notices.size != request.size) {
+            throw BusinessException(PostError.NOT_CONTAIN_DELETE_NOTICE)
+        }
 
-        postRepository.delete(post)
+        postRepository.deleteAll(notices)
     }
 }

--- a/src/main/kotlin/co/yappuworld/post/client/application/NoticeService.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/application/NoticeService.kt
@@ -6,7 +6,7 @@ import co.yappuworld.post.client.dto.request.NoticePageRequest
 import co.yappuworld.post.client.dto.request.NoticeTypeInRequest.ALL
 import co.yappuworld.post.client.dto.response.NoticeOverviewResponse
 import co.yappuworld.post.client.dto.response.NoticeResponse
-import co.yappuworld.post.domain.BoardError
+import co.yappuworld.post.domain.PostError
 import co.yappuworld.post.domain.NoticeEntity
 import co.yappuworld.post.domain.NoticeType
 import co.yappuworld.post.infrastructure.PostRepository
@@ -39,7 +39,7 @@ class NoticeService(
                 val user = users[notice.writerId]
                 if (user == null) {
                     logger.error { "게시물 작성자의 ID ${notice.writerId}를 유저 테이블에서 찾을 수 없었습니다." }
-                    throw BusinessException(BoardError.NOTICE_WRITER_NOT_FOUND)
+                    throw BusinessException(PostError.NOTICE_WRITER_NOT_FOUND)
                 }
                 NoticeOverviewResponse(notice, user)
             }.subList(0, min(request.limit, notices.size))
@@ -55,7 +55,7 @@ class NoticeService(
     @Transactional(readOnly = true)
     fun getNotice(noticeId: UUID): NoticeResponse {
         val notice = postRepository.findByIdOrNull(noticeId)
-            ?: throw BusinessException(BoardError.BOARD_NOT_FOUND)
+            ?: throw BusinessException(PostError.POST_NOT_FOUND)
         val user = userRepository.findUserWithActivityUnit(notice.writerId)
 
         return NoticeResponse.from(notice as NoticeEntity, user)

--- a/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeDeleteRequest.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeDeleteRequest.kt
@@ -1,7 +1,13 @@
 package co.yappuworld.post.client.dto.request
 
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 data class AdminNoticeDeleteRequest(
-    val id: UUID
-)
+    @Schema(description = "삭제할 ID 목록")
+    val noticeIds: List<UUID>
+) {
+
+    @Transient
+    val size: Int = noticeIds.size
+}

--- a/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeDeleteRequest.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeDeleteRequest.kt
@@ -9,5 +9,5 @@ data class AdminNoticeDeleteRequest(
 ) {
 
     @Transient
-    val size: Int = noticeIds.size
+    val size: Int = noticeIds.toSet().size
 }

--- a/src/main/kotlin/co/yappuworld/post/client/presentation/AdminNoticeApi.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/presentation/AdminNoticeApi.kt
@@ -10,6 +10,11 @@ import co.yappuworld.post.client.dto.request.AdminNoticeUpdateRequest
 import co.yappuworld.post.client.dto.response.AdminNoticeDetailResponse
 import co.yappuworld.post.client.dto.response.AdminNoticeSummaryResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
@@ -52,6 +57,34 @@ interface AdminNoticeApi {
     ): ResponseEntity<Unit>
 
     @Operation(summary = "공지사항 삭제")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                content = [Content()]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                content = [
+                    Content(
+                        schema = Schema(implementation = SuccessResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "존재하지 않는 공지사항이 요청에 포함",
+                                value = """
+                                    {
+                                        "isSuccess": false,
+                                        "errorCode": "PST_1002",
+                                        "message": "존재하지 않는 공지사항이 요청에 포함되어 있습니다."
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
     @DeleteMapping("/admin/v1/notices")
     fun deleteNotice(
         @RequestBody request: AdminNoticeDeleteRequest

--- a/src/main/kotlin/co/yappuworld/post/client/presentation/NoticeApi.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/presentation/NoticeApi.kt
@@ -1,10 +1,10 @@
 package co.yappuworld.post.client.presentation
 
-import co.yappuworld.post.client.dto.request.NoticePageRequest
-import co.yappuworld.post.client.dto.response.NoticeResponse
-import co.yappuworld.post.client.dto.response.NoticeOverviewResponse
 import co.yappuworld.global.response.CursorPageResponse
 import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.post.client.dto.request.NoticePageRequest
+import co.yappuworld.post.client.dto.response.NoticeOverviewResponse
+import co.yappuworld.post.client.dto.response.NoticeResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -25,7 +25,6 @@ interface NoticeApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
                 content = [
                     Content(
@@ -79,7 +78,6 @@ interface NoticeApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
                 content = [
                     Content(
@@ -116,7 +114,6 @@ interface NoticeApi {
                 ]
             ),
             ApiResponse(
-                description = "조회 실패.",
                 responseCode = "404",
                 content = [
                     Content(

--- a/src/main/kotlin/co/yappuworld/post/domain/PostError.kt
+++ b/src/main/kotlin/co/yappuworld/post/domain/PostError.kt
@@ -22,7 +22,7 @@ enum class PostError : Error {
         override val type: ErrorType = ErrorType.NOT_FOUND
     },
     NOT_CONTAIN_DELETE_NOTICE {
-        override val message: String = "삭제 요청 공지사항 중 존재하지 않는 공지사항이 있습니다."
+        override val message: String = "존재하지 않는 공지사항이 요청에 포함되어 있습니다."
         override val code: String = "PST_1002"
         override val type: ErrorType = ErrorType.NOT_FOUND
     }

--- a/src/main/kotlin/co/yappuworld/post/domain/PostError.kt
+++ b/src/main/kotlin/co/yappuworld/post/domain/PostError.kt
@@ -3,8 +3,8 @@ package co.yappuworld.post.domain
 import co.yappuworld.global.exception.Error
 import co.yappuworld.global.exception.ErrorType
 
-enum class BoardError : Error {
-    BOARD_NOT_FOUND {
+enum class PostError : Error {
+    POST_NOT_FOUND {
         override val message: String = "게시글이 존재하지 않습니다."
         override val code: String = "BRD_0001"
         override val type: ErrorType = ErrorType.NOT_FOUND
@@ -19,6 +19,11 @@ enum class BoardError : Error {
     NOTICE_WRITER_NOT_FOUND {
         override val message: String = "공지사항 작성자 정보가 존재하지 않습니다."
         override val code: String = "BRD_1001"
+        override val type: ErrorType = ErrorType.NOT_FOUND
+    },
+    NOT_CONTAIN_DELETE_NOTICE {
+        override val message: String = "삭제 요청 공지사항 중 존재하지 않는 공지사항이 있습니다."
+        override val code: String = "PST_1002"
         override val type: ErrorType = ErrorType.NOT_FOUND
     }
 }

--- a/src/main/kotlin/co/yappuworld/post/infrastructure/PostRepository.kt
+++ b/src/main/kotlin/co/yappuworld/post/infrastructure/PostRepository.kt
@@ -1,8 +1,8 @@
 package co.yappuworld.post.infrastructure
 
 import co.yappuworld.post.domain.NoticeEntity
-import co.yappuworld.post.domain.PostEntity
 import co.yappuworld.post.domain.NoticeType
+import co.yappuworld.post.domain.PostEntity
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Query
 import java.util.UUID
 
 interface PostRepository : JpaRepository<PostEntity, UUID> {
+
+    fun findAllByIdIn(ids: List<UUID>): List<PostEntity>
 
     @Query(
         value = """


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 공지사항 삭제 시 여러 개 삭제가 가능해야합니다.


## ⭐️ 어떻게 해결했나요?
- 공지사항 삭제 요청을 리스트로 받아, 단건이나 복수건이나 모두 처리할 수 있도록 했습니다.
- 요청한 공지사항 ID 개수와 처리한 ID 개수가 다르면 에러를 발생시킵니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
