### PR TITLE
fix: 요청 DTO에서 size 필드가 노출되지 않도록 처리

### DIFF
--- a/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeDeleteRequest.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeDeleteRequest.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.post.client.dto.request
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
@@ -8,6 +9,6 @@ data class AdminNoticeDeleteRequest(
     val noticeIds: List<UUID>
 ) {
 
-    @Transient
+    @JsonIgnore
     val size: Int = noticeIds.toSet().size
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 요청 DTO에 선언된 필드 중, 실제 요청 시에는 사용되지 않는 필드가 있어 노출을 막아야 함


## ⭐️ 어떻게 해결했나요?
- JsonIgnore 어노테이션을 활용하여 처리


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
