### PR TITLE
fix: 공지사항 목록 작성일 변경

### DIFF
--- a/src/main/kotlin/co/yappuworld/post/client/dto/response/NoticeOverviewResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/response/NoticeOverviewResponseDto.kt
@@ -34,7 +34,7 @@ data class NoticeSimpleResponse(
 
     constructor(notice: NoticeEntity) : this(
         id = notice.id,
-        createdAt = LocalDate.now(),
+        createdAt = notice.createdAt.toLocalDate(),
         title = notice.title,
         content = notice.contentSummary.take(200),
         noticeType = notice.noticeType


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 공지사항 목록에서 작성일이 정상 노출되지 않음


## ⭐️ 어떻게 해결했나요?
- 작성일을 반환할 수 있도록 처리


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
