### PR TITLE
fix: 커서 정보 null 처리

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/response/CursorPageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/global/response/CursorPageResponse.kt
@@ -6,7 +6,7 @@ class CursorPageResponse<T, R>(
     @Schema(description = "데이터 목록")
     val data: List<T>,
     @Schema(description = "다음 요청에 사용되는 커서 정보, 사용 방법은 API 별로 상이할 수 있음")
-    val lastCursor: R,
+    val lastCursor: R?,
     @Schema(description = "조회 개수")
     val limit: Int,
     @Schema(description = "다음 데이터 존재 여부")

--- a/src/main/kotlin/co/yappuworld/post/client/application/NoticeService.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/application/NoticeService.kt
@@ -47,7 +47,7 @@ class NoticeService(
 
         return CursorPageResponse(
             data = data,
-            lastCursor = data.last().notice.id,
+            lastCursor = data.lastOrNull()?.notice?.id,
             limit = request.limit,
             hasNext = notices.size > request.limit
         )


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 커서 페이지네이션에서 조회된 데이터가 없는 경우 lastCursor 추출에 실패하면서 에러가 발생했습니다.


## ⭐️ 어떻게 해결했나요?
- 데이터(리스트)가 없을 수 있다는 가정으로 List.last() 메서드를 List.lastOrNull()로 null 처리를 진행하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
