### PR TITLE
fix: 세션 bulk 삭제

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
@@ -3,13 +3,14 @@ package co.yappuworld.schedule.client.application
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.schedule.client.dto.request.AdminSessionCreateRequest
+import co.yappuworld.schedule.client.dto.request.AdminSessionDeleteRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionPageRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
 import co.yappuworld.schedule.domain.ScheduleError
 import co.yappuworld.schedule.domain.SessionEntity
-import co.yappuworld.schedule.infrastructure.ScheduleJpaRepository
+import co.yappuworld.schedule.infrastructure.ScheduleRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,20 +18,20 @@ import java.util.UUID
 
 @Service
 class ScheduleAdminService(
-    private val scheduleJpaRepository: ScheduleJpaRepository
+    private val scheduleRepository: ScheduleRepository
 ) {
 
     @Transactional
     fun createSchedule(request: AdminSessionCreateRequest): UUID {
-        val schedule = scheduleJpaRepository.save(request.toDomain())
+        val schedule = scheduleRepository.save(request.toDomain())
         return schedule.id
     }
 
     @Transactional(readOnly = true)
     fun getSessions(request: AdminSessionPageRequest): OffsetPageResponse<AdminSessionOverviewResponse> =
         when (request.generation != null) {
-            true -> scheduleJpaRepository.findAllByGeneration(request.toPageRequest(), request.generation)
-            false -> scheduleJpaRepository.findAll(request.toPageRequest())
+            true -> scheduleRepository.findAllByGeneration(request.toPageRequest(), request.generation)
+            false -> scheduleRepository.findAll(request.toPageRequest())
         }.let {
             OffsetPageResponse(
                 data = it.content.map { session -> AdminSessionOverviewResponse(session as SessionEntity) },
@@ -43,7 +44,7 @@ class ScheduleAdminService(
 
     @Transactional(readOnly = true)
     fun getSession(id: UUID): AdminSessionDetailResponse =
-        scheduleJpaRepository
+        scheduleRepository
             .findByIdOrNull(id)
             ?.let { AdminSessionDetailResponse(it as SessionEntity) }
             ?: throw BusinessException(ScheduleError.NOT_FOUND_SESSION)
@@ -52,13 +53,19 @@ class ScheduleAdminService(
      * 어드민에서 요청하는 세션 삭제라, hard delete 구현
      */
     @Transactional
-    fun deleteSession(id: UUID) {
-        scheduleJpaRepository.deleteById(id)
+    fun deleteSession(request: AdminSessionDeleteRequest) {
+        val sessions = scheduleRepository.findAllByIdIn(request.ids)
+
+        if (sessions.size != request.ids.size) {
+            throw BusinessException(ScheduleError.CONTAIN_IMPROPER_ID_FOR_DELETE_SESSION)
+        }
+
+        scheduleRepository.deleteAll(sessions)
     }
 
     @Transactional
     fun updateSession(request: AdminSessionUpdateRequest) {
-        val schedule = scheduleJpaRepository.findByIdOrNull(request.id)
+        val schedule = scheduleRepository.findByIdOrNull(request.id)
             ?: throw BusinessException(ScheduleError.UPDATE_FAIL_NOT_SESSION_TYPE)
 
         (schedule as SessionEntity).apply { request.applyTo(this) }

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -4,7 +4,7 @@ import co.yappuworld.operation.infrastructure.GenerationRepository
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
-import co.yappuworld.schedule.infrastructure.ScheduleJpaRepository
+import co.yappuworld.schedule.infrastructure.ScheduleRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -13,7 +13,7 @@ import java.time.LocalDateTime
 @Service
 class ScheduleService(
     private val generationRepository: GenerationRepository,
-    private val scheduleJpaRepository: ScheduleJpaRepository
+    private val scheduleRepository: ScheduleRepository
 ) {
 
     @Transactional(readOnly = true)
@@ -21,7 +21,7 @@ class ScheduleService(
         val currentGeneration = generationRepository.getGenerationOrNullByIsActiveIsTrue()
             ?: return ActiveGenerationSessionsResponse.from(emptyList(), now)
         return ActiveGenerationSessionsResponse.from(
-            sessions = scheduleJpaRepository.findAllSessionEntityByGeneration(currentGeneration.value),
+            sessions = scheduleRepository.findAllSessionEntityByGeneration(currentGeneration.value),
             now = now
         )
     }
@@ -30,7 +30,7 @@ class ScheduleService(
         request: SchedulePageRequest,
         now: LocalDateTime
     ): SchedulePageResponse {
-        val schedules = scheduleJpaRepository.findScheduleEntitiesByDateBetween(request.from, request.to)
+        val schedules = scheduleRepository.findScheduleEntitiesByDateBetween(request.from, request.to)
         return SchedulePageResponse.from(schedules, request, now)
     }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionDeleteRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionDeleteRequest.kt
@@ -1,9 +1,11 @@
 package co.yappuworld.schedule.client.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
 import java.util.UUID
 
 data class AdminSessionDeleteRequest(
-    @Schema(description = "삭제할 세션 ID")
-    val id: UUID
+    @Schema(description = "삭제할 세션 ID 목록")
+    @field:NotEmpty(message = "삭제할 ID는 하나 이상이어야 합니다.")
+    val ids: List<UUID>
 )

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import java.util.UUID
 
-@Tag(name = "세션 어드민 API", description = "세션 관리")
+@Tag(name = "어드민 세션 API", description = "세션 관리")
 interface ScheduleAdminApi {
 
     @Operation(summary = "세션 생성")
@@ -160,7 +160,7 @@ interface ScheduleAdminApi {
                 content = [Content()]
             ),
             ApiResponse(
-                responseCode = "404",
+                responseCode = "400",
                 content = [
                     Content(
                         examples = [
@@ -168,8 +168,18 @@ interface ScheduleAdminApi {
                                 name = "ID와 일치하는 세션이 존재하지 않습니다.",
                                 value = """
                                     {
-                                        "message": "세션을 찾지 못했습니다.",
-                                        "errorCode": "SCH_1002",
+                                        "message": "삭제할 수 없는 ID가 포함되어 있습니다.",
+                                        "errorCode": "SCH_1003",
+                                        "isSuccess": false
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "요청 ID 리스트가 비어있는 경우",
+                                value = """
+                                    {
+                                        "message": "삭제할 ID는 하나 이상이어야 합니다.",
+                                        "errorCode": "COM_0002",
                                         "isSuccess": false
                                     }
                                 """
@@ -182,7 +192,7 @@ interface ScheduleAdminApi {
     )
     @DeleteMapping("/admin/v1/sessions")
     fun deleteSession(
-        @RequestBody request: AdminSessionDeleteRequest
+        @Valid @RequestBody request: AdminSessionDeleteRequest
     ): ResponseEntity<Unit>
 
     @Operation(summary = "세션 수정")

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminController.kt
@@ -37,7 +37,7 @@ class ScheduleAdminController(
             .let { ResponseEntity.ok(SuccessResponse(it)) }
 
     override fun deleteSession(request: AdminSessionDeleteRequest): ResponseEntity<Unit> {
-        scheduleAdminService.deleteSession(request.id)
+        scheduleAdminService.deleteSession(request)
         return ResponseEntity.noContent().build()
     }
 

--- a/src/main/kotlin/co/yappuworld/schedule/domain/ScheduleError.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/ScheduleError.kt
@@ -20,5 +20,10 @@ enum class ScheduleError : Error {
         override val message: String = "세션 타입 수정만 요청 가능합니다."
         override val code: String = "SCH_1003"
         override val type: ErrorType = ErrorType.BAD_REQUEST
+    },
+    CONTAIN_IMPROPER_ID_FOR_DELETE_SESSION {
+        override val message: String = "삭제할 수 없는 ID가 포함되어 있습니다."
+        override val code: String = "SCH_1004"
+        override val type: ErrorType = ErrorType.BAD_REQUEST
     }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/ScheduleRepository.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/ScheduleRepository.kt
@@ -8,7 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDate
 import java.util.UUID
 
-interface ScheduleJpaRepository : JpaRepository<ScheduleEntity, UUID> {
+interface ScheduleRepository : JpaRepository<ScheduleEntity, UUID> {
+
+    fun findAllByIdIn(ids: List<UUID>): List<SessionEntity>
 
     fun findAllSessionEntityByGeneration(generation: Int): List<SessionEntity>
 

--- a/src/test/kotlin/co/yappuworld/schedule/application/ScheduleServiceScheduleProgressPhaseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/application/ScheduleServiceScheduleProgressPhaseTest.kt
@@ -4,7 +4,7 @@ import co.yappuworld.operation.infrastructure.GenerationRepository
 import co.yappuworld.schedule.client.application.ScheduleService
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
 import co.yappuworld.schedule.domain.ScheduleEntity
-import co.yappuworld.schedule.infrastructure.ScheduleJpaRepository
+import co.yappuworld.schedule.infrastructure.ScheduleRepository
 import co.yappuworld.support.fixture.schedule.ScheduleFixture.getSessionFixture
 import io.mockk.every
 import io.mockk.mockk
@@ -15,7 +15,7 @@ import kotlin.test.assertEquals
 class ScheduleServiceScheduleProgressPhaseTest {
 
     private val generationRepository = mockk<GenerationRepository>()
-    private val scheduleRepository = mockk<ScheduleJpaRepository>()
+    private val scheduleRepository = mockk<ScheduleRepository>()
     private val scheduleService = ScheduleService(generationRepository, scheduleRepository)
 
     fun mockScheduleRepository(vararg schedules: ScheduleEntity) {

--- a/src/test/kotlin/co/yappuworld/schedule/application/ScheduleServiceSessionProgressPhaseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/application/ScheduleServiceSessionProgressPhaseTest.kt
@@ -7,7 +7,7 @@ import co.yappuworld.schedule.domain.SessionProgressPhase.DONE
 import co.yappuworld.schedule.domain.SessionProgressPhase.PENDING
 import co.yappuworld.schedule.domain.SessionProgressPhase.TODAY
 import co.yappuworld.schedule.domain.SessionProgressPhase.UPCOMING
-import co.yappuworld.schedule.infrastructure.ScheduleJpaRepository
+import co.yappuworld.schedule.infrastructure.ScheduleRepository
 import co.yappuworld.support.fixture.operation.OperationFixture
 import co.yappuworld.support.fixture.schedule.ScheduleFixture
 import io.mockk.every
@@ -20,7 +20,7 @@ import kotlin.test.assertEquals
 class ScheduleServiceSessionProgressPhaseTest {
 
     private val generationRepository = mockk<GenerationRepository>()
-    private val scheduleRepository = mockk<ScheduleJpaRepository>()
+    private val scheduleRepository = mockk<ScheduleRepository>()
     private val scheduleService = ScheduleService(generationRepository, scheduleRepository)
 
     private val generation = 2

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/ScheduleRepositoryTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/ScheduleRepositoryTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.Test
 class ScheduleRepositoryTest {
 
     @Autowired
-    lateinit var scheduleRepository: ScheduleJpaRepository
+    lateinit var scheduleRepository: ScheduleRepository
 
     @Test
     fun `Session 타입의 데이터도 잘 저장이 된다`() {


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 세션을 한 번에 삭제할 수 있어야 합니다.


## ⭐️ 어떻게 해결했나요?
- 기존 단건 삭제 요청을 리스트 요청으로 변경하였습니다.
- 요청에 들어온 삭제 List ID와 조회된 세션의 개수가 같아야만 삭제를 진행할 수 있도록 하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
