### PR TITLE
feat: 출석 통계

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 - 특별히 아키텍처라고 할 건 없고, 다음의 사진과 같은 규칙을 따르고 있습니다.
 
-![패키지 아키텍처](https://github.com/user-attachments/assets/2c90c1c8-3590-491e-b566-1c1b318707dd)
+![패키지 아키텍처](https://github.com/user-attachments/assets/b1d8c7b9-60ad-4bba-9d84-89635c323f98)
+
 
 ## ⚙️ 프로젝트 세팅
 

--- a/src/main/kotlin/co/yappuworld/attendance/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/client/application/AttendanceService.kt
@@ -1,10 +1,12 @@
 package co.yappuworld.attendance.client.application
 
 import co.yappuworld.attendance.client.dto.request.AttendanceRequest
+import co.yappuworld.attendance.client.dto.response.AttendanceStatisticsResponse
 import co.yappuworld.attendance.domain.Attendance
 import co.yappuworld.attendance.domain.AttendanceError
 import co.yappuworld.attendance.infrastructure.AttendanceCommandService
 import co.yappuworld.attendance.infrastructure.AttendanceFindService
+import co.yappuworld.attendance.infrastructure.LatePassFindService
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.operation.infrastructure.ConfigFindService
 import co.yappuworld.operation.infrastructure.GenerationFindService
@@ -27,7 +29,8 @@ class AttendanceService(
     private val configFindService: ConfigFindService,
     private val sessionFindService: SessionFindService,
     private val generationFindService: GenerationFindService,
-    private val userFindService: UserFindService
+    private val userFindService: UserFindService,
+    private val latePassFindService: LatePassFindService
 ) {
 
     @Transactional
@@ -43,6 +46,23 @@ class AttendanceService(
                 Attendance.checkInSession(now = now, userId = userId, session = it as SessionEntity)
             )
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun getAttendanceStatistics(
+        userId: UUID,
+        now: LocalDateTime
+    ): AttendanceStatisticsResponse {
+        val activeGeneration = generationFindService.findActiveGeneration()
+            ?: throw BusinessException(AttendanceError.NO_ACTIVE_GENERATION)
+        val thisGenerationSessions = sessionFindService.findCurrentGenerationSessions(activeGeneration)
+        val attendances = attendanceFindService.findAttendancesBySchedules(
+            userId = userId,
+            scheduleIds = thisGenerationSessions.map { it.id }
+        )
+        val latePassCount = latePassFindService.countLatePasses(activeGeneration, userId)
+
+        return AttendanceStatisticsResponse.of(thisGenerationSessions, attendances, now, latePassCount)
     }
 
     private fun validateCheckIn(

--- a/src/main/kotlin/co/yappuworld/attendance/client/dto/response/AttendanceStatisticsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/client/dto/response/AttendanceStatisticsResponse.kt
@@ -1,0 +1,63 @@
+package co.yappuworld.attendance.client.dto.response
+
+import co.yappuworld.attendance.domain.Attendance
+import co.yappuworld.attendance.domain.AttendanceStatus.ABSENT
+import co.yappuworld.attendance.domain.AttendanceStatus.LATE
+import co.yappuworld.attendance.domain.AttendanceStatus.ON_TIME
+import co.yappuworld.schedule.domain.SessionEntity
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class AttendanceStatisticsResponse(
+    @Schema(description = "전체 세션 수")
+    val totalSessionCount: Int,
+    @Schema(description = "남은 세션 수")
+    val remainingSessionCount: Int,
+    @Schema(description = "세션 진행률")
+    val sessionProgressRate: Int,
+    @Schema(description = "출석 점수")
+    val attendancePoint: Int,
+    @Schema(description = "출석한 세션 수")
+    val attendanceCount: Int,
+    @Schema(description = "지각한 세션 수")
+    val lateCount: Int,
+    @Schema(description = "결석한 세션 수")
+    val absenceCount: Int,
+    @Schema(description = "지각 면제권 수")
+    val latePassCount: Int
+) {
+
+    companion object {
+        fun of(
+            sessions: List<SessionEntity>,
+            attendances: List<Attendance>,
+            now: LocalDateTime,
+            latePassCount: Int
+        ): AttendanceStatisticsResponse {
+            val finishedSessions = sessions.filter {
+                it.date.isBefore(now.toLocalDate()) ||
+                    (it.date.isEqual(now.toLocalDate()) && it.endTime?.isBefore(now.toLocalTime()) ?: false)
+            }
+
+            val attendanceBySession = attendances.associateBy { it.scheduleId }
+
+            val defaultPoint = 100
+            val attendanceCount = finishedSessions.count { attendanceBySession[it.id]?.status == ON_TIME }
+            val lateCount = finishedSessions.count { attendanceBySession[it.id]?.status == LATE }
+            val absenceCount = finishedSessions.count { attendanceBySession[it.id]?.status == ABSENT }
+
+            val attendancePoint = defaultPoint - lateCount * 10 - absenceCount * 20 + latePassCount * 10
+
+            return AttendanceStatisticsResponse(
+                totalSessionCount = sessions.size,
+                remainingSessionCount = sessions.size - finishedSessions.size,
+                sessionProgressRate = finishedSessions.size * 100 / sessions.size,
+                attendancePoint = attendancePoint,
+                attendanceCount = attendanceCount,
+                lateCount = lateCount,
+                absenceCount = absenceCount,
+                latePassCount = latePassCount
+            )
+        }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/attendance/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/client/presentation/AttendanceApi.kt
@@ -1,6 +1,8 @@
 package co.yappuworld.attendance.client.presentation
 
 import co.yappuworld.attendance.client.dto.request.AttendanceRequest
+import co.yappuworld.attendance.client.dto.response.AttendanceStatisticsResponse
+import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 
@@ -92,7 +95,7 @@ interface AttendanceApi {
                                 value = """
                                     {
                                         "errorCode": "ATD_2002",
-                                        "message": "활성화 된 기수가 없다면 출석이 가능한 세션도 없습니다.",
+                                        "message": "활성화 된 기수가 없어서 출석 관련 처리가 불가합니다.",
                                         "isSuccess": false
                                     }
                                 """
@@ -137,4 +140,10 @@ interface AttendanceApi {
         @Valid @RequestBody request: AttendanceRequest,
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<Unit>
+
+    @Operation(summary = "나의 출석 통계")
+    @GetMapping("/v1/attendance-statistics")
+    fun getAttendanceStatistics(
+        @AuthenticationPrincipal securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<AttendanceStatisticsResponse>>
 }

--- a/src/main/kotlin/co/yappuworld/attendance/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/client/presentation/AttendanceApi.kt
@@ -7,6 +7,7 @@ import co.yappuworld.global.security.SecurityUser
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -142,6 +143,57 @@ interface AttendanceApi {
     ): ResponseEntity<Unit>
 
     @Operation(summary = "나의 출석 통계")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                content = [
+                    Content(
+                        schema = Schema(implementation = AttendanceStatisticsResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "출석 통계 조회",
+                                value = """
+                                    {
+                                        "data": {
+                                            "totalSessionCount": 17,
+                                            "remainingSessionCount": 2,
+                                            "sessionProgressRate": 88,
+                                            "attendancePoint": 40,
+                                            "attendanceCount": 10,
+                                            "lateCount": 3,
+                                            "absenceCount": 2,
+                                            "latePassCount": 1
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "활성화 된 기수가 없어 출석 통계 조회 불가",
+                                value = """
+                                    {
+                                        "errorCode": "ATD_2002",
+                                        "message": "활성화 된 기수가 없어서 출석 통계 조회가 불가합니다.",
+                                        "isSuccess": false
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
     @GetMapping("/v1/attendance-statistics")
     fun getAttendanceStatistics(
         @AuthenticationPrincipal securityUser: SecurityUser

--- a/src/main/kotlin/co/yappuworld/attendance/client/presentation/AttendanceController.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/client/presentation/AttendanceController.kt
@@ -2,11 +2,14 @@ package co.yappuworld.attendance.client.presentation
 
 import co.yappuworld.attendance.client.application.AttendanceService
 import co.yappuworld.attendance.client.dto.request.AttendanceRequest
+import co.yappuworld.attendance.client.dto.response.AttendanceStatisticsResponse
+import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.util.TimeUtils
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
+import java.time.LocalDateTime
 
 @RestController
 class AttendanceController(
@@ -20,4 +23,13 @@ class AttendanceController(
         attendanceService.checkIn(request, securityUser.userId, TimeUtils.getCurrentDateTimeInKST())
         return ResponseEntity.created(URI("")).build()
     }
+
+    override fun getAttendanceStatistics(
+        securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<AttendanceStatisticsResponse>> =
+        ResponseEntity.ok(
+            SuccessResponse(
+                attendanceService.getAttendanceStatistics(securityUser.userId, LocalDateTime.now())
+            )
+        )
 }

--- a/src/main/kotlin/co/yappuworld/attendance/domain/Attendance.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/domain/Attendance.kt
@@ -45,4 +45,8 @@ class Attendance(
     @Enumerated(EnumType.STRING)
     var status: AttendanceStatus = status
         private set
+
+    fun updateStatus(status: AttendanceStatus) {
+        this.status = status
+    }
 }

--- a/src/main/kotlin/co/yappuworld/attendance/domain/AttendanceError.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/domain/AttendanceError.kt
@@ -33,7 +33,7 @@ enum class AttendanceError : Error {
         override val type: ErrorType = ErrorType.BAD_REQUEST
     },
     NO_ACTIVE_GENERATION {
-        override val message: String = "활성화 된 기수가 없다면 출석이 가능한 세션도 없습니다."
+        override val message: String = "활성화 된 기수가 없어서 출석 관련 처리가 불가합니다."
         override val code: String = "ATD_2002"
         override val type: ErrorType = ErrorType.WRONG_STATE
     },

--- a/src/main/kotlin/co/yappuworld/attendance/domain/LatePass.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/domain/LatePass.kt
@@ -1,0 +1,19 @@
+package co.yappuworld.attendance.domain
+
+import co.yappuworld.global.persistence.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "late_passes")
+class LatePass(
+    val userId: UUID,
+    val generation: Int,
+    reason: String? = null
+) : BaseEntity() {
+
+    @Column(name = "reason")
+    val reason: String? = reason
+}

--- a/src/main/kotlin/co/yappuworld/attendance/infrastructure/AttendanceFindService.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/infrastructure/AttendanceFindService.kt
@@ -20,4 +20,20 @@ class AttendanceFindService(
         userId: UUID,
         sessionId: UUID
     ): Attendance? = attendanceRepository.findByUserIdAndScheduleId(userId, sessionId)
+
+    fun findAttendancesBySchedules(
+        userId: UUID,
+        scheduleIds: List<UUID>
+    ): List<Attendance> =
+        attendanceRepository
+            .findAll {
+                select(entity(Attendance::class))
+                    .from(entity(Attendance::class))
+                    .where(
+                        and(
+                            path(Attendance::userId).equal(userId),
+                            path(Attendance::scheduleId).`in`(scheduleIds)
+                        )
+                    )
+            }.filterNotNull()
 }

--- a/src/main/kotlin/co/yappuworld/attendance/infrastructure/AttendanceRepository.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/infrastructure/AttendanceRepository.kt
@@ -1,10 +1,13 @@
 package co.yappuworld.attendance.infrastructure
 
 import co.yappuworld.attendance.domain.Attendance
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface AttendanceRepository : JpaRepository<Attendance, UUID> {
+interface AttendanceRepository :
+    JpaRepository<Attendance, UUID>,
+    KotlinJdslJpqlExecutor {
 
     fun existsAttendanceByUserIdAndScheduleId(
         userId: UUID,

--- a/src/main/kotlin/co/yappuworld/attendance/infrastructure/LatePassFindService.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/infrastructure/LatePassFindService.kt
@@ -1,0 +1,17 @@
+package co.yappuworld.attendance.infrastructure
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class LatePassFindService(
+    private val latePassRepository: LatePassRepository
+) {
+
+    fun countLatePasses(
+        generation: Int,
+        userId: UUID
+    ): Int = latePassRepository.countAllByGenerationAndUserId(generation, userId)
+}

--- a/src/main/kotlin/co/yappuworld/attendance/infrastructure/LatePassRepository.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/infrastructure/LatePassRepository.kt
@@ -1,0 +1,13 @@
+package co.yappuworld.attendance.infrastructure
+
+import co.yappuworld.attendance.domain.LatePass
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface LatePassRepository : JpaRepository<LatePass, Long> {
+
+    fun countAllByGenerationAndUserId(
+        generation: Int,
+        userId: UUID
+    ): Int
+}

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -9,6 +9,7 @@ import co.yappuworld.schedule.client.dto.response.UpcomingSessionAttendanceRespo
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -172,6 +173,10 @@ interface ScheduleApi {
                 responseCode = "200",
                 content = [
                     Content(
+                        schema = Schema(
+                            implementation = UpcomingSessionAttendanceResponse::class,
+                            subTypes = [UpcomingSessionAttendanceResponse::class]
+                        ),
                         examples = [
                             ExampleObject(
                                 name = "활동 유저가 아니거나 미출석 & 출석 가능한 시간이 아닌 경우",

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -166,6 +166,80 @@ interface ScheduleApi {
     ): ResponseEntity<SuccessResponse<SchedulePageResponse>>
 
     @Operation(summary = "임박한 세션의 출석 정보")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "활동 유저가 아니거나 미출석 & 출석 가능한 시간이 아닌 경우",
+                                value = """
+                                    {
+                                        "data": {
+                                            "sessionId": "552390a8-ff12-11ef-ad31-0242ac120002",
+                                            "date": "2024-11-01",
+                                            "canCheckIn": false,
+                                            "status": null
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "미출석 & 출석 가능한 시간",
+                                value = """
+                                    {
+                                        "data": {
+                                            "sessionId": "552390a8-ff12-11ef-ad31-0242ac120002",
+                                            "date": "2024-11-01",
+                                            "canCheckIn": true,
+                                            "status": null
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "출석한 상태",
+                                value = """
+                                    {
+                                        "data": {
+                                            "sessionId": "552390a8-ff12-11ef-ad31-0242ac120002",
+                                            "date": "2024-11-01",
+                                            "canCheckIn": false,
+                                            "status": "출석"
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "활성화 된 기수가 없거나 다음 세션이 없는 경우",
+                                value = """
+                                    {
+                                        "message": "예정된 세션이 존재하지 않습니다.",
+                                        "errorCode": "SCH_1005",
+                                        "isSuccess": false
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
     @GetMapping("/v1/sessions/upcoming")
     fun getUpcomingSessionAttendance(
         @AuthenticationPrincipal securityUser: SecurityUser

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
@@ -30,4 +30,12 @@ class SessionFindService(
                         )
                     ).orderBy(path(SessionEntity::date).asc())
             }.singleOrNull()
+
+    fun findCurrentGenerationSessions(generation: Int): List<SessionEntity> =
+        scheduleRepository
+            .findAll {
+                select(entity(SessionEntity::class))
+                    .from(entity(SessionEntity::class))
+                    .where(path(SessionEntity::generation).equal(generation))
+            }.filterNotNull()
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -29,10 +29,10 @@ VALUES ('attendanceCode', now(), now(), '출석코드', 'ATTENDANCE_CODE', '0000
 
 INSERT INTO users (id, created_at, updated_at, email, password, name, role, is_active)
 VALUES (UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), '2025-03-05 03:11:16', now(), 'admin@admin.com',
-        '$2a$10$FlqVcwbK6JAnkVx7gEdFdeH3Gb7bF/bzDfu5u0afry0jss.3I71Oe', '홍길동', 'ADMIN', true);
+        '$2a$10$FlqVcwbK6JAnkVx7gEdFdeH3Gb7bF/bzDfu5u0afry0jss.3I71Oe', '홍길동', 'ACTIVE', true);
 
 INSERT INTO activity_units (id, created_at, updated_at, position, generation, user_id)
-VALUES (UUID_TO_BIN(uuid()), now(), now(), 'PM', 1, UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'));
+VALUES (UUID_TO_BIN(uuid()), now(), now(), 'PM', 25, UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'));
 
 INSERT INTO user_devices (id, created_at, updated_at, user_id, fcm_token)
 VALUES (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), 'fcm_token');
@@ -98,16 +98,43 @@ VALUES (1, null, null, false),
        (22, '2023-04-29', '2023-08-05', false),
        (23, '2023-10-28', '2024-02-24', false),
        (24, '2024-05-11', '2024-09-14', false),
-       (25, '2024-11-16', '2025-03-08', false);
+       (25, '2024-11-16', '2025-03-08', true);
 
-INSERT INTO schedules (id, created_at, updated_at, is_deleted, name, description, place, date, end_date, time, end_time,
-                       is_all_day, generation, type, session_type)
-VALUES (UUID_TO_BIN(uuid()), now(), now(), false, 'OT', '첫 세션이에요',
-        '강북노동자복지관', '2024-11-1', '2024-11-1', '14:00:00', '18:00:00',
-        false, 25, 'SESSION', 'OFFLINE'),
-       (UUID_TO_BIN(uuid()), now(), now(), false, '팀세션', '첫 팀세션',
-        null, '2024-11-1', '2024-11-1', null, null, true, 25, 'SESSION',
-        'TEAM'),
-       (UUID_TO_BIN(uuid()), now(), now(), false, '팀매칭',
-        '팀을 매칭해요', 'SBA 산학센터', '2024-11-3', '2024-11-3',
-        '14:00:00', '18:00:00', false, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c076cadd-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, 'OT', 'OT 진행 & PM·디자이너 팀매칭', '강북노동자복지관', '2024-11-16', '2024-11-16', '14:00:00', '18:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c076ff63-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '팀 매칭', null, 'SBA 산학센터', '2024-11-23', '2024-11-23', '14:00:00', '18:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c0775226-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '팀 세션', null, null, '2024-11-30', '2024-11-30', null, null, FALSE, 25, 'SESSION', 'TEAM');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c0778896-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '관심사 세션', '팀별 자율 진행 (출석 인증 필수)', null, '2024-12-07', '2024-12-07', '14:00:00', '18:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c077c803-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '기획 세션', '기획 & 와이어프레임 발표', null, '2024-12-21', '2024-12-21', '13:00:00', '17:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c077fc61-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '1차 Dev.camp', '1차 UT & 해커톤', '성수 엘리스 랩', '2025-01-04', '2025-01-04', '09:00:00', '21:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c0784091-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '팀 세션', '팀별 자율 진행 (출석 인증 필수)', null, '2025-01-11', '2025-01-11', null, null, FALSE, 25, 'SESSION', 'TEAM');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c0788497-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '2차 Dev.camp', '1차 데모 & 직군 피드백', '공덕창업허브', '2025-01-18', '2025-01-18', '14:00:00', '18:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c078c671-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '팀 세션', '팀별 자율 진행 (출석 인증 필수)', null, '2025-01-25', '2025-01-25', null, null, FALSE, 25, 'SESSION', 'TEAM');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c0791ec0-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '팀 세션', '팀별 자율 진행 (출석 인증 필수)', null, '2025-02-01', '2025-02-01', null, null, FALSE, 25, 'SESSION', 'TEAM');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c0795e0f-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '3차 Dev.camp', '2차 UT & 직군 세션', '공덕창업허브', '2025-02-08', '2025-02-08', '14:00:00', '18:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c079a452-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '팀 세션', '팀별 자율 진행 (출석 인증 필수)', null, '2025-02-15', '2025-02-15', null, null, FALSE, 25, 'SESSION', 'TEAM');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c079db6e-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '데모데이', '연합 데모데이', '공덕창업허브', '2025-02-22', '2025-02-22', '14:00:00', '17:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c07a1f04-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '팀 세션', '팀별 자율 진행 (출석 인증 필수)', null, '2025-03-01', '2025-03-01', null, null, FALSE, 25, 'SESSION', 'TEAM');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c07a6213-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '성과 공유회', null, '서울시공익활동지원센터', '2025-03-08', '2025-03-08', '13:30:00', '17:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c07aa77e-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '가짜 세션1', null, '아몰랑', '2025-04-18', '2025-04-18', '13:30:00', '17:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+INSERT INTO schedules VALUES (UUID_TO_BIN('c07afa8b-1b30-11f0-add0-0242ac140002'), NOW(), NOW(), FALSE, '가짜 세션2', null, '아몰랑', '2025-05-08', '2025-05-08', '13:30:00', '17:00:00', FALSE, 25, 'SESSION', 'OFFLINE');
+
+INSERT INTO attendances (id, created_at, updated_at, user_id, schedule_id, status)
+VALUES (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c076cadd-1b30-11f0-add0-0242ac140002'), 'ON_TIME'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c076ff63-1b30-11f0-add0-0242ac140002'), 'LATE'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c0775226-1b30-11f0-add0-0242ac140002'), 'ABSENT'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c0778896-1b30-11f0-add0-0242ac140002'), 'ON_TIME'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c077c803-1b30-11f0-add0-0242ac140002'), 'ON_TIME'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c077fc61-1b30-11f0-add0-0242ac140002'), 'ON_TIME'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c0784091-1b30-11f0-add0-0242ac140002'), 'ABSENT'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c0788497-1b30-11f0-add0-0242ac140002'), 'ON_TIME'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c078c671-1b30-11f0-add0-0242ac140002'), 'ON_TIME'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c0791ec0-1b30-11f0-add0-0242ac140002'), 'LATE'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c0795e0f-1b30-11f0-add0-0242ac140002'), 'ON_TIME'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c079a452-1b30-11f0-add0-0242ac140002'), 'LATE'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c079db6e-1b30-11f0-add0-0242ac140002'), 'ON_TIME'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c07a1f04-1b30-11f0-add0-0242ac140002'), 'ON_TIME'),
+       (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), UUID_TO_BIN('c07a6213-1b30-11f0-add0-0242ac140002'), 'ON_TIME');
+
+INSERT INTO late_passes (id, created_at, updated_at, user_id, generation, reason)
+VALUES (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), 25, '한 번 봐드림');
+

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -147,5 +147,6 @@ create table late_passes
     created_at datetime(6),
     updated_at datetime(6),
     user_id    binary(16) NOT NULL,
+    generation int NOT NULL,
     reason     varchar(128)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -139,3 +139,13 @@ create table attendances
     schedule_id binary(16) NOT NULL,
     status      varchar(32) NOT NULL
 );
+
+drop table if exists late_passes;
+create table late_passes
+(
+    id         binary(16) PRIMARY KEY,
+    created_at datetime(6),
+    updated_at datetime(6),
+    user_id    binary(16) NOT NULL,
+    reason     varchar(128)
+);

--- a/src/test/kotlin/co/yappuworld/attendance/client/application/AttendanceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/attendance/client/application/AttendanceServiceTest.kt
@@ -6,6 +6,7 @@ import co.yappuworld.attendance.domain.AttendanceError
 import co.yappuworld.attendance.domain.AttendanceStatus
 import co.yappuworld.attendance.infrastructure.AttendanceCommandService
 import co.yappuworld.attendance.infrastructure.AttendanceFindService
+import co.yappuworld.attendance.infrastructure.LatePassFindService
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.operation.infrastructure.ConfigFindService
 import co.yappuworld.operation.infrastructure.GenerationFindService
@@ -35,13 +36,15 @@ class AttendanceServiceTest :
         val sessionFindService = mockk<SessionFindService>()
         val generationFindService = mockk<GenerationFindService>()
         val userFindService = mockk<UserFindService>()
+        val latePassFindService = mockk<LatePassFindService>()
         val attendanceService = AttendanceService(
             attendanceFindService = attendanceFindService,
             attendanceCommandService = attendanceCommandService,
             configFindService = configFindService,
             sessionFindService = sessionFindService,
             generationFindService = generationFindService,
-            userFindService = userFindService
+            userFindService = userFindService,
+            latePassFindService = latePassFindService
         )
 
         feature("출석 체크") {
@@ -190,6 +193,17 @@ class AttendanceServiceTest :
                             .shouldBe(AttendanceStatus.ABSENT)
                     }
                 }
+            }
+        }
+
+        feature("출석 통계 조회") {
+
+            scenario("활성화된 기수가 없으면 예외가 발생한다.") {
+                every { generationFindService.findActiveGeneration() } returns null
+
+                shouldThrow<BusinessException> {
+                    attendanceService.getAttendanceStatistics(UUID.randomUUID(), LocalDateTime.now())
+                }.error.shouldBe(AttendanceError.NO_ACTIVE_GENERATION)
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/attendance/client/dto/response/AttendanceStatisticsResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/attendance/client/dto/response/AttendanceStatisticsResponseTest.kt
@@ -1,0 +1,116 @@
+package co.yappuworld.attendance.client.dto.response
+
+import co.yappuworld.attendance.domain.AttendanceStatus
+import co.yappuworld.attendance.domain.AttendanceStatus.ABSENT
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceFixture
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import co.yappuworld.support.fixture.UserFixture
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class AttendanceStatisticsResponseTest :
+    FeatureSpec({
+
+        feature("데이터 검증") {
+            val activeGeneration = 25
+            val user = UserFixture.getUserWithLastActivityUnitFixture(generation = activeGeneration)
+            val datetime = LocalDateTime.of(2025, 3, 4, 8, 0, 0)
+            val sessions = listOf(
+                getSessionEntityFixture(date = datetime.toLocalDate().minusDays(1)),
+                getSessionEntityFixture(
+                    date = datetime.toLocalDate(),
+                    endTime = datetime.toLocalTime().minusMinutes(10)
+                ),
+                getSessionEntityFixture(
+                    date = datetime.toLocalDate(),
+                    endTime = datetime.toLocalTime()
+                ),
+                getSessionEntityFixture(
+                    date = datetime.toLocalDate(),
+                    endTime = datetime.toLocalTime().plusMinutes(10)
+                ),
+                getSessionEntityFixture(date = datetime.toLocalDate().plusDays(1))
+            )
+
+            scenario("일자, 시간에 따른 잔여 세션 수와 진행률 검증") {
+                val attendances = sessions.map { getAttendanceFixture(scheduleId = it.id) }
+                AttendanceStatisticsResponse.of(sessions, attendances, datetime, 0).let {
+                    it.totalSessionCount shouldBe 5
+                    it.remainingSessionCount shouldBe 3
+                    it.sessionProgressRate shouldBe 40
+                }
+            }
+
+            scenario("datetime 기준으로 조회를 진행") {
+                val attendances = sessions.map { getAttendanceFixture(scheduleId = it.id) }
+                AttendanceStatisticsResponse
+                    .of(
+                        sessions = sessions,
+                        attendances = attendances,
+                        now = datetime,
+                        latePassCount = 0
+                    ).let {
+                        it.totalSessionCount shouldBe 5
+                        it.remainingSessionCount shouldBe 3
+                        it.sessionProgressRate shouldBe 40
+                        it.attendancePoint shouldBe 100
+                        it.attendanceCount shouldBe 2
+                        it.lateCount shouldBe 0
+                        it.absenceCount shouldBe 0
+                    }
+            }
+
+            scenario("모두 출석이면 출석 점수가 100점이다.") {
+                AttendanceStatisticsResponse
+                    .of(
+                        sessions = sessions,
+                        attendances = sessions.map { getAttendanceFixture(scheduleId = it.id) },
+                        now = datetime,
+                        latePassCount = 0
+                    ).let {
+                        it.totalSessionCount shouldBe 5
+                        it.remainingSessionCount shouldBe 3
+                        it.sessionProgressRate shouldBe 40
+                        it.attendancePoint shouldBe 100
+                        it.attendanceCount shouldBe 2
+                        it.lateCount shouldBe 0
+                        it.absenceCount shouldBe 0
+                    }
+            }
+
+            scenario("지각 횟수당 10점씩 깎인다.") {
+                val attendances = sessions.map { getAttendanceFixture(scheduleId = it.id) }
+                repeat(2) { r ->
+                    attendances[r].updateStatus(AttendanceStatus.LATE)
+                    AttendanceStatisticsResponse.of(sessions, attendances, datetime, 0).let {
+                        it.attendancePoint shouldBe 100 - ((r + 1) * 10)
+                        it.attendanceCount shouldBe 2 - (r + 1)
+                        it.lateCount shouldBe r + 1
+                    }
+                }
+            }
+
+            scenario("결석 횟수당 20점씩 깎인다.") {
+                val attendances = sessions.map { getAttendanceFixture(scheduleId = it.id) }
+                repeat(2) { r ->
+                    attendances[r].updateStatus(ABSENT)
+                    AttendanceStatisticsResponse.of(sessions, attendances, datetime, 0).let {
+                        it.attendancePoint shouldBe 100 - ((r + 1) * 20)
+                        it.attendanceCount shouldBe 2 - (r + 1)
+                        it.absenceCount shouldBe r + 1
+                    }
+                }
+            }
+
+            scenario("지각 면제권 1회당 10점씩 추가된다.") {
+                val attendances = sessions.map { getAttendanceFixture(scheduleId = it.id, status = ABSENT) }
+                repeat(3) { latePassCount ->
+                    AttendanceStatisticsResponse.of(sessions, attendances, datetime, latePassCount).let {
+                        it.latePassCount shouldBe latePassCount
+                        it.attendancePoint shouldBe 60 + latePassCount * 10
+                    }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/operation/client/application/GenerationActiveStateManagerTest.kt
+++ b/src/test/kotlin/co/yappuworld/operation/client/application/GenerationActiveStateManagerTest.kt
@@ -33,8 +33,6 @@ class GenerationActiveStateManagerTest {
     @Test
     @Transactional
     fun `특정 기수를 활성화 시키면 나머지는 모두 비활성화 된다`() {
-        assertThat(generationActiveStateManager.getActiveGenerationOrNull()).isNull()
-
         generationActiveStateManager.activate(23)
         generationActiveStateManager.activate(24)
         generationActiveStateManager.activate(25)
@@ -52,11 +50,6 @@ class GenerationActiveStateManagerTest {
 
         generationActiveStateManager.deactivate(25)
         assertThat(repository.findByIdOrNull(25)?.isActive).isFalse()
-    }
-
-    @Test
-    fun `현재 활성화 되어 있는 기수가 없다면 NULL을 반환한다`() {
-        assertThat(generationActiveStateManager.getActiveGenerationOrNull()).isNull()
     }
 
     @Test


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
마이 페이지의 출석 통계 화면을 위한 기능을 제공합니다.


## ⭐️ 어떻게 해결했나요?
- 이번 기수의 세션과 출석 기록을 조합하여 응답을 생성합니다.
- 지각 면제권은 별도의 테이블을 만들어 관리합니다.
- 빠른 구현을 위해 별도 조인 없이 진행합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
