### PR TITLE
fix: 활동 중인 기수의 세션 목록 조회 시 임박한 세션 정보를 ID로 전달

### DIFF
--- a/src/main/kotlin/co/yappuworld/attendance/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/attendance/client/presentation/AttendanceApi.kt
@@ -194,7 +194,7 @@ interface AttendanceApi {
             )
         ]
     )
-    @GetMapping("/v1/attendance-statistics")
+    @GetMapping("/v1/attendances/statistics")
     fun getAttendanceStatistics(
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<SuccessResponse<AttendanceStatisticsResponse>>

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
@@ -24,7 +24,7 @@ data class ActiveGenerationSessionsResponse(
         """,
         nullable = true
     )
-    val upcomingSessionIndex: Int? = null
+    val upcomingSessionId: UUID? = null
 ) {
 
     companion object {
@@ -38,7 +38,7 @@ data class ActiveGenerationSessionsResponse(
             val (upcomingSessionIndex, upcomingSessionStatus) = getUpcomingSessionIndexAndStatus(orderedSessions, now)
                 ?: return ActiveGenerationSessionsResponse(
                     sessions.map { ActiveGenerationSessionResponse(it, DONE) },
-                    sessions.lastIndex
+                    sessions.last().id
                 )
 
             return ActiveGenerationSessionsResponse(
@@ -49,7 +49,7 @@ data class ActiveGenerationSessionsResponse(
                         else -> ActiveGenerationSessionResponse(session, PENDING)
                     }
                 },
-                upcomingSessionIndex = upcomingSessionIndex
+                upcomingSessionId = sessions[upcomingSessionIndex].id
             )
         }
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -70,7 +70,7 @@ interface ScheduleApi {
                                                     "progressPhase": "DONE"
                                                 }
                                             ],
-                                            "upcomingSessionIndex": 2
+                                            "upcomingSessionId": "5523913c-ff12-11ef-ad31-0242ac120002"
                                         },
                                         "isSuccess": true
                                     }

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleServiceSessionProgressPhaseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleServiceSessionProgressPhaseTest.kt
@@ -59,7 +59,7 @@ class ScheduleServiceSessionProgressPhaseTest {
         assertEquals(result.sessions[0].progressPhase, DONE)
         assertEquals(result.sessions[1].progressPhase, TODAY)
         assertEquals(result.sessions[2].progressPhase, PENDING)
-        assertEquals(result.upcomingSessionId, 1)
+        assertEquals(result.upcomingSessionId, result.sessions[1].id)
     }
 
     @Test
@@ -78,6 +78,6 @@ class ScheduleServiceSessionProgressPhaseTest {
         assertEquals(result.sessions[1].progressPhase, DONE)
         assertEquals(result.sessions[2].progressPhase, UPCOMING)
         assertEquals(result.sessions[3].progressPhase, PENDING)
-        assertEquals(result.upcomingSessionId, 2)
+        assertEquals(result.upcomingSessionId, result.sessions[2].id)
     }
 }

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleServiceSessionProgressPhaseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleServiceSessionProgressPhaseTest.kt
@@ -59,7 +59,7 @@ class ScheduleServiceSessionProgressPhaseTest {
         assertEquals(result.sessions[0].progressPhase, DONE)
         assertEquals(result.sessions[1].progressPhase, TODAY)
         assertEquals(result.sessions[2].progressPhase, PENDING)
-        assertEquals(result.upcomingSessionIndex, 1)
+        assertEquals(result.upcomingSessionId, 1)
     }
 
     @Test
@@ -78,6 +78,6 @@ class ScheduleServiceSessionProgressPhaseTest {
         assertEquals(result.sessions[1].progressPhase, DONE)
         assertEquals(result.sessions[2].progressPhase, UPCOMING)
         assertEquals(result.sessions[3].progressPhase, PENDING)
-        assertEquals(result.upcomingSessionIndex, 2)
+        assertEquals(result.upcomingSessionId, 2)
     }
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 활동 중인 기수의 세션 목록 조회에서 임박한 세션 정보 전달을 위한 매개체를 수정합니다.


## ⭐️ 어떻게 해결했나요?
- 기존에 index로 제공하던 정보를 id로 변경하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
