### PR TITLE
fix: 세션 목록에 출석 상태 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -27,11 +27,15 @@ class ScheduleService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getCurrentGenerationSessions(now: LocalDate): ActiveGenerationSessionsResponse {
+    fun getCurrentGenerationSessions(
+        userId: UUID,
+        now: LocalDate
+    ): ActiveGenerationSessionsResponse {
         val currentGeneration = generationFindService.findActiveGeneration()
             ?: return ActiveGenerationSessionsResponse.from(emptyList(), now)
+        val sessions = sessionFindService.findSessionsWithAttendanceStatus(currentGeneration, userId)
         return ActiveGenerationSessionsResponse.from(
-            sessions = scheduleRepository.findAllSessionEntityByGeneration(currentGeneration),
+            sessions = sessions,
             now = now
         )
     }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
@@ -1,13 +1,14 @@
 package co.yappuworld.schedule.client.dto.response
 
+import co.yappuworld.attendance.domain.AttendanceStatus
 import co.yappuworld.global.util.TimeUtils.isBeforeOrEqual
-import co.yappuworld.schedule.domain.SessionEntity
 import co.yappuworld.schedule.domain.SessionProgressPhase
 import co.yappuworld.schedule.domain.SessionProgressPhase.DONE
 import co.yappuworld.schedule.domain.SessionProgressPhase.PENDING
 import co.yappuworld.schedule.domain.SessionProgressPhase.TODAY
 import co.yappuworld.schedule.domain.SessionProgressPhase.UPCOMING
 import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime
@@ -29,7 +30,7 @@ data class ActiveGenerationSessionsResponse(
 
     companion object {
         fun from(
-            sessions: List<SessionEntity>,
+            sessions: List<SessionWithAttendanceStatus>,
             now: LocalDate
         ): ActiveGenerationSessionsResponse {
             if (sessions.isEmpty()) return ActiveGenerationSessionsResponse(emptyList(), null)
@@ -37,16 +38,19 @@ data class ActiveGenerationSessionsResponse(
             val orderedSessions = sessions.sortedBy { it.date }
             val (upcomingSessionIndex, upcomingSessionStatus) = getUpcomingSessionIndexAndStatus(orderedSessions, now)
                 ?: return ActiveGenerationSessionsResponse(
-                    sessions.map { ActiveGenerationSessionResponse(it, DONE) },
+                    sessions.map { ActiveGenerationSessionResponse.from(it, DONE) },
                     sessions.last().id
                 )
 
             return ActiveGenerationSessionsResponse(
                 sessions = sessions.mapIndexed { index, session ->
                     when {
-                        index < upcomingSessionIndex -> ActiveGenerationSessionResponse(session, DONE)
-                        index == upcomingSessionIndex -> ActiveGenerationSessionResponse(session, upcomingSessionStatus)
-                        else -> ActiveGenerationSessionResponse(session, PENDING)
+                        index < upcomingSessionIndex -> ActiveGenerationSessionResponse.from(session, DONE)
+                        index == upcomingSessionIndex -> ActiveGenerationSessionResponse.from(
+                            session,
+                            upcomingSessionStatus
+                        )
+                        else -> ActiveGenerationSessionResponse.from(session, PENDING)
                     }
                 },
                 upcomingSessionId = sessions[upcomingSessionIndex].id
@@ -54,7 +58,7 @@ data class ActiveGenerationSessionsResponse(
         }
 
         private fun getUpcomingSessionIndexAndStatus(
-            orderedSessions: List<SessionEntity>,
+            orderedSessions: List<SessionWithAttendanceStatus>,
             now: LocalDate
         ): Pair<Int, SessionProgressPhase>? {
             val upcomingSession = orderedSessions.firstOrNull { now.isBeforeOrEqual(it.date) }
@@ -70,26 +74,52 @@ data class ActiveGenerationSessionsResponse(
 }
 
 data class ActiveGenerationSessionResponse(
+    @Schema(description = "세션 식별자")
     val id: UUID,
+    @Schema(description = "세션 이름")
     val name: String,
+    @Schema(description = "세션 장소", nullable = true)
     val place: String?,
+    @Schema(description = "세션 시작일", nullable = true)
     val date: LocalDate,
+    @Schema(description = "세션 종료일", nullable = true)
     val endDate: LocalDate?,
+    @Schema(description = "세션 시작 시간", nullable = true)
     val time: LocalTime?,
+    @Schema(description = "세션 종료 시간", nullable = true)
     val endTime: LocalTime?,
+    @Schema(description = "세션 타입")
     val type: SessionType,
-    val progressPhase: SessionProgressPhase
+    @Schema(description = "세션 진행 상태")
+    val progressPhase: SessionProgressPhase,
+    @Schema(description = "출석 상태", nullable = true, allowableValues = ["출석", "지각", "결석", "조퇴", "공결"])
+    val attendanceStatus: String?
 ) {
 
-    constructor(session: SessionEntity, status: SessionProgressPhase) : this(
-        id = session.id,
-        name = session.name,
-        place = session.place,
-        date = session.date,
-        endDate = session.endDate,
-        time = session.time,
-        endTime = session.endTime,
-        type = session.sessionType,
-        progressPhase = status
-    )
+    companion object {
+
+        fun from(
+            session: SessionWithAttendanceStatus,
+            status: SessionProgressPhase
+        ): ActiveGenerationSessionResponse {
+            val attendanceStatus = if (session.attendanceStatus == null && status == DONE) {
+                AttendanceStatus.ABSENT
+            } else {
+                session.attendanceStatus
+            }
+
+            return ActiveGenerationSessionResponse(
+                id = session.id,
+                name = session.name,
+                place = session.place,
+                date = session.date,
+                endDate = session.endDate,
+                time = session.time,
+                endTime = session.endTime,
+                type = session.sessionType,
+                progressPhase = status,
+                attendanceStatus = attendanceStatus?.let { it.label }
+            )
+        }
+    }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
@@ -8,7 +8,7 @@ import co.yappuworld.schedule.domain.SessionProgressPhase.PENDING
 import co.yappuworld.schedule.domain.SessionProgressPhase.TODAY
 import co.yappuworld.schedule.domain.SessionProgressPhase.UPCOMING
 import co.yappuworld.schedule.domain.SessionType
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceStatus
+import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendance
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime
@@ -30,7 +30,7 @@ data class ActiveGenerationSessionsResponse(
 
     companion object {
         fun from(
-            sessions: List<SessionWithAttendanceStatus>,
+            sessions: List<SessionWithAttendance>,
             now: LocalDate
         ): ActiveGenerationSessionsResponse {
             if (sessions.isEmpty()) return ActiveGenerationSessionsResponse(emptyList(), null)
@@ -58,7 +58,7 @@ data class ActiveGenerationSessionsResponse(
         }
 
         private fun getUpcomingSessionIndexAndStatus(
-            orderedSessions: List<SessionWithAttendanceStatus>,
+            orderedSessions: List<SessionWithAttendance>,
             now: LocalDate
         ): Pair<Int, SessionProgressPhase>? {
             val upcomingSession = orderedSessions.firstOrNull { now.isBeforeOrEqual(it.date) }
@@ -99,7 +99,7 @@ data class ActiveGenerationSessionResponse(
     companion object {
 
         fun from(
-            session: SessionWithAttendanceStatus,
+            session: SessionWithAttendance,
             status: SessionProgressPhase
         ): ActiveGenerationSessionResponse {
             val attendanceStatus = if (session.attendanceStatus == null && status == DONE) {

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -45,7 +45,8 @@ interface ScheduleApi {
                                                     "time": "14:00:00",
                                                     "endTime": "18:00:00",
                                                     "type": "OFFLINE",
-                                                    "progressPhase": "DONE"
+                                                    "progressPhase": "DONE",
+                                                    "attendanceStatus": "출석"
                                                 },
                                                 {
                                                     "id": "552390a8-ff12-11ef-ad31-0242ac120002",
@@ -56,7 +57,8 @@ interface ScheduleApi {
                                                     "time": null,
                                                     "endTime": null,
                                                     "type": "TEAM",
-                                                    "progressPhase": "DONE"
+                                                    "progressPhase": "DONE",
+                                                    "attendanceStatus": "지각"
                                                 },
                                                 {
                                                     "id": "5523913c-ff12-11ef-ad31-0242ac120002",
@@ -67,7 +69,8 @@ interface ScheduleApi {
                                                     "time": "14:00:00",
                                                     "endTime": "18:00:00",
                                                     "type": "OFFLINE",
-                                                    "progressPhase": "DONE"
+                                                    "progressPhase": "DONE",
+                                                    "attendanceStatus": "결석"
                                                 }
                                             ],
                                             "upcomingSessionId": "5523913c-ff12-11ef-ad31-0242ac120002"
@@ -83,7 +86,9 @@ interface ScheduleApi {
         ]
     )
     @GetMapping("/v1/sessions")
-    fun getSessions(): ResponseEntity<SuccessResponse<ActiveGenerationSessionsResponse>>
+    fun getSessions(
+        @AuthenticationPrincipal securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<ActiveGenerationSessionsResponse>>
 
     @Operation(summary = "일정 조회")
     @ApiResponses(

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleController.kt
@@ -9,6 +9,7 @@ import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsRespon
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.UpcomingSessionAttendanceResponse
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -16,11 +17,13 @@ class ScheduleController(
     private val scheduleService: ScheduleService
 ) : ScheduleApi {
 
-    override fun getSessions(): ResponseEntity<SuccessResponse<ActiveGenerationSessionsResponse>> {
+    override fun getSessions(
+        @AuthenticationPrincipal securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<ActiveGenerationSessionsResponse>> {
         val now = TimeUtils.getCurrentDateTimeInKST()
         return ResponseEntity.ok(
             SuccessResponse(
-                scheduleService.getCurrentGenerationSessions(now.toLocalDate())
+                scheduleService.getCurrentGenerationSessions(securityUser.userId, now.toLocalDate())
             )
         )
     }

--- a/src/main/kotlin/co/yappuworld/schedule/domain/SessionProgressPhase.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/SessionProgressPhase.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.schedule.domain
 
 enum class SessionProgressPhase(
-    private val label: String
+    val label: String
 ) {
     DONE("완료"),
     TODAY("당일"),

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
@@ -1,6 +1,8 @@
 package co.yappuworld.schedule.infrastructure
 
+import co.yappuworld.attendance.domain.Attendance
 import co.yappuworld.schedule.domain.SessionEntity
+import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceStatus
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -37,5 +39,34 @@ class SessionFindService(
                 select(entity(SessionEntity::class))
                     .from(entity(SessionEntity::class))
                     .where(path(SessionEntity::generation).equal(generation))
+            }.filterNotNull()
+
+    fun findSessionsWithAttendanceStatus(
+        generation: Int,
+        userId: UUID
+    ): List<SessionWithAttendanceStatus> =
+        scheduleRepository
+            .findAll {
+                selectNew<SessionWithAttendanceStatus>(
+                    path(SessionEntity::getId),
+                    path(SessionEntity::name),
+                    path(SessionEntity::description),
+                    path(SessionEntity::place),
+                    path(SessionEntity::date),
+                    path(SessionEntity::endDate),
+                    path(SessionEntity::time),
+                    path(SessionEntity::endTime),
+                    path(SessionEntity::generation),
+                    path(SessionEntity::sessionType),
+                    path(Attendance::status)
+                ).from(
+                    entity(SessionEntity::class),
+                    leftJoin(Attendance::class).on(
+                        and(
+                            path(SessionEntity::getId).equal(path(Attendance::scheduleId)),
+                            path(Attendance::userId).equal(userId)
+                        )
+                    )
+                )
             }.filterNotNull()
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
@@ -2,7 +2,7 @@ package co.yappuworld.schedule.infrastructure
 
 import co.yappuworld.attendance.domain.Attendance
 import co.yappuworld.schedule.domain.SessionEntity
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceStatus
+import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendance
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -44,10 +44,10 @@ class SessionFindService(
     fun findSessionsWithAttendanceStatus(
         generation: Int,
         userId: UUID
-    ): List<SessionWithAttendanceStatus> =
+    ): List<SessionWithAttendance> =
         scheduleRepository
             .findAll {
-                selectNew<SessionWithAttendanceStatus>(
+                selectNew<SessionWithAttendance>(
                     path(SessionEntity::getId),
                     path(SessionEntity::name),
                     path(SessionEntity::description),

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendance.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendance.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 
-data class SessionWithAttendanceStatus(
+data class SessionWithAttendance(
     val id: UUID,
     val name: String,
     val description: String?,

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceStatus.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceStatus.kt
@@ -1,0 +1,21 @@
+package co.yappuworld.schedule.infrastructure.dto
+
+import co.yappuworld.attendance.domain.AttendanceStatus
+import co.yappuworld.schedule.domain.SessionType
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+
+data class SessionWithAttendanceStatus(
+    val id: UUID,
+    val name: String,
+    val description: String?,
+    val place: String?,
+    val date: LocalDate,
+    val endDate: LocalDate,
+    val time: LocalTime?,
+    val endTime: LocalTime?,
+    val generation: Int,
+    val sessionType: SessionType,
+    val attendanceStatus: AttendanceStatus?
+)

--- a/src/main/kotlin/co/yappuworld/user/client/dto/response/UserActivityHistoriesResponse.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/dto/response/UserActivityHistoriesResponse.kt
@@ -26,7 +26,7 @@ data class UserActivityHistoryResponse(
     val generation: Int,
     @Schema(
         description = "직군",
-        allowableValues = ["PM", "Design", "Web", "Android", "iOS", "Flutter", "Server", "Staff"]
+        allowableValues = ["PM", "Design", "Web", "Android", "iOS", "Flutter", "Server", "운영진"]
     )
     val position: String,
     @Schema(description = "활동 시작일", nullable = true)

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserProfileApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserProfileApi.kt
@@ -66,7 +66,7 @@ interface UserProfileApi {
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<SuccessResponse<UserProfileResponse>>
 
-    @Operation(summary = "활동이력 조회")
+    @Operation(summary = "활동 이력 조회")
     @ApiResponses(
         value = [
             ApiResponse(

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleServiceSessionProgressPhaseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleServiceSessionProgressPhaseTest.kt
@@ -2,13 +2,13 @@ package co.yappuworld.schedule.client.application
 
 import co.yappuworld.attendance.infrastructure.AttendanceFindService
 import co.yappuworld.operation.infrastructure.GenerationFindService
-import co.yappuworld.schedule.domain.SessionEntity
 import co.yappuworld.schedule.domain.SessionProgressPhase.DONE
 import co.yappuworld.schedule.domain.SessionProgressPhase.PENDING
 import co.yappuworld.schedule.domain.SessionProgressPhase.TODAY
 import co.yappuworld.schedule.domain.SessionProgressPhase.UPCOMING
 import co.yappuworld.schedule.infrastructure.ScheduleRepository
 import co.yappuworld.schedule.infrastructure.SessionFindService
+import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendance
 import co.yappuworld.support.fixture.ScheduleFixture
 import co.yappuworld.user.infrastructure.UserFindService
 import io.mockk.every
@@ -16,6 +16,7 @@ import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.util.UUID
 import kotlin.test.assertEquals
 
 class ScheduleServiceSessionProgressPhaseTest {
@@ -41,21 +42,21 @@ class ScheduleServiceSessionProgressPhaseTest {
         every { generationFindService.findActiveGeneration() } returns generation
     }
 
-    fun mockScheduleRepository(schedules: List<SessionEntity>) {
-        every { scheduleRepository.findAllSessionEntityByGeneration(generation) } returns schedules
+    fun mockScheduleRepository(schedules: List<SessionWithAttendance>) {
+        every { sessionFindService.findSessionsWithAttendanceStatus(generation, any()) } returns schedules
     }
 
     @Test
     fun `지난 건 DONE, 오늘 건 TODAY, 남은 건 PENDING이다`() {
         mockScheduleRepository(
             listOf(
-                ScheduleFixture.getSessionEntityFixture(date = now.minusDays(1)),
-                ScheduleFixture.getSessionEntityFixture(date = now),
-                ScheduleFixture.getSessionEntityFixture(date = now.plusDays(3))
+                ScheduleFixture.getSessionWithAttendanceFixture(date = now.minusDays(1)),
+                ScheduleFixture.getSessionWithAttendanceFixture(date = now),
+                ScheduleFixture.getSessionWithAttendanceFixture(date = now.plusDays(3))
             )
         )
 
-        val result = scheduleService.getCurrentGenerationSessions(now)
+        val result = scheduleService.getCurrentGenerationSessions(UUID.randomUUID(), now)
         assertEquals(result.sessions[0].progressPhase, DONE)
         assertEquals(result.sessions[1].progressPhase, TODAY)
         assertEquals(result.sessions[2].progressPhase, PENDING)
@@ -66,14 +67,14 @@ class ScheduleServiceSessionProgressPhaseTest {
     fun `지난 건 DONE, 임박한 건 UPCOMING, 남은 건 PENDING이다`() {
         mockScheduleRepository(
             listOf(
-                ScheduleFixture.getSessionEntityFixture(date = now.minusDays(2)),
-                ScheduleFixture.getSessionEntityFixture(date = now.minusDays(1)),
-                ScheduleFixture.getSessionEntityFixture(date = now.plusDays(1)),
-                ScheduleFixture.getSessionEntityFixture(date = now.plusDays(3))
+                ScheduleFixture.getSessionWithAttendanceFixture(date = now.minusDays(2)),
+                ScheduleFixture.getSessionWithAttendanceFixture(date = now.minusDays(1)),
+                ScheduleFixture.getSessionWithAttendanceFixture(date = now.plusDays(1)),
+                ScheduleFixture.getSessionWithAttendanceFixture(date = now.plusDays(3))
             )
         )
 
-        val result = scheduleService.getCurrentGenerationSessions(now)
+        val result = scheduleService.getCurrentGenerationSessions(UUID.randomUUID(), now)
         assertEquals(result.sessions[0].progressPhase, DONE)
         assertEquals(result.sessions[1].progressPhase, DONE)
         assertEquals(result.sessions[2].progressPhase, UPCOMING)

--- a/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
@@ -1,10 +1,13 @@
 package co.yappuworld.support.fixture
 
+import co.yappuworld.attendance.domain.AttendanceStatus
 import co.yappuworld.schedule.domain.SessionEntity
 import co.yappuworld.schedule.domain.SessionType
 import co.yappuworld.schedule.domain.TaskEntity
+import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendance
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.UUID
 
 object ScheduleFixture {
 
@@ -49,4 +52,31 @@ object ScheduleFixture {
         time = time,
         endTime = endTime
     )
+
+    fun getSessionWithAttendanceFixture(
+        id: UUID = UUID.randomUUID(),
+        name: String = "세션 이름",
+        description: String? = "세션 설명",
+        place: String? = "세션 장소",
+        date: LocalDate = LocalDate.of(2025, 2, 15),
+        endDate: LocalDate = LocalDate.of(2025, 2, 15),
+        time: LocalTime? = LocalTime.of(14, 0),
+        endTime: LocalTime? = LocalTime.of(18, 0),
+        generation: Int = 25,
+        sessionType: SessionType = SessionType.OFFLINE,
+        attendanceStatus: AttendanceStatus? = AttendanceStatus.ON_TIME
+    ): SessionWithAttendance =
+        SessionWithAttendance(
+            id = id,
+            name = name,
+            description = description,
+            place = place,
+            date = date,
+            endDate = endDate,
+            time = time,
+            endTime = endTime,
+            generation = generation,
+            sessionType = sessionType,
+            attendanceStatus = attendanceStatus
+        )
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 세션 내역에서 출석 정보가 노출되어야 합니다.


## ⭐️ 어떻게 해결했나요?
- 이미 종료된 세션은 출석 정보가 노출되며, 만약 출석 정보가 없는 경우에는 '결석'을 노출합니다.
- 아직 끝나지 않은 세션은 null로 반환합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료
![image](https://github.com/user-attachments/assets/7bc23fa4-f5a2-4062-aca1-b02191745f5c)



## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
