### PR TITLE
fix: 스웨거 스키마 노출

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/config/SwaggerCommonResponses.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SwaggerCommonResponses.kt
@@ -1,17 +1,21 @@
 package co.yappuworld.global.config
 
+import io.swagger.v3.oas.models.SpecVersion
 import io.swagger.v3.oas.models.examples.Example
 import io.swagger.v3.oas.models.media.Content
 import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.responses.ApiResponse
 
-data class SwaggerCommonResponse(
-    val code: String,
-    val apiResponse: ApiResponse
-)
-
 object SwaggerCommonResponses {
-    val v = mapOf(
+
+    private val errorResponseSchema = Schema<String>(SpecVersion.V30).apply {
+        `$ref` = "#/components/schemas/ErrorResponse"
+    }
+
+    fun hasErrorResponse(status: String) = errorResponses.containsKey(status)
+
+    val errorResponses = mapOf(
         "400" to ApiResponse().apply {
             description = "Bad Request"
             content = Content().apply {
@@ -29,6 +33,7 @@ object SwaggerCommonResponses {
                                 """.trimIndent()
                             }
                         )
+                        schema = errorResponseSchema
                     }
                 )
             }
@@ -59,6 +64,7 @@ object SwaggerCommonResponses {
                                 """.trimIndent()
                             }
                         )
+                        schema = errorResponseSchema
                     }
                 )
             }
@@ -80,6 +86,7 @@ object SwaggerCommonResponses {
                                 """.trimIndent()
                             }
                         )
+                        schema = errorResponseSchema
                     }
                 )
             }

--- a/src/main/kotlin/co/yappuworld/global/response/ErrorResponse.kt
+++ b/src/main/kotlin/co/yappuworld/global/response/ErrorResponse.kt
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class ErrorResponse(
     @Schema(description = "메세지")
     val message: String,
-    @Schema(description = "에러코드")
+    @Schema(description = "에러 코드", nullable = true)
     val errorCode: String?
 ) : Response() {
 

--- a/src/main/kotlin/co/yappuworld/global/util/SwaggerUtils.kt
+++ b/src/main/kotlin/co/yappuworld/global/util/SwaggerUtils.kt
@@ -14,68 +14,67 @@ object SwaggerUtils {
         OpenApiCustomizer { openApi ->
             openApi.paths.values.forEach { item ->
                 item.readOperations().forEach { operation ->
-                    operation.responses.addCommonResponse()
+                    operation.responses.appendAndOrganizeResponse()
                 }
             }
         }
 
-    private fun ApiResponses.addCommonResponse() {
+    private fun ApiResponses.appendAndOrganizeResponse() {
+        // API에 명시된 응답을 순회
         for ((status, response) in this) {
             if (response.content == null) {
                 continue
             }
 
-            val commonResponse = SwaggerCommonResponses.v[status]
-            when (commonResponse == null) {
-                true -> {
-                    val examples = mutableMapOf<String, Example>().apply {
-                        response.content.values.forEach { mediaType ->
-                            mediaType.examples?.let { putAll(it) }
-                            mediaType.example?.let {
-                                put("성공", Example().apply { value = it })
-                            }
-                        }
-                    }
-
-                    val content = Content().apply {
-                        addMediaType(
-                            "application/json",
-                            MediaType().apply { setExamples(examples) }
-                        )
-                    }
-
-                    response.content = content
-                }
-                false -> response.combineContent(commonResponse)
+            when (SwaggerCommonResponses.hasErrorResponse(status)) {
+                true -> response.addCommonErrorResponse(status)
+                false -> response.refineResponse()
             }
         }
 
-        for ((status, response) in SwaggerCommonResponses.v) {
+        // Error를 순회하며 추가되지 않은 공통 에러 응답을 추가
+        for ((status, response) in SwaggerCommonResponses.errorResponses) {
             if (this[status] == null) {
                 this.addApiResponse(status, response)
             }
         }
     }
 
-    private fun ApiResponse.combineContent(response: ApiResponse): ApiResponse {
-        val examples = mutableMapOf<String, Example>()
-        this.content.values.forEach { value ->
-            if (value.examples != null) {
-                examples.putAll(value.examples)
-            }
+    private fun ApiResponse.addCommonErrorResponse(status: String): ApiResponse {
+        val newExamples = mutableMapOf<String, Example>()
+
+        this.content.values.forEach { mediaType ->
+            mediaType.example?.let { newExamples["성공"] = Example().apply { value = it } }
+            mediaType.examples?.let { newExamples.putAll(it) }
         }
-        response.content.values.forEach {
-            if (it.examples != null) {
-                examples.putAll(it.examples)
+
+        SwaggerCommonResponses.errorResponses[status]?.let { errorResponse ->
+            errorResponse.content.values.forEach { mediaType ->
+                mediaType.examples?.let { newExamples.putAll(it) }
             }
         }
 
+        replaceWith(newExamples)
+
+        return this
+    }
+
+    private fun ApiResponse.refineResponse() =
+        replaceWith(
+            mutableMapOf<String, Example>().apply {
+                content.values.forEach { mediaType ->
+                    mediaType.examples?.let { putAll(it) }
+                    mediaType.example?.let { put("성공", Example().apply { value = it }) }
+                }
+            }
+        )
+
+    private fun ApiResponse.replaceWith(examples: Map<String, Example>) {
         this.content = Content().apply {
             addMediaType(
                 "application/json",
                 MediaType().apply { setExamples(examples) }
             )
         }
-        return this
     }
 }

--- a/src/main/kotlin/co/yappuworld/global/util/SwaggerUtils.kt
+++ b/src/main/kotlin/co/yappuworld/global/util/SwaggerUtils.kt
@@ -1,9 +1,11 @@
 package co.yappuworld.global.util
 
 import co.yappuworld.global.config.SwaggerCommonResponses
+import io.swagger.v3.oas.models.SpecVersion
 import io.swagger.v3.oas.models.examples.Example
 import io.swagger.v3.oas.models.media.Content
 import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.responses.ApiResponses
 import org.springdoc.core.customizers.OpenApiCustomizer
@@ -44,7 +46,6 @@ object SwaggerUtils {
         val newExamples = mutableMapOf<String, Example>()
 
         this.content.values.forEach { mediaType ->
-            mediaType.example?.let { newExamples["성공"] = Example().apply { value = it } }
             mediaType.examples?.let { newExamples.putAll(it) }
         }
 
@@ -54,27 +55,66 @@ object SwaggerUtils {
             }
         }
 
-        replaceWith(newExamples)
+        replaceWith(newExamples, "#/components/schemas/ErrorResponse")
 
         return this
     }
 
-    private fun ApiResponse.refineResponse() =
-        replaceWith(
-            mutableMapOf<String, Example>().apply {
-                content.values.forEach { mediaType ->
-                    mediaType.examples?.let { putAll(it) }
-                    mediaType.example?.let { put("성공", Example().apply { value = it }) }
-                }
+    private fun ApiResponse.refineResponse() {
+        val refs = mutableListOf<String>()
+        val examples = mutableMapOf<String, Example>().apply {
+            content.values.forEach { mediaType ->
+                mediaType.examples?.let { putAll(it) }
+                mediaType.example?.let { put("성공", Example().apply { value = it }) }
+                refs.addAll(collectAllRefs(mediaType.schema))
             }
-        )
+        }
 
-    private fun ApiResponse.replaceWith(examples: Map<String, Example>) {
+        replaceWith(
+            examples,
+            refs.maxByOrNull { it.length }
+        )
+    }
+
+    private fun ApiResponse.replaceWith(
+        examples: Map<String, Example>,
+        schemaRef: String? = null
+    ) {
         this.content = Content().apply {
             addMediaType(
                 "application/json",
-                MediaType().apply { setExamples(examples) }
+                MediaType().apply {
+                    schema = Schema<String>(SpecVersion.V30).apply { `$ref` = schemaRef }
+                    setExamples(examples)
+                }
             )
         }
+    }
+
+    private fun collectAllRefs(schema: Schema<*>?): Set<String> {
+        val refs = mutableSetOf<String>()
+        val visited = mutableSetOf<Schema<*>>() // 순환 참조 방지
+
+        fun traverse(current: Schema<*>?) {
+            if (current == null || current in visited) return
+            visited += current
+
+            // ref가 있으면 더 이상 내려가지 않음
+            current.`$ref`?.let {
+                refs += it
+                return
+            }
+
+            current.items?.let { traverse(it) }
+            current.allOf?.forEach(::traverse)
+            current.anyOf?.forEach(::traverse)
+            current.oneOf?.forEach(::traverse)
+            current.properties?.values?.forEach(::traverse)
+            val additional = current.additionalProperties
+            if (additional is Schema<*>) traverse(additional)
+        }
+
+        traverse(schema)
+        return refs
     }
 }

--- a/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminOperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminOperationApi.kt
@@ -1,14 +1,13 @@
 package co.yappuworld.operation.client.presentation
 
 import co.yappuworld.global.response.SuccessResponse
-import co.yappuworld.operation.client.dto.request.AdminOperationLinkUpdateRequest
-import co.yappuworld.operation.client.dto.response.AdminOperationLinksResponse
 import co.yappuworld.operation.client.dto.request.AdminMinSupportVersionUpdateRequest
+import co.yappuworld.operation.client.dto.request.AdminOperationLinkUpdateRequest
 import co.yappuworld.operation.client.dto.response.AdminMinSupportVersionResponse
+import co.yappuworld.operation.client.dto.response.AdminOperationLinksResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -25,10 +24,9 @@ interface AdminOperationApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 value = """
@@ -77,10 +75,9 @@ interface AdminOperationApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 value = """

--- a/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminUserOperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminUserOperationApi.kt
@@ -1,11 +1,12 @@
 package co.yappuworld.operation.client.presentation
 
+import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
-import co.yappuworld.operation.client.dto.request.AdminSignupCodeDeleteRequest
 import co.yappuworld.operation.client.dto.request.AdminGenerationActiveUpdateRequest
 import co.yappuworld.operation.client.dto.request.AdminGenerationPageRequest
 import co.yappuworld.operation.client.dto.request.AdminGenerationRegisterRequest
+import co.yappuworld.operation.client.dto.request.AdminSignupCodeDeleteRequest
 import co.yappuworld.operation.client.dto.response.AdminGenerationActiveUpdateResponse
 import co.yappuworld.operation.client.dto.response.AdminGenerationResponse
 import co.yappuworld.user.client.dto.request.AdminSignUpCodeUpdateRequest
@@ -33,12 +34,10 @@ interface AdminUserOperationApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = OffsetPageResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "직군 데이터 조회",
@@ -85,7 +84,6 @@ interface AdminUserOperationApi {
             ApiResponse(
                 description = "성공",
                 responseCode = "201",
-                useReturnTypeSchema = true,
                 content = [Content()]
             )
         ]
@@ -99,7 +97,6 @@ interface AdminUserOperationApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "OK",
                 responseCode = "200",
                 useReturnTypeSchema = true,
                 content = [
@@ -146,11 +143,10 @@ interface AdminUserOperationApi {
                 ]
             ),
             ApiResponse(
-                description = "Not Found",
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "존재하지 않는 기수",
@@ -167,11 +163,10 @@ interface AdminUserOperationApi {
                 ]
             ),
             ApiResponse(
-                description = "Conflict",
                 responseCode = "409",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "활성화 정합성 오류",
@@ -198,8 +193,8 @@ interface AdminUserOperationApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
                         examples = [
@@ -261,7 +256,6 @@ interface AdminUserOperationApi {
     @Operation(summary = "인증번호 수정")
     @ApiResponse(
         responseCode = "204",
-        description = "No Content",
         content = [Content()]
     )
     @PatchMapping("/admin/v1/auth/authentication-codes")
@@ -272,7 +266,6 @@ interface AdminUserOperationApi {
     @Operation(summary = "인증번호 삭제")
     @ApiResponse(
         responseCode = "204",
-        description = "No Content",
         content = [Content()]
     )
     @DeleteMapping("/admin/v1/auth/authentication-codes")

--- a/src/main/kotlin/co/yappuworld/operation/client/presentation/OperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/presentation/OperationApi.kt
@@ -22,6 +22,36 @@ import org.springframework.web.bind.annotation.GetMapping
 interface OperationApi {
 
     @Operation(summary = "직군 정보")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "직군 정보 조회 성공",
+                                value = """
+                                    {
+                                        "data": {
+                                            "positions": [
+                                                {
+                                                    "name": "PM",
+                                                    "label": "PM"
+                                                }
+                                            ]
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
     @GetMapping("/v1/operations/positions")
     fun getPositions(): ResponseEntity<SuccessResponse<PositionsResponse>>
 
@@ -29,12 +59,10 @@ interface OperationApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "강제 업데이트 필요",
@@ -65,7 +93,6 @@ interface OperationApi {
             ApiResponse(
                 description = "잘못된 포맷 요청",
                 responseCode = "400",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -95,12 +122,10 @@ interface OperationApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "활동 중일 때",
@@ -136,14 +161,89 @@ interface OperationApi {
     fun getActiveGeneration(): ResponseEntity<SuccessResponse<ActiveGenerationResponse>>
 
     @Operation(summary = "이용 문의 링크")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "이용 문의 링크 조회",
+                                value = """
+                                    {
+                                        "data": {
+                                            "link": "https://yapp.co.kr"
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
     @GetMapping("/v1/operations/links/usage-inquiry")
     fun getUsageInquiryLink(): ResponseEntity<SuccessResponse<OperationLinkResponse>>
 
     @Operation(summary = "이용 약관 링크")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "이용 약관 링크 조회",
+                                value = """
+                                    {
+                                        "data": {
+                                            "link": "https://yapp.co.kr"
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
     @GetMapping("/v1/operations/links/terms-of-service")
     fun getTermsOfServiceLink(): ResponseEntity<SuccessResponse<OperationLinkResponse>>
 
     @Operation(summary = "개인정보 처리방침 링크")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "개인정보 처리방침 링크 조회",
+                                value = """
+                                    {
+                                        "data": {
+                                            "link": "https://yapp.co.kr"
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
     @GetMapping("/v1/operations/links/privacy-policy")
     fun getPrivacyPolicyLink(): ResponseEntity<SuccessResponse<OperationLinkResponse>>
 }

--- a/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeCreateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeCreateRequest.kt
@@ -1,13 +1,18 @@
 package co.yappuworld.post.client.dto.request
 
 import co.yappuworld.post.domain.NoticeType
+import io.swagger.v3.oas.annotations.media.Schema
 import org.hibernate.validator.constraints.Length
 
 data class AdminNoticeCreateRequest(
+    @Schema(description = "공지 타입")
     val type: NoticeType,
+    @Schema(description = "제목")
     @field:Length(max = 50, message = "제목은 50자 이하여야 합니다.")
     val title: String,
+    @Schema(description = "마크다운 형태 내용")
     @field:Length(max = 5000, message = "내용은 5000자 이하여야 합니다.")
     val content: String,
+    @Schema(description = "평문 형태 내용")
     val plainContent: String
 )

--- a/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeUpdateRequest.kt
@@ -1,15 +1,21 @@
 package co.yappuworld.post.client.dto.request
 
 import co.yappuworld.post.domain.NoticeType
+import io.swagger.v3.oas.annotations.media.Schema
 import org.hibernate.validator.constraints.Length
 import java.util.UUID
 
 data class AdminNoticeUpdateRequest(
+    @Schema(description = "공지사항 ID")
     val id: UUID,
+    @Schema(description = "공지사항 타입")
     val type: NoticeType,
+    @Schema(description = "공지사항 제목")
     @field:Length(max = 50, message = "제목은 50자 이하여야 합니다.")
     val title: String,
+    @Schema(description = "마크다운 형태 내용")
     @field:Length(max = 5000, message = "내용은 5000자 이하여야 합니다.")
     val content: String,
+    @Schema(description = "평문 형태 내용")
     val plainContent: String
 )

--- a/src/main/kotlin/co/yappuworld/post/client/dto/response/AdminNoticeDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/response/AdminNoticeDetailResponse.kt
@@ -2,14 +2,21 @@ package co.yappuworld.post.client.dto.response
 
 import co.yappuworld.post.domain.NoticeType
 import co.yappuworld.user.domain.model.UserEntity
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 data class AdminNoticeDetailResponse(
+    @Schema(description = "공지사항 ID")
     val noticeId: UUID,
+    @Schema(description = "공지사항 작성일")
     val createdAt: String,
+    @Schema(description = "공지사항 제목")
     val title: String,
+    @Schema(description = "공지사항 내용")
     val content: String,
+    @Schema(description = "공지사항 타입")
     val type: NoticeType,
+    @Schema(description = "공지사항 작성자")
     val writer: AdminNoticeDetailWriterResponse
 )
 

--- a/src/main/kotlin/co/yappuworld/post/client/dto/response/AdminNoticeSummaryResponse.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/response/AdminNoticeSummaryResponse.kt
@@ -2,14 +2,20 @@ package co.yappuworld.post.client.dto.response
 
 import co.yappuworld.post.domain.NoticeEntity
 import co.yappuworld.user.domain.model.UserEntity
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 import java.util.UUID
 
 data class AdminNoticeSummaryResponse(
+    @Schema(description = "공지사항 ID")
     val noticeId: String,
+    @Schema(description = "공지사항 제목")
     val title: String,
+    @Schema(description = "공지사항 생성일")
     val createdAt: LocalDateTime,
+    @Schema(description = "공지사항 작성자")
     val writer: AdminNoticeSummaryWriterResponse,
+    @Schema(description = "공지사항 타입")
     val noticeType: String
 ) {
     constructor(notice: NoticeEntity, user: UserEntity) : this(
@@ -22,7 +28,9 @@ data class AdminNoticeSummaryResponse(
 }
 
 data class AdminNoticeSummaryWriterResponse(
+    @Schema(description = "작성자 ID")
     val userId: UUID,
+    @Schema(description = "작성자 이름")
     val name: String
 ) {
     constructor(user: UserEntity) : this(user.id, user.name)

--- a/src/main/kotlin/co/yappuworld/post/client/presentation/AdminNoticeApi.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/presentation/AdminNoticeApi.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.post.client.presentation
 
+import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
@@ -51,6 +52,14 @@ interface AdminNoticeApi {
     ): ResponseEntity<Unit>
 
     @Operation(summary = "공지사항 수정")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                content = [Content()]
+            )
+        ]
+    )
     @PutMapping("/admin/v1/notices")
     fun updateNotice(
         @Valid @RequestBody request: AdminNoticeUpdateRequest
@@ -67,7 +76,7 @@ interface AdminNoticeApi {
                 responseCode = "404",
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "존재하지 않는 공지사항이 요청에 포함",

--- a/src/main/kotlin/co/yappuworld/post/client/presentation/NoticeApi.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/presentation/NoticeApi.kt
@@ -1,6 +1,7 @@
 package co.yappuworld.post.client.presentation
 
 import co.yappuworld.global.response.CursorPageResponse
+import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.post.client.dto.request.NoticePageRequest
 import co.yappuworld.post.client.dto.response.NoticeOverviewResponse
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,9 +28,9 @@ interface NoticeApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "공지사항 리스트 조회 결과",
@@ -71,7 +73,7 @@ interface NoticeApi {
     )
     @GetMapping("/v1/posts/notices")
     fun getNotices(
-        @ParameterObject request: NoticePageRequest
+        @Valid @ParameterObject request: NoticePageRequest
     ): ResponseEntity<SuccessResponse<CursorPageResponse<NoticeOverviewResponse, UUID>>>
 
     @Operation(summary = "공지사항 상세 조회")
@@ -79,9 +81,9 @@ interface NoticeApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "공지사항 상세 조회",
@@ -117,7 +119,7 @@ interface NoticeApi {
                 responseCode = "404",
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "해당 게시물이 존재하지 않습니다.",

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.client.presentation
 
+import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
@@ -33,6 +34,7 @@ interface AttendanceApi {
                 responseCode = "400",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "출석코드 오류",
@@ -62,6 +64,7 @@ interface AttendanceApi {
                 responseCode = "404",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "출석 대상 세션 오류",
@@ -81,6 +84,7 @@ interface AttendanceApi {
                 responseCode = "409",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "이미 출석을 완료",
@@ -120,6 +124,7 @@ interface AttendanceApi {
                 responseCode = "500",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "출석 코드 설정 에러",
@@ -148,9 +153,9 @@ interface AttendanceApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = AttendanceStatisticsResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "출석 통계 조회",
@@ -178,6 +183,7 @@ interface AttendanceApi {
                 responseCode = "404",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "활성화 된 기수가 없어 출석 통계 조회 불가",
@@ -205,9 +211,9 @@ interface AttendanceApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = AttendancesHistoryResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "출석 내역 조회",
@@ -247,6 +253,7 @@ interface AttendanceApi {
                 responseCode = "409",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "활성화 된 기수 없음",

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.client.presentation
 
+import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.schedule.client.dto.request.AdminSessionCreateRequest
@@ -11,6 +12,7 @@ import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -47,6 +49,7 @@ interface ScheduleAdminApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
                         examples = [
@@ -102,6 +105,7 @@ interface ScheduleAdminApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
                         examples = [
@@ -130,6 +134,7 @@ interface ScheduleAdminApi {
                 responseCode = "404",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "ID와 일치하는 세션이 존재하지 않습니다.",
@@ -163,6 +168,7 @@ interface ScheduleAdminApi {
                 responseCode = "400",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "ID와 일치하는 세션이 존재하지 않습니다.",
@@ -206,6 +212,7 @@ interface ScheduleAdminApi {
                 responseCode = "400",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "세션 타입이 아닌 일정에 대한 수정 요청",
@@ -225,6 +232,7 @@ interface ScheduleAdminApi {
                 responseCode = "404",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "ID와 일치하는 세션이 존재하지 않습니다.",

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.client.presentation
 
+import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
@@ -27,6 +28,7 @@ interface ScheduleApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
                         examples = [
@@ -95,6 +97,7 @@ interface ScheduleApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
                         examples = [
@@ -176,12 +179,9 @@ interface ScheduleApi {
         value = [
             ApiResponse(
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(
-                            implementation = UpcomingSessionAttendanceResponse::class,
-                            subTypes = [UpcomingSessionAttendanceResponse::class]
-                        ),
                         examples = [
                             ExampleObject(
                                 name = "활동 유저가 아니거나 미출석 & 출석 가능한 시간이 아닌 경우",
@@ -233,6 +233,7 @@ interface ScheduleApi {
                 responseCode = "404",
                 content = [
                     Content(
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "활성화 된 기수가 없거나 다음 세션이 없는 경우",

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserApi.kt
@@ -25,7 +25,6 @@ interface AdminUserApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저 목록 조회",
@@ -47,7 +46,6 @@ interface AdminUserApi {
             ),
             ApiResponse(
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -68,7 +66,6 @@ interface AdminUserApi {
             ),
             ApiResponse(
                 responseCode = "500",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
@@ -110,7 +110,7 @@ interface AdminUserManageApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
+                        schema = Schema(implementation = AdminUserOverviewResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저 목록 조회",

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
@@ -1,10 +1,11 @@
 package co.yappuworld.user.client.presentation
 
+import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
-import co.yappuworld.user.client.dto.response.AdminUserDetailResponse
 import co.yappuworld.user.client.dto.request.AdminUserPageRequest
 import co.yappuworld.user.client.dto.request.AdminUserUpdateRequest
+import co.yappuworld.user.client.dto.response.AdminUserDetailResponse
 import co.yappuworld.user.client.dto.response.AdminUserOverviewResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -29,12 +30,10 @@ interface AdminUserManageApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저 상세 조회",
@@ -75,10 +74,9 @@ interface AdminUserManageApi {
             ApiResponse(
                 description = "리소스를 찾을 수 없습니다.",
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저가 존재하지 않습니다.",
@@ -105,12 +103,10 @@ interface AdminUserManageApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = AdminUserOverviewResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저 목록 조회",
@@ -162,12 +158,15 @@ interface AdminUserManageApi {
     @ApiResponses(
         value = [
             ApiResponse(
+                responseCode = "204",
+                content = [Content()]
+            ),
+            ApiResponse(
                 description = "리소스를 찾을 수 없습니다.",
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
+                        schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저가 존재하지 않습니다.",
@@ -188,5 +187,5 @@ interface AdminUserManageApi {
     @PutMapping("/admin/v1/users")
     fun updateUserDetails(
         @Valid @RequestBody request: AdminUserUpdateRequest
-    )
+    ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageController.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageController.kt
@@ -31,11 +31,13 @@ class AdminUserManageController(
             SuccessResponse(adminUserService.getUserOverviews(request))
         )
 
-    override fun updateUserDetails(request: AdminUserUpdateRequest) {
+    override fun updateUserDetails(request: AdminUserUpdateRequest): ResponseEntity<Unit> {
         request.phoneNumber?.let {
             if (it.isPhoneNumber().not()) throw BusinessException(GlobalError.INVALID_REQUEST_ARGUMENT)
         }
 
         adminUserService.updateUserDetails(request)
+
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserAlarmApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserAlarmApi.kt
@@ -8,7 +8,6 @@ import co.yappuworld.user.client.dto.response.UserAlarmStatusResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -30,7 +29,6 @@ interface UserAlarmApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저 알림 설정 상태",
@@ -73,7 +71,6 @@ interface UserAlarmApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저 마스터 알림 On",

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthAdminApi.kt
@@ -4,12 +4,12 @@ import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.Token
+import co.yappuworld.user.client.dto.request.AdminSignUpApplicationPageRequest
 import co.yappuworld.user.client.dto.request.LoginRequest
 import co.yappuworld.user.client.dto.request.SignUpApplicationApproveRequest
 import co.yappuworld.user.client.dto.request.SignUpApplicationRejectRequest
-import co.yappuworld.user.client.dto.response.AdminSignUpApplicationOverviewResponse
-import co.yappuworld.user.client.dto.request.AdminSignUpApplicationPageRequest
 import co.yappuworld.user.client.dto.request.UserRoleUpdateRequest
+import co.yappuworld.user.client.dto.response.AdminSignUpApplicationOverviewResponse
 import co.yappuworld.user.client.dto.response.AdminSignUpApplicationResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -39,7 +39,6 @@ interface UserAuthAdminApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "로그인 성공",
@@ -59,7 +58,6 @@ interface UserAuthAdminApi {
             ),
             ApiResponse(
                 responseCode = "401",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -80,7 +78,6 @@ interface UserAuthAdminApi {
             ),
             ApiResponse(
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -101,7 +98,6 @@ interface UserAuthAdminApi {
             ),
             ApiResponse(
                 responseCode = "409",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -154,7 +150,6 @@ interface UserAuthAdminApi {
             ApiResponse(
                 description = "성공",
                 responseCode = "204",
-                useReturnTypeSchema = true,
                 content = [Content()]
             )
         ]
@@ -176,13 +171,11 @@ interface UserAuthAdminApi {
             ApiResponse(
                 description = "성공",
                 responseCode = "204",
-                useReturnTypeSchema = true,
                 content = [Content()]
             ),
             ApiResponse(
                 description = "리소스를 찾을 수 없음",
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -219,7 +212,6 @@ interface UserAuthAdminApi {
             ApiResponse(
                 description = "리소스를 찾을 수 없음",
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -249,8 +241,8 @@ interface UserAuthAdminApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
                         examples = [
@@ -295,8 +287,8 @@ interface UserAuthAdminApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "200",
+                useReturnTypeSchema = true,
                 content = [
                     Content(
                         examples = [

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthApi.kt
@@ -36,7 +36,6 @@ interface UserAuthApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 value = """
@@ -56,7 +55,6 @@ interface UserAuthApi {
             ApiResponse(
                 description = "가입 코드를 입력하지 않는 경우, 가입 신청 처리",
                 responseCode = "201",
-                useReturnTypeSchema = true,
                 content = [Content()]
             ),
             ApiResponse(
@@ -124,7 +122,6 @@ interface UserAuthApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "로그인 성공",
@@ -144,7 +141,6 @@ interface UserAuthApi {
             ),
             ApiResponse(
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -165,7 +161,6 @@ interface UserAuthApi {
             ),
             ApiResponse(
                 responseCode = "409",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -220,7 +215,6 @@ interface UserAuthApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 value = """
@@ -239,7 +233,6 @@ interface UserAuthApi {
             ),
             ApiResponse(
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -260,7 +253,6 @@ interface UserAuthApi {
             ),
             ApiResponse(
                 responseCode = "409",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -291,12 +283,10 @@ interface UserAuthApi {
         value = [
             ApiResponse(
                 responseCode = "204",
-                useReturnTypeSchema = true,
                 content = [Content()]
             ),
             ApiResponse(
                 responseCode = "409",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -330,7 +320,6 @@ interface UserAuthApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(implementation = SuccessResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "최근의 가입 신청이 보류",
@@ -374,7 +363,6 @@ interface UserAuthApi {
             ),
             ApiResponse(
                 responseCode = "409",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -396,7 +384,6 @@ interface UserAuthApi {
             ApiResponse(
                 description = "회원가입 신청을 한 내역이 없습니다.",
                 responseCode = "404",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -431,7 +418,6 @@ interface UserAuthApi {
             ),
             ApiResponse(
                 responseCode = "409",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -40,20 +40,6 @@ VALUES (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-
 INSERT INTO user_alarm_settings (id, created_at, updated_at, user_id, device, master)
 VALUES (UUID_TO_BIN(uuid()), now(), now(), UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), true, true);
 
-INSERT INTO boards (id, created_at, updated_at, board_type, notice_type, title, content, content_summary,
-                    display_target, writer_id,
-                    is_active)
-VALUES (UUID_TO_BIN(uuid()), now(), now(), 'NOTICE', 'SESSION', '제목입니다1', '## 안녕하세요 만나서 반갑습니다', '요약', '몰라?',
-        UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), true),
-       (UUID_TO_BIN(uuid()), now(), now(), 'NOTICE', 'SESSION', '제목입니다2', '## 안녕하세요 만나서 반갑습니다', '요약', '몰라?',
-        UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), true),
-       (UUID_TO_BIN(uuid()), now(), now(), 'NOTICE', 'SESSION', '제목입니다3', '## 안녕하세요 만나서 반갑습니다', '요약', '몰라?',
-        UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), true),
-       (UUID_TO_BIN(uuid()), now(), now(), 'NOTICE', 'OPERATION', '제목입니다4', '## 안녕하세요 만나서 반갑습니다', '요약', '몰라?',
-        UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), true),
-       (UUID_TO_BIN(uuid()), now(), now(), 'NOTICE', 'OPERATION', '제목입니다5', '## 안녕하세요 만나서 반갑습니다', '요약', '몰라?',
-        UUID_TO_BIN('01954809-38fd-1268-e0d6-d3fda39f6b4c'), true);
-
 INSERT INTO posts (id, created_at, updated_at, type, notice_type, title, content, content_summary,
                    display_target, writer_id,
                    is_active)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -88,22 +88,6 @@ CREATE TABLE schedules
     session_type varchar(32)
 );
 
-DROP TABLE IF EXISTS boards;
-CREATE TABLE boards
-(
-    id              binary(16) PRIMARY KEY,
-    created_at      datetime(6),
-    updated_at      datetime(6),
-    board_type      varchar(255),
-    notice_type     varchar(255),
-    title           varchar(64),
-    content         varchar(4000),
-    content_summary varchar(255),
-    display_target  varchar(255),
-    writer_id       binary(16) NOT NULL,
-    is_active       tinyint(1)  NOT NULL
-);
-
 DROP TABLE IF EXISTS posts;
 CREATE TABLE posts
 (


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 스웨거에 스키마가 노출되지 않던 이슈가 있습니다.


## ⭐️ 어떻게 해결했나요?
- 공통 응답을 커스터마이징 하는 과정에서, ref가 적절히 처리되지 못했습니다.
- 성공 응답의 경우 useReturnTypeSchema 옵션을 활용하여, 응답 객체 형태 그대로 Schema를 노출할 수 있도록 처리하였습니다.
- 실패 응답의 경우 ErrorResponse로 schema 형태를 지정해두었습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료
- Example Value 옆에 Schema가 노출되지 않는 상황

![image](https://github.com/user-attachments/assets/59b7cd72-f694-47e8-816b-be8f590e0ac0)



## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
