### PR TITLE
fix: 일부 API에서 스키마가 노출되지 않던 이슈 해결

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/response/SuccessResponse.kt
+++ b/src/main/kotlin/co/yappuworld/global/response/SuccessResponse.kt
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "성공 응답")
 class SuccessResponse<T : Any?>(
-    @Schema(description = "응답 본문")
+    @field:Schema(description = "응답 본문")
     val data: T? = null
 ) : Response() {
 
-    @Schema(description = "요청의 성공 여부", example = "true")
+    @field:Schema(description = "요청의 성공 여부", example = "true")
     override val isSuccess: Boolean = true
 }

--- a/src/main/kotlin/co/yappuworld/operation/client/presentation/OperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/presentation/OperationApi.kt
@@ -63,9 +63,11 @@ interface OperationApi {
                 useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = ForceUpdateResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "강제 업데이트 필요",
+//                                ref = "#/components/schemas/SuccessResponseForceUpdateResponse",
                                 value = """
                                     {
                                         "isSuccess": "true",

--- a/src/main/kotlin/co/yappuworld/post/client/dto/response/NoticeOverviewResponseDto.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/response/NoticeOverviewResponseDto.kt
@@ -9,7 +9,9 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class NoticeOverviewResponse(
+    @Schema(description = "공지사항 정보")
     val notice: NoticeSimpleResponse,
+    @Schema(description = "작성자 정보")
     val writer: NoticeOverviewWriterResponse
 ) {
 

--- a/src/main/kotlin/co/yappuworld/post/client/presentation/NoticeApi.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/presentation/NoticeApi.kt
@@ -81,9 +81,9 @@ interface NoticeApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = NoticeResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "공지사항 상세 조회",

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendancesHistoryResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendancesHistoryResponse.kt
@@ -23,7 +23,7 @@ data class AttendanceHistoryResponse(
     val name: String,
     @Schema(description = "출석 시간", nullable = true)
     val checkedInAt: LocalDateTime?,
-    @Schema(description = "출석 상태", allowableValues = ["출석", "지각", "결석", "조퇴", "공결"])
+    @Schema(description = "출석 상태", nullable = true, allowableValues = ["출석", "지각", "결석", "조퇴", "공결"])
     val attendanceStatus: String?
 ) {
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
@@ -9,12 +9,14 @@ import co.yappuworld.schedule.domain.SessionEntity
 import co.yappuworld.schedule.domain.SessionType
 import co.yappuworld.schedule.domain.TaskEntity
 import co.yappuworld.schedule.domain.getProgressPhase
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.UUID
 
 data class SchedulePageResponse(
+    @Schema(description = "날짜 목록")
     val dates: List<DateGroupedScheduleResponse>
 ) {
 
@@ -39,7 +41,9 @@ data class SchedulePageResponse(
 }
 
 data class DateGroupedScheduleResponse(
+    @Schema(description = "날짜")
     val date: LocalDate,
+    @Schema(description = "일정 목록")
     val schedules: List<SimpleScheduleResponse>
 ) {
 
@@ -50,15 +54,25 @@ data class DateGroupedScheduleResponse(
 }
 
 data class SimpleScheduleResponse(
+    @Schema(description = "일정 ID")
     val id: UUID,
+    @Schema(description = "일정 이름")
     val name: String,
+    @Schema(description = "일정 장소", nullable = true)
     val place: String?,
+    @Schema(description = "일정 날짜")
     val date: LocalDate,
-    val endDate: LocalDate?,
+    @Schema(description = "일정 종료 날짜")
+    val endDate: LocalDate,
+    @Schema(description = "일정 시작 시간", nullable = true)
     val time: LocalTime?,
+    @Schema(description = "일정 종료 시간", nullable = true)
     val endTime: LocalTime?,
+    @Schema(description = "일정 종류")
     val scheduleType: ScheduleType,
+    @Schema(description = "세션 종류", nullable = true)
     val sessionType: SessionType?,
+    @Schema(description = "일정 진행 상태")
     val scheduleProgressPhase: ScheduleProgressPhase
 ) {
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
@@ -211,9 +211,9 @@ interface AttendanceApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = AttendancesHistoryResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "출석 내역 조회",

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -179,9 +179,9 @@ interface ScheduleApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = UpcomingSessionAttendanceResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "활동 유저가 아니거나 미출석 & 출석 가능한 시간이 아닌 경우",

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserApi.kt
@@ -4,6 +4,7 @@ import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.user.client.dto.response.AdminUserProfileResponse
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
@@ -17,14 +18,14 @@ import org.springframework.web.bind.annotation.GetMapping
 @Tag(name = "어드민 회원 API", description = "_")
 interface AdminUserApi {
 
-    @GetMapping("/admin/v1/users/profile")
+    @Operation(summary = "어드민 유저 프로필")
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = AdminUserProfileResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저 목록 조회",
@@ -86,6 +87,7 @@ interface AdminUserApi {
             )
         ]
     )
+    @GetMapping("/admin/v1/users/profile")
     fun getUserProfile(
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<SuccessResponse<AdminUserProfileResponse>>

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
@@ -31,9 +31,9 @@ interface AdminUserManageApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = AdminUserDetailResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "유저 상세 조회",

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthAdminApi.kt
@@ -36,9 +36,9 @@ interface UserAuthAdminApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = Token::class),
                         examples = [
                             ExampleObject(
                                 name = "로그인 성공",

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthApi.kt
@@ -33,9 +33,10 @@ interface UserAuthApi {
             ApiResponse(
                 description = "가입 코드를 통해 별도 신청 절차 없이 가입 처리",
                 responseCode = "200",
-                useReturnTypeSchema = true,
+//                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(ref = "#/components/schemas/SuccessResponseToken"),
                         examples = [
                             ExampleObject(
                                 value = """
@@ -317,9 +318,9 @@ interface UserAuthApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                useReturnTypeSchema = true,
                 content = [
                     Content(
+                        schema = Schema(implementation = LatestSignUpApplicationResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "최근의 가입 신청이 보류",


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 일부 API에서 스웨거가 제대로 노출되지 않는 현상이 발생했습니다.


## ⭐️ 어떻게 해결했나요?
- 기본적으로 useReturnTypeSchema 옵션을 사용하여 Generic 형태의 Response 타입을 파싱합니다.
- 일부 API에서 정상적으로 타입을 파싱하지 못하는 경우가 있어서, 해당 경우에는 SuccessResponse 내부의 Generic 타입만 schema로 지정했습니다.
- 현재 해당 이슈가 왜 발생하는지 알 수는 없는 상태입니다. 
- 추후에는 useReturnTypeSchema 옵션을 제거하고, Content 내부에서 schema를 직접 지정해주는 방향으로 통일할 예정입니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
