### PR TITLE
feat: 일정 목록에서 오늘인지 판단할 수 있는 필드 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
@@ -51,6 +51,8 @@ data class SchedulePageResponse(
 data class DateGroupedScheduleResponse(
     @Schema(description = "날짜")
     val date: LocalDate,
+    @Schema(description = "당일 여부")
+    val isToday: Boolean,
     @Schema(description = "일정 목록")
     val schedules: List<SimpleScheduleResponse>
 ) {
@@ -62,6 +64,7 @@ data class DateGroupedScheduleResponse(
         now: LocalDateTime
     ) : this(
         date = date,
+        isToday = date.isEqual(now.toLocalDate()),
         schedules = scheduleWithAttendance.map { SimpleScheduleResponse.from(it, userWithActivityUnits, now) }
     )
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -109,6 +109,7 @@ interface ScheduleApi {
                                             "dates": [
                                                 {
                                                     "date": "2024-11-01",
+                                                    "isToday": true,
                                                     "schedules": [
                                                         {
                                                             "id": "552390a8-ff12-11ef-ad31-0242ac120002",
@@ -142,6 +143,7 @@ interface ScheduleApi {
                                                 },
                                                 {
                                                     "date": "2024-11-03",
+                                                    "isToday": false,
                                                     "schedules": [
                                                         {
                                                             "id": "5523913c-ff12-11ef-ad31-0242ac120002",

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -109,7 +109,7 @@ interface ScheduleApi {
                                             "dates": [
                                                 {
                                                     "date": "2024-11-01",
-                                                    "isToday": true,
+                                                    "isToday": false,
                                                     "schedules": [
                                                         {
                                                             "id": "552390a8-ff12-11ef-ad31-0242ac120002",
@@ -139,6 +139,7 @@ interface ScheduleApi {
                                                 },
                                                 {
                                                     "date": "2024-11-02",
+                                                    "isToday": true,
                                                     "schedules": []
                                                 },
                                                 {


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 일정 목록에서 오늘은 강조 효과가 필요하여, 해당 여부를 판단해야 합니다.


## ⭐️ 어떻게 해결했나요?
- 기기에서도 가능하지만, 필드를 추가하여 서버 응답을 통해서도 확인할 수 있도록 합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
