### PR TITLE
fix: 임박한 세션 정보 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -68,7 +68,7 @@ class ScheduleService(
     ): UpcomingSessionAttendanceResponse {
         val user = userFindService.findUserWithLastActivityUnit(userId)
         val activeGeneration = generationFindService.findActiveGeneration()
-            ?: throw BusinessException(ScheduleError.NO_UPCOMING_SESSION)
+            ?: throw BusinessException(ScheduleError.NO_SESSION_IN_BREAK_PERIOD)
         val session = sessionFindService.findUpcomingSession(activeGeneration, now)
             ?: throw BusinessException(ScheduleError.NO_UPCOMING_SESSION)
         val attendanceOrNull = attendanceFindService.findSessionAttendance(userId, session.id)

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionAttendanceResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionAttendanceResponse.kt
@@ -7,13 +7,18 @@ import co.yappuworld.user.infrastructure.model.UserWithLastActivityUnit
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.util.UUID
 
 data class UpcomingSessionAttendanceResponse(
     @Schema(description = "세션 식별자")
     val sessionId: UUID,
+    @Schema(description = "세션 이름")
+    val name: String,
     @Schema(description = "세션 일자")
     val date: LocalDate,
+    @Schema(description = "세션 시간")
+    val time: LocalTime?,
     @Schema(
         description = """
             현재 출석이 가능한지 여부
@@ -44,7 +49,9 @@ data class UpcomingSessionAttendanceResponse(
 
             return UpcomingSessionAttendanceResponse(
                 sessionId = session.id,
+                name = session.name,
                 date = session.date,
+                time = session.time,
                 canCheckIn = canCheckIn,
                 status = attendance?.status?.label
             )

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -197,7 +197,9 @@ interface ScheduleApi {
                                     {
                                         "data": {
                                             "sessionId": "552390a8-ff12-11ef-ad31-0242ac120002",
+                                            "name": "OT",
                                             "date": "2024-11-01",
+                                            "time": "14:00:00",
                                             "canCheckIn": false,
                                             "status": null
                                         },
@@ -211,7 +213,9 @@ interface ScheduleApi {
                                     {
                                         "data": {
                                             "sessionId": "552390a8-ff12-11ef-ad31-0242ac120002",
+                                            "name": "OT",
                                             "date": "2024-11-01",
+                                            "time": "14:00:00",
                                             "canCheckIn": true,
                                             "status": null
                                         },
@@ -225,7 +229,9 @@ interface ScheduleApi {
                                     {
                                         "data": {
                                             "sessionId": "552390a8-ff12-11ef-ad31-0242ac120002",
+                                            "name": "OT",
                                             "date": "2024-11-01",
+                                            "time": "14:00:00",
                                             "canCheckIn": false,
                                             "status": "출석"
                                         },
@@ -244,11 +250,31 @@ interface ScheduleApi {
                         schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
-                                name = "활성화 된 기수가 없거나 다음 세션이 없는 경우",
+                                name = "다음 세션이 없는 경우",
                                 value = """
                                     {
                                         "message": "예정된 세션이 존재하지 않습니다.",
                                         "errorCode": "SCH_1005",
+                                        "isSuccess": false
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "409",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "활성화 된 기수가 없는 경우",
+                                value = """
+                                    {
+                                        "message": "활성화 된 기수가 없어서 임박한 세션이 존재하지 않습니다.",
+                                        "errorCode": "SCH_1006",
                                         "isSuccess": false
                                     }
                                 """

--- a/src/main/kotlin/co/yappuworld/schedule/domain/ScheduleError.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/ScheduleError.kt
@@ -30,5 +30,10 @@ enum class ScheduleError : Error {
         override val message: String = "예정된 세션이 존재하지 않습니다."
         override val code: String = "SCH_1005"
         override val type: ErrorType = ErrorType.NOT_FOUND
+    },
+    NO_SESSION_IN_BREAK_PERIOD {
+        override val message: String = "활성화 된 기수가 없어서 임박한 세션이 존재하지 않습니다."
+        override val code: String = "SCH_1006"
+        override val type: ErrorType = ErrorType.WRONG_STATE
     }
 }

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
@@ -81,7 +81,7 @@ class UpcomingSessionFindTest :
 
                 shouldThrowExactly<BusinessException> {
                     scheduleService.getUpcomingSessionAttendance(userId, now)
-                }.error shouldBe ScheduleError.NO_UPCOMING_SESSION
+                }.error shouldBe ScheduleError.NO_SESSION_IN_BREAK_PERIOD
             }
 
             scenario("세션이 존재하지 않으면 예외가 발생한다.") {


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 임박한 세션 정보 반환 시 세션 이름과 시간이 나와있지 않아, 세션 상세 정보 API를 다시 찔러야 함


## ⭐️ 어떻게 해결했나요?
- 세션 이름과 시간을 필드로 추가


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
