### PR TITLE
fix: 남은 일자 수, 요일 필드를 일정 응답에 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.client.dto.response
 
+import co.yappuworld.global.util.TimeUtils.korean
 import co.yappuworld.schedule.domain.SessionProgressPhase
 import co.yappuworld.schedule.domain.SessionProgressPhase.DONE
 import co.yappuworld.schedule.domain.SessionProgressPhase.PENDING
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 data class ActiveGenerationSessionsResponse(
@@ -37,16 +39,16 @@ data class ActiveGenerationSessionsResponse(
             val orderedSessions = sessions.sortedBy { it.date }
             val (upcomingSessionIndex, upcomingSessionStatus) = getUpcomingSessionIndexAndStatus(orderedSessions, now)
                 ?: return ActiveGenerationSessionsResponse(
-                    sessions.map { ActiveGenerationSessionResponse(it, DONE) },
+                    sessions.map { ActiveGenerationSessionResponse(it, DONE, now) },
                     sessions.last().id
                 )
 
             return ActiveGenerationSessionsResponse(
                 sessions = sessions.mapIndexed { index, session ->
                     when {
-                        index < upcomingSessionIndex -> ActiveGenerationSessionResponse(session, DONE)
-                        index > upcomingSessionIndex -> ActiveGenerationSessionResponse(session, PENDING)
-                        else -> ActiveGenerationSessionResponse(session, upcomingSessionStatus)
+                        index < upcomingSessionIndex -> ActiveGenerationSessionResponse(session, DONE, now)
+                        index > upcomingSessionIndex -> ActiveGenerationSessionResponse(session, PENDING, now)
+                        else -> ActiveGenerationSessionResponse(session, upcomingSessionStatus, now)
                     }
                 },
                 upcomingSessionId = sessions[upcomingSessionIndex].id
@@ -76,10 +78,23 @@ data class ActiveGenerationSessionResponse(
     val name: String,
     @Schema(description = "세션 장소", nullable = true)
     val place: String?,
-    @Schema(description = "세션 시작일", nullable = true)
+    @Schema(description = "세션 시작일")
     val date: LocalDate,
+    @Schema(description = "세션 시작 요일")
+    val startDayOfWeek: String,
     @Schema(description = "세션 종료일", nullable = true)
     val endDate: LocalDate?,
+    @Schema(description = "세션 종료 요일", nullable = true)
+    val endDayOfWeek: String?,
+    @Schema(
+        description = """
+            세션 시작일 기준 상대 날짜. D-N 혹은 D+N 으로 표시되는 값.
+            ex) -2(D-2): 세션 시작일 기준 2일 전
+            ex) 0(D-0, D+0): 세션 당일
+            ex) +3(D+3): 세션 시작일 기준 3일 후
+        """
+    )
+    val relativeDays: Int,
     @Schema(description = "세션 시작 시간", nullable = true)
     val time: LocalTime?,
     @Schema(description = "세션 종료 시간", nullable = true)
@@ -94,13 +109,17 @@ data class ActiveGenerationSessionResponse(
 
     constructor(
         session: SessionWithAttendance,
-        status: SessionProgressPhase
+        status: SessionProgressPhase,
+        now: LocalDateTime
     ) : this(
         id = session.id,
         name = session.name,
         place = session.place,
         date = session.date,
+        startDayOfWeek = session.date.dayOfWeek.korean(),
         endDate = session.endDate,
+        endDayOfWeek = session.endDate.dayOfWeek?.korean(),
+        relativeDays = ChronoUnit.DAYS.between(session.date, now.toLocalDate()).toInt(),
         time = session.time,
         endTime = session.endTime,
         type = session.sessionType,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionAttendanceResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionAttendanceResponse.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.client.dto.response
 
+import co.yappuworld.global.util.TimeUtils.korean
 import co.yappuworld.schedule.domain.AttendanceEntity
 import co.yappuworld.schedule.domain.SessionEntity
 import co.yappuworld.user.domain.vo.UserRole
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 data class UpcomingSessionAttendanceResponse(
@@ -15,10 +17,29 @@ data class UpcomingSessionAttendanceResponse(
     val sessionId: UUID,
     @Schema(description = "세션 이름")
     val name: String,
-    @Schema(description = "세션 일자")
-    val date: LocalDate,
-    @Schema(description = "세션 시간")
-    val time: LocalTime?,
+    @Schema(description = "세션 시작 일자")
+    val startDate: LocalDate,
+    @Schema(description = "세션 시작 요일")
+    val startDayOfWeek: String,
+    @Schema(description = "세션 종료 일자")
+    val endDate: LocalDate,
+    @Schema(description = "세션 종료 요일")
+    val endDayOfWeek: String,
+    @Schema(description = "세션 시작 시간")
+    val startTime: LocalTime?,
+    @Schema(description = "세션 종료 시간")
+    val endTime: LocalTime?,
+    @Schema(description = "장소")
+    val place: String?,
+    @Schema(
+        description = """
+            세션 시작일 기준 상대 날짜. D-N 혹은 D+N 으로 표시되는 값.
+            ex) -2(D-2): 세션 시작일 기준 2일 전
+            ex) 0(D-0, D+0): 세션 당일
+            ex) +3(D+3): 세션 시작일 기준 3일 후
+        """
+    )
+    val relativeDays: Int,
     @Schema(
         description = """
             현재 출석이 가능한지 여부
@@ -50,8 +71,14 @@ data class UpcomingSessionAttendanceResponse(
             return UpcomingSessionAttendanceResponse(
                 sessionId = session.id,
                 name = session.name,
-                date = session.date,
-                time = session.time,
+                startDate = session.date,
+                startDayOfWeek = session.date.dayOfWeek.korean(),
+                endDate = session.endDate,
+                endDayOfWeek = session.endDate.dayOfWeek.korean(),
+                startTime = session.time,
+                endTime = session.endTime,
+                place = session.place,
+                relativeDays = ChronoUnit.DAYS.between(session.date, now.toLocalDate()).toInt(),
                 canCheckIn = canCheckIn,
                 status = attendance?.status?.label
             )

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -33,49 +33,58 @@ interface ScheduleApi {
                     Content(
                         examples = [
                             ExampleObject(
-                                name = "활동 중인 기수의 세션 목록 (길이상 일부 생략)",
+                                name = "활동 중인 기수의 세션 목록 (25년 4월 29일 기준)",
                                 value = """
                                     {
                                         "data": {
                                             "sessions": [
                                                 {
-                                                    "id": "55238f62-ff12-11ef-ad31-0242ac120002",
-                                                    "name": "OT",
-                                                    "place": "강북노동자복지관",
-                                                    "date": "2024-11-01",
-                                                    "endDate": null,
-                                                    "time": "14:00:00",
-                                                    "endTime": "18:00:00",
-                                                    "type": "OFFLINE",
-                                                    "progressPhase": "DONE",
-                                                    "attendanceStatus": "출석"
-                                                },
-                                                {
-                                                    "id": "552390a8-ff12-11ef-ad31-0242ac120002",
-                                                    "name": "팀세션",
-                                                    "place": null,
-                                                    "date": "2024-11-01",
-                                                    "endDate": null,
-                                                    "time": null,
-                                                    "endTime": null,
-                                                    "type": "TEAM",
-                                                    "progressPhase": "DONE",
-                                                    "attendanceStatus": "지각"
-                                                },
-                                                {
-                                                    "id": "5523913c-ff12-11ef-ad31-0242ac120002",
-                                                    "name": "팀매칭",
-                                                    "place": "SBA 산학센터",
-                                                    "date": "2024-11-03",
-                                                    "endDate": null,
-                                                    "time": "14:00:00",
-                                                    "endTime": "18:00:00",
+                                                    "id": "c07aa77e-1b30-11f0-add0-0242ac140002",
+                                                    "name": "가짜 세션1",
+                                                    "place": "아몰랑",
+                                                    "date": "2025-04-18",
+                                                    "startDayOfWeek": "금",
+                                                    "endDate": "2025-04-18",
+                                                    "endDayOfWeek": "금",
+                                                    "relativeDays": 11,
+                                                    "time": "13:30:00",
+                                                    "endTime": "17:00:00",
                                                     "type": "OFFLINE",
                                                     "progressPhase": "DONE",
                                                     "attendanceStatus": "결석"
+                                                },
+                                                {
+                                                    "id": "c07afa8b-1b30-11f0-add0-0242ac140002",
+                                                    "name": "가짜 세션2",
+                                                    "place": "아몰랑",
+                                                    "date": "2025-05-08",
+                                                    "startDayOfWeek": "목",
+                                                    "endDate": "2025-05-08",
+                                                    "endDayOfWeek": "목",
+                                                    "relativeDays": -9,
+                                                    "time": "13:30:00",
+                                                    "endTime": "17:00:00",
+                                                    "type": "OFFLINE",
+                                                    "progressPhase": "UPCOMING",
+                                                    "attendanceStatus": null
+                                                },
+                                                {
+                                                    "id": "c07afa8b-1b30-11f0-add0-0242ac140003",
+                                                    "name": "가짜 세션3",
+                                                    "place": "아몰랑",
+                                                    "date": "2025-05-11",
+                                                    "startDayOfWeek": "일",
+                                                    "endDate": "2025-05-11",
+                                                    "endDayOfWeek": "일",
+                                                    "relativeDays": -12,
+                                                    "time": "13:30:00",
+                                                    "endTime": "17:00:00",
+                                                    "type": "OFFLINE",
+                                                    "progressPhase": "PENDING",
+                                                    "attendanceStatus": null
                                                 }
                                             ],
-                                            "upcomingSessionId": "5523913c-ff12-11ef-ad31-0242ac120002"
+                                            "upcomingSessionId": "c07afa8b-1b30-11f0-add0-0242ac140002"
                                         },
                                         "isSuccess": true
                                     }
@@ -198,8 +207,14 @@ interface ScheduleApi {
                                         "data": {
                                             "sessionId": "552390a8-ff12-11ef-ad31-0242ac120002",
                                             "name": "OT",
-                                            "date": "2024-11-01",
-                                            "time": "14:00:00",
+                                            "startDate": "2025-05-08",
+                                            "startDayOfWeek": "목",
+                                            "endDate": "2025-05-08",
+                                            "endDayOfWeek": "목",
+                                            "startTime": "13:30:00",
+                                            "endTime": "17:00:00",
+                                            "place": "아몰랑",
+                                            "relativeDays": -1,
                                             "canCheckIn": false,
                                             "status": null
                                         },
@@ -214,8 +229,14 @@ interface ScheduleApi {
                                         "data": {
                                             "sessionId": "552390a8-ff12-11ef-ad31-0242ac120002",
                                             "name": "OT",
-                                            "date": "2024-11-01",
-                                            "time": "14:00:00",
+                                            "startDate": "2025-05-08",
+                                            "startDayOfWeek": "목",
+                                            "endDate": "2025-05-08",
+                                            "endDayOfWeek": "목",
+                                            "startTime": "13:30:00",
+                                            "endTime": "17:00:00",
+                                            "place": "아몰랑",
+                                            "relativeDays": 0,
                                             "canCheckIn": true,
                                             "status": null
                                         },
@@ -230,8 +251,14 @@ interface ScheduleApi {
                                         "data": {
                                             "sessionId": "552390a8-ff12-11ef-ad31-0242ac120002",
                                             "name": "OT",
-                                            "date": "2024-11-01",
-                                            "time": "14:00:00",
+                                            "startDate": "2025-05-08",
+                                            "startDayOfWeek": "목",
+                                            "endDate": "2025-05-08",
+                                            "endDayOfWeek": "목",
+                                            "startTime": "13:30:00",
+                                            "endTime": "17:00:00",
+                                            "place": "아몰랑",
+                                            "relativeDays": 0,
                                             "canCheckIn": false,
                                             "status": "출석"
                                         },


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 남은 일자 수(D-?)와 요일 정보를 응답에 추가 합니다.


## ⭐️ 어떻게 해결했나요?
- 남은 일자 수는 ChronoUnit의 between 메서드를 이용했습니다.
- 요일은 dayOfWeek를 이용하여 처리하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
