### PR TITLE
fix: SignUpCodeBook 도메인 모델으로 가입코드 처리

### DIFF
--- a/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminUserOperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminUserOperationApi.kt
@@ -263,7 +263,7 @@ interface AdminUserOperationApi {
         @Valid @RequestBody request: AdminSignUpCodeUpdateRequest
     ): ResponseEntity<Unit>
 
-    @Operation(summary = "인증번호 삭제")
+    @Operation(summary = "인증번호 초기화")
     @ApiResponse(
         responseCode = "204",
         content = [Content()]

--- a/src/main/kotlin/co/yappuworld/operation/infrastructure/ConfigCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/operation/infrastructure/ConfigCommandService.kt
@@ -1,0 +1,25 @@
+package co.yappuworld.operation.infrastructure
+
+import co.yappuworld.user.domain.model.SignUpCodeBook
+import co.yappuworld.user.domain.vo.UserRole
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class ConfigCommandService(
+    private val configRepository: ConfigRepository
+) {
+
+    fun update(signUpCodeBook: SignUpCodeBook) {
+        val configBySignUpCodeKey = configRepository
+            .findAllByIdIn(UserRole.entries.map { it.signUpCodeKey })
+            .associateBy { it.id }
+
+        UserRole.entries.forEach { entry ->
+            configBySignUpCodeKey[entry.signUpCodeKey]?.update(signUpCodeBook.getCode(entry))
+        }
+
+        configRepository.saveAll(configBySignUpCodeKey.values)
+    }
+}

--- a/src/main/kotlin/co/yappuworld/operation/infrastructure/ConfigFindService.kt
+++ b/src/main/kotlin/co/yappuworld/operation/infrastructure/ConfigFindService.kt
@@ -1,6 +1,8 @@
 package co.yappuworld.operation.infrastructure
 
 import co.yappuworld.operation.domain.ConfigEntity
+import co.yappuworld.user.domain.model.SignUpCodeBook
+import co.yappuworld.user.domain.vo.UserRole
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,4 +14,9 @@ class ConfigFindService(
 ) {
 
     fun findConfig(id: String): ConfigEntity? = configRepository.findByIdOrNull(id)
+
+    fun findSignUpCodeBook(): SignUpCodeBook =
+        SignUpCodeBook(
+            configRepository.findAllByIdIn(UserRole.entries.map { it.signUpCodeKey })
+        )
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
@@ -2,18 +2,29 @@ package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.schedule.domain.SessionEntity
 import co.yappuworld.schedule.domain.SessionType
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 
 data class AdminSessionDetailResponse(
+    @Schema(description = "세션 ID")
     val id: UUID,
+    @Schema(description = "세션 이름")
     val name: String,
+    @Schema(description = "기수")
     val generation: Int,
+    @Schema(description = "세션 장소")
     val place: String?,
+    @Schema(description = "세션 시작 일자")
     val date: LocalDate,
-    val time: LocalTime?,
-    val endTime: LocalTime?,
+    @Schema(description = "세션 종료 일자")
+    val endDate: LocalDate,
+    @Schema(description = "세션 시작 시간")
+    val time: LocalTime,
+    @Schema(description = "세션 종료 시간")
+    val endTime: LocalTime,
+    @Schema(description = "세션 타입")
     val sessionType: SessionType
 ) {
 
@@ -23,6 +34,7 @@ data class AdminSessionDetailResponse(
         generation = session.generation,
         place = session.place,
         date = session.date,
+        endDate = session.endDate,
         time = session.time,
         endTime = session.endTime,
         sessionType = session.sessionType

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionOverviewResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionOverviewResponse.kt
@@ -20,8 +20,10 @@ data class AdminSessionOverviewResponse(
     val place: String?,
     @Schema(description = "날짜")
     val date: LocalDate,
+    @Schema(description = "종료 날짜")
+    val endDate: LocalDate,
     @Schema(description = "시작 시간")
-    val time: LocalTime?,
+    val time: LocalTime,
     @Schema(description = "종료 시간")
     val endTime: LocalTime?
 ) {
@@ -33,6 +35,7 @@ data class AdminSessionOverviewResponse(
         title = session.name,
         place = session.place,
         date = session.date,
+        endDate = session.endDate,
         time = session.time,
         endTime = session.endTime
     )

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponse.kt
@@ -36,7 +36,7 @@ data class AttendanceStatisticsResponse(
         ): AttendanceStatisticsResponse {
             val finishedSessions = sessions.filter {
                 it.date.isBefore(now.toLocalDate()) ||
-                    (it.date.isEqual(now.toLocalDate()) && it.endTime?.isBefore(now.toLocalTime()) ?: false)
+                    (it.date.isEqual(now.toLocalDate()) && it.endTime.isBefore(now.toLocalTime()) ?: false)
             }
 
             val attendanceBySession = attendances.associateBy { it.scheduleId }

--- a/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
@@ -9,7 +9,8 @@ import co.yappuworld.global.security.Token
 import co.yappuworld.global.util.ifNotEmpty
 import co.yappuworld.operation.client.application.GenerationActiveStateManager
 import co.yappuworld.operation.client.dto.request.AdminSignupCodeDeleteRequest
-import co.yappuworld.operation.domain.ConfigError
+import co.yappuworld.operation.infrastructure.ConfigCommandService
+import co.yappuworld.operation.infrastructure.ConfigFindService
 import co.yappuworld.operation.infrastructure.ConfigRepository
 import co.yappuworld.user.client.application.usecase.UserLoginPermissionChecker
 import co.yappuworld.user.client.dto.request.AdminActivityUnitUpdateRequest
@@ -26,7 +27,6 @@ import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.ActivityUnitCommandService
 import co.yappuworld.user.infrastructure.ActivityUnitFindService
 import co.yappuworld.user.infrastructure.UserFindService
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -41,7 +41,9 @@ class AdminUserService(
     private val jwtGenerator: JwtGenerator,
     private val jwtResolver: JwtResolver,
     private val userLoginPermissionChecker: UserLoginPermissionChecker,
-    private val generationActiveStateManager: GenerationActiveStateManager
+    private val generationActiveStateManager: GenerationActiveStateManager,
+    private val configFindService: ConfigFindService,
+    private val configCommandService: ConfigCommandService
 ) {
 
     @Transactional
@@ -104,16 +106,18 @@ class AdminUserService(
 
     @Transactional
     fun updateSignUpCode(request: AdminSignUpCodeUpdateRequest) {
-        configRepository
-            .findByIdOrNull(request.role.signUpCodeKey)
-            ?.apply { update(request.getPaddedCode()) }
-            ?: throw BusinessException(ConfigError.CONFIG_KEY_ERROR)
+        configFindService
+            .findSignUpCodeBook()
+            .apply { updateSignUpCode(request.role, request.getPaddedCode()) }
+            .also { configCommandService.update(it) }
     }
 
     @Transactional
     fun deleteSignupCode(request: AdminSignupCodeDeleteRequest) {
-        configRepository.findByIdOrNull(request.role.signUpCodeKey)?.apply { update(null) }
-            ?: throw BusinessException(ConfigError.CONFIG_KEY_ERROR)
+        configFindService
+            .findSignUpCodeBook()
+            .apply { initializeSignUpCode(request.role) }
+            .also { configCommandService.update(it) }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/co/yappuworld/user/client/application/SignUpService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/SignUpService.kt
@@ -1,15 +1,12 @@
 package co.yappuworld.user.client.application
 
-import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.security.JwtGenerator
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.security.Token
-import co.yappuworld.operation.client.application.ConfigInquiryComponent
+import co.yappuworld.operation.infrastructure.ConfigFindService
 import co.yappuworld.user.client.application.usecase.SignUpApplicationExecutor
 import co.yappuworld.user.client.dto.request.CheckingEmailAvailabilityRequest
 import co.yappuworld.user.client.dto.request.UserSignUpRequest
-import co.yappuworld.user.domain.vo.UserError
-import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.UserCommandService
 import co.yappuworld.user.infrastructure.UserSystemNotifier
 import org.springframework.stereotype.Service
@@ -21,7 +18,7 @@ class SignUpService(
     private val userCommandService: UserCommandService,
     private val signUpApplicationExecutor: SignUpApplicationExecutor,
     private val jwtGenerator: JwtGenerator,
-    private val configInquiryComponent: ConfigInquiryComponent,
+    private val configFindService: ConfigFindService,
     private val userSystemNotifier: UserSystemNotifier
 ) {
 
@@ -47,20 +44,11 @@ class SignUpService(
         return userCommandService
             .signUp(
                 application = request.toSignUpApplication(),
-                role = getUserRoleWithSignUpCode(request.signUpCode!!)
+                role = configFindService.findSignUpCodeBook().decideRole(checkNotNull(request.signUpCode))
             ).let { user -> jwtGenerator.generateToken(SecurityUser.from(user), now) }
     }
 
     @Transactional(readOnly = true)
     fun checkEmailAvailability(request: CheckingEmailAvailabilityRequest) =
         signUpApplicationExecutor.checkEmailAvailability(request.email)
-
-    private fun getUserRoleWithSignUpCode(signUpCode: String): UserRole {
-        val config = configInquiryComponent
-            .findConfigsBy(UserRole.entries.map { it.signUpCodeKey })
-            .singleOrNull { it.value == signUpCode }
-            ?: throw BusinessException(UserError.INVALID_SIGN_UP_CODE)
-
-        return UserRole.entries.single { it.signUpCodeKey == config.id }
-    }
 }

--- a/src/main/kotlin/co/yappuworld/user/domain/model/SignUpCodeBook.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/SignUpCodeBook.kt
@@ -1,0 +1,65 @@
+package co.yappuworld.user.domain.model
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.operation.domain.ConfigEntity
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.domain.vo.UserRole
+
+class SignUpCodeBook(
+    configs: List<ConfigEntity>
+) {
+
+    private val codeByUserRole: MutableMap<UserRole, String?>
+    private val codes: List<String>
+        get() = codeByUserRole.values.filterNotNull()
+
+    init {
+        val codeByUserRole = mutableMapOf<UserRole, String?>()
+        val codeById = configs.associateBy { it.id }
+
+        UserRole.entries.forEach { entry ->
+            val config = codeById[entry.signUpCodeKey]
+                ?: throw BusinessException(UserError.SIGN_UP_CODE_UNREGISTERED)
+
+            codeByUserRole[entry] = checkValue(config.value)
+        }
+
+        this.codeByUserRole = codeByUserRole
+        checkDuplicateValue()
+    }
+
+    fun updateSignUpCode(
+        userRole: UserRole,
+        code: String
+    ) {
+        if (codes.contains(code)) {
+            throw BusinessException(UserError.CANNOT_UPDATE_EXISTS_SIGN_UP_CODE)
+        }
+
+        codeByUserRole[userRole] = checkValue(code)
+    }
+
+    fun initializeSignUpCode(userRole: UserRole) {
+        codeByUserRole[userRole] = null
+    }
+
+    fun getCode(userRole: UserRole): String? = codeByUserRole[userRole]
+
+    fun decideRole(code: String): UserRole =
+        UserRole.entries.singleOrNull { codeByUserRole[it] == code }
+            ?: throw BusinessException(UserError.WRONG_SIGN_UP_CODE)
+
+    private fun checkValue(value: String?): String? {
+        if (value != null && value.length != 6) {
+            throw BusinessException(UserError.INVALID_SIGN_UP_CODE)
+        }
+
+        return value
+    }
+
+    private fun checkDuplicateValue() {
+        if (codes.size != codes.distinct().size) {
+            throw BusinessException(UserError.SIGN_UP_CODE_DUPLICATED)
+        }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
@@ -33,7 +33,7 @@ enum class UserError : Error {
     },
 
     // 1000번대 - 회원가입 에러
-    INVALID_SIGN_UP_CODE {
+    WRONG_SIGN_UP_CODE {
         override val message: String = "잘못된 가입코드입니다."
         override val code: String = "USR_1001"
         override val type: ErrorType = ErrorType.WRONG_ARGUMENT
@@ -111,5 +111,27 @@ enum class UserError : Error {
         override val message: String = "이미 탈퇴한 계정입니다."
         override val code: String = "USR_1201"
         override val type: ErrorType = ErrorType.WRONG_STATE
+    },
+
+    // 2000번대 - 가입 코드
+    SIGN_UP_CODE_UNREGISTERED {
+        override val message: String = "가입코드가 등록되지 않았습니다."
+        override val code: String = "USR_2000"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    },
+    INVALID_SIGN_UP_CODE {
+        override val message: String = "가입코드가 형식에 맞지 않습니다."
+        override val code: String = "USR_2001"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    },
+    SIGN_UP_CODE_DUPLICATED {
+        override val message: String = "가입코드가 중복되었습니다."
+        override val code: String = "USR_2002"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    },
+    CANNOT_UPDATE_EXISTS_SIGN_UP_CODE {
+        override val message: String = "기존에 존재하는 가입코드이므로 변경할 수 없습니다."
+        override val code: String = "USR_2003"
+        override val type: ErrorType = ErrorType.WRONG_ARGUMENT
     }
 }

--- a/src/test/kotlin/co/yappuworld/operation/infrastructure/ConfigCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/operation/infrastructure/ConfigCommandServiceTest.kt
@@ -1,0 +1,50 @@
+package co.yappuworld.operation.infrastructure
+
+import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.user.domain.model.SignUpCodeBook
+import co.yappuworld.user.domain.vo.UserRole
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import org.springframework.beans.factory.annotation.Autowired
+
+class ConfigCommandServiceTest @Autowired constructor(
+    private val configRepository: ConfigRepository,
+    private val entityManager: EntityManager
+) : CustomDataJpaFeatureSpec({
+
+        val configCommandService = ConfigCommandService(configRepository)
+
+        feature("가입코드 수정") {
+
+            scenario("가입코드를 수정한다.") {
+                val originConfigs = configRepository.findAllByIdIn(
+                    UserRole.entries.map { it.signUpCodeKey }
+                )
+                val valueBySignUpCodeKey = originConfigs.associate { it.id to it.value }
+
+                val signUpCodeBook = SignUpCodeBook(originConfigs)
+                UserRole.entries.sortedBy { it.ordinal }.forEach { role ->
+                    val code = signUpCodeBook.getCode(role)
+                    code?.let {
+                        signUpCodeBook.updateSignUpCode(
+                            role,
+                            (code.toInt() + 100).toString().padStart(6, '0')
+                        )
+                    }
+                }
+
+                configCommandService.update(signUpCodeBook)
+                entityManager.flush()
+
+                val updatedConfigs = configRepository.findAllByIdIn(UserRole.entries.map { it.signUpCodeKey })
+                UserRole.entries.forEach { role ->
+                    val originValue = valueBySignUpCodeKey[role.signUpCodeKey].shouldNotBeNull()
+                    val updatedValue = updatedConfigs.single { it.name == role.signUpCodeKey }.value
+
+                    updatedValue.shouldNotBeNull() shouldBe
+                        (originValue.toInt() + 100).toString().padStart(6, '0')
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/user/domain/model/SignUpCodeBookTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/domain/model/SignUpCodeBookTest.kt
@@ -1,0 +1,147 @@
+package co.yappuworld.user.domain.model
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.operation.domain.ConfigCategory
+import co.yappuworld.operation.domain.ConfigEntity
+import co.yappuworld.user.domain.vo.UserError
+import co.yappuworld.user.domain.vo.UserRole
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.data.blocking.forAll
+import io.kotest.data.row
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class SignUpCodeBookTest :
+    FeatureSpec({
+
+        val configs = UserRole.entries.sortedBy { it.ordinal }.mapIndexed { index, role ->
+            ConfigEntity(
+                name = role.signUpCodeKey,
+                value = "00000$index",
+                label = "가입 코드",
+                category = ConfigCategory.ATTENDANCE_CODE
+            )
+        }
+
+        feature("초기화 시") {
+
+            scenario("UserRole 중 존재하지 않는 가입 코드가 있을 경우") {
+                forAll(
+                    row(UserRole.ADMIN),
+                    row(UserRole.STAFF),
+                    row(UserRole.ACTIVE),
+                    row(UserRole.ALUMNI),
+                    row(UserRole.GRADUATE)
+                ) { role ->
+                    val withoutOneRole = UserRole.entries
+                        .filterNot { it == role }
+                        .map { entry ->
+                            ConfigEntity(
+                                name = entry.signUpCodeKey,
+                                value = entry.ordinal.toString().padStart(6, '0'),
+                                label = "가입 코드",
+                                category = ConfigCategory.ATTENDANCE_CODE
+                            )
+                        }
+
+                    shouldThrowExactly<BusinessException> {
+                        SignUpCodeBook(withoutOneRole)
+                    }.error shouldBe UserError.SIGN_UP_CODE_UNREGISTERED
+                }
+            }
+
+            scenario("중복된 가입코드가 있으면 예외가 발생한다.") {
+                val configs = UserRole.entries
+                    .map { entry ->
+                        ConfigEntity(
+                            name = entry.signUpCodeKey,
+                            value = "000000",
+                            label = "가입 코드",
+                            category = ConfigCategory.ATTENDANCE_CODE
+                        )
+                    }
+
+                shouldThrowExactly<BusinessException> {
+                    SignUpCodeBook(configs)
+                }.error shouldBe UserError.SIGN_UP_CODE_DUPLICATED
+            }
+
+            scenario("가입코드가 NULL인 경우 중복되어도 예외가 발생하지 않는다.") {
+                val configs = UserRole.entries
+                    .map { entry ->
+                        ConfigEntity(
+                            name = entry.signUpCodeKey,
+                            value = null,
+                            label = "가입 코드",
+                            category = ConfigCategory.ATTENDANCE_CODE
+                        )
+                    }
+
+                shouldNotThrowAny { SignUpCodeBook(configs) }
+            }
+
+            scenario("가입코드가 여섯자리가 아니면 예외가 발생한다.") {
+                val configs = UserRole.entries
+                    .map { entry ->
+                        ConfigEntity(
+                            name = entry.signUpCodeKey,
+                            value = "00000",
+                            label = "가입 코드",
+                            category = ConfigCategory.ATTENDANCE_CODE
+                        )
+                    }
+
+                shouldThrowExactly<BusinessException> {
+                    SignUpCodeBook(configs)
+                }.error shouldBe UserError.INVALID_SIGN_UP_CODE
+            }
+        }
+
+        feature("가입코드 수정 시") {
+
+            scenario("가입코드가 중복되면 예외가 발생한다.") {
+                val signUpCodeBook = SignUpCodeBook(configs)
+
+                shouldThrowExactly<BusinessException> {
+                    signUpCodeBook.updateSignUpCode(
+                        UserRole.STAFF,
+                        signUpCodeBook.getCode(UserRole.ADMIN)!!
+                    )
+                }
+            }
+
+            scenario("가입코드가 6자리가 아니면 예외가 발생한다.") {
+                val signUpCodeBook = SignUpCodeBook(configs)
+
+                shouldThrowExactly<BusinessException> {
+                    signUpCodeBook.updateSignUpCode(UserRole.ADMIN, "00000")
+                }.error shouldBe UserError.INVALID_SIGN_UP_CODE
+            }
+
+            scenario("가입코드가 6자리이면 정상적으로 수정된다.") {
+                val signUpCodeBook = SignUpCodeBook(configs)
+
+                shouldNotThrowAny { signUpCodeBook.updateSignUpCode(UserRole.ADMIN, "123456") }
+            }
+        }
+
+        feature("초기화") {
+
+            scenario("초기화 하면 가입 코드가 NULL로 설정된다.") {
+                val signUpCodeBook = SignUpCodeBook(configs)
+                forAll(
+                    row(UserRole.ADMIN),
+                    row(UserRole.STAFF),
+                    row(UserRole.ACTIVE),
+                    row(UserRole.ALUMNI),
+                    row(UserRole.GRADUATE)
+                ) { role ->
+                    signUpCodeBook.getCode(role).shouldNotBeNull()
+                    signUpCodeBook.initializeSignUpCode(role)
+                    signUpCodeBook.getCode(role) shouldBe null
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 가입코드 관련 어드민 처리에서 문제가 있었습니다.
	- 중복된 가입코드가 설정되는 문제
	- 초기화를 시켰을 때 '000000'으로 설정되는 문제


## ⭐️ 어떻게 해결했나요?
### 도메인 모델 생성
- 가입코드를 핸들링 하는 도메인 모델을 생성하였습니다.
- 가입코드의 수정, 초기화, 매칭을 처리합니다.
### 가입코드 처리
- 초기화, 수정 시 중복이 발생하지 않도록 합니다.
- 초기화 시 NULL 값이 저장되도록 합니다.
- 유저에서 가입코드 기반의 회원가입을 진행할 때, 코드에 매칭되는 유저 역할을 반환하도록 합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
