### PR TITLE
feat: 유저 조회에 빠진 조건절 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
@@ -168,6 +168,7 @@ class UserFindService(
                         .on(
                             and(
                                 path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)),
+                                path(UserEntity::getId).equal(userId),
                                 path(ActivityUnitEntity::generation).equal(generation)
                             )
                         )


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 기존 쿼리에서 요청한 유저의 id를 쿼리에 사용하지 않아, 단건이 아닌 다건이 조회되었습니다.
- 이로 인해, singleOrNull()에서 single이 아니므로 null이 반환되어 에러가 발생했습니다.


## ⭐️ 어떻게 해결했나요?
- 파라미터로 전달된 userId를 on절에 추가하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
