### PR TITLE
fix: PathFilter에 actuaotr를 추가하여 모니터링 지표 수집이 가능하도록 처리

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
@@ -36,8 +36,9 @@ class SecurityConfig(
                     .hasAnyRole("ADMIN", "STAFF", "ALUMNI", "GRADUATE", "ACTIVE")
                     .requestMatchers(staffOrAdminMatchers)
                     .hasAnyRole("ADMIN", "STAFF")
-            }.authorizeHttpRequests { it.anyRequest().permitAll() }
-            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
+                    .anyRequest()
+                    .permitAll()
+            }.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
 
     private fun getCorsConfigureSource(): CorsConfigurationSource =

--- a/src/main/kotlin/co/yappuworld/global/config/SwaggerConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SwaggerConfig.kt
@@ -28,7 +28,7 @@ class SwaggerConfig {
         GroupedOpenApi
             .builder()
             .group("App API")
-            .pathsToExclude("/admin/**")
+            .pathsToMatch("/v1/**")
             .addOpenApiCustomizer(customizeResponses)
             .build()
 

--- a/src/main/kotlin/co/yappuworld/global/filter/PathRegistry.kt
+++ b/src/main/kotlin/co/yappuworld/global/filter/PathRegistry.kt
@@ -17,7 +17,8 @@ class PathRegistry(
     private val customRegisteredPaths = setOf(
         "/swagger-ui/**",
         "/health",
-        "/v3/api-docs/**"
+        "/v3/api-docs/**",
+        "/actuator/**"
     )
 
     @PostConstruct

--- a/src/main/kotlin/co/yappuworld/global/security/SecurityPathMatchersManager.kt
+++ b/src/main/kotlin/co/yappuworld/global/security/SecurityPathMatchersManager.kt
@@ -12,6 +12,8 @@ import org.springframework.security.web.util.matcher.RequestMatchers
 object SecurityPathMatchersManager {
     val anyoneMatchers: RequestMatcher = RequestMatchers.anyOf(
         antMatcher("/health"),
+        antMatcher("/actuator"),
+        antMatcher("/actuator/**"),
         // swagger
         antMatcher("/swagger-ui/**"),
         antMatcher("/v3/api-docs/**"),

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -38,3 +38,9 @@ jwt:
     secret_key: thisisforlocalsecretkeyonlyusinginlocalenvironmentthisisforlocalsecretkeyonlyusinginlocalenvironment
     access_token_expiration_times: 3600000 # 1hour = 1000(=1s) * 60 * 60
     refresh_token_expiration_times: 1209600000 # 2weeks = 1000(=1s) * 60 * 60 * 24 * 14
+
+management:
+    endpoints:
+        web:
+            exposure:
+                exclude: "*"


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 크롤러 요청에 대응하기 위해 PathFilter를 생성하였습니다.
- 해당 Filter에서 대상으로 하는 registry에 /actuator 경로가 등록되어 있지 않아, 모니터링 툴에서 지표를 수집하지 못하였습니다.


## ⭐️ 어떻게 해결했나요?
- PathRegistry에 actuator 경로를 등록합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
