### PR TITLE
feat: 어드민 출석 조회에 통계 포함

### DIFF
--- a/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationFindService.kt
+++ b/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationFindService.kt
@@ -2,7 +2,7 @@ package co.yappuworld.operation.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.operation.domain.GenerationEntity
-import co.yappuworld.schedule.domain.AttendanceError
+import co.yappuworld.schedule.domain.vo.AttendanceError
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
@@ -3,8 +3,10 @@ package co.yappuworld.schedule.client.application
 import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.AdminAttendanceUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminAttendancesResponse
+import co.yappuworld.schedule.domain.AttendanceBook
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
+import co.yappuworld.schedule.infrastructure.LatePassFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.user.infrastructure.UserFindService
@@ -18,21 +20,22 @@ class AdminAttendanceService(
     private val attendanceCommandService: AttendanceCommandService,
     private val userFindService: UserFindService,
     private val sessionFindService: SessionFindService,
-    private val generationFindService: GenerationFindService
+    private val generationFindService: GenerationFindService,
+    private val latePassFindService: LatePassFindService
 ) {
 
     @Transactional(readOnly = true)
     fun findAttendances(now: LocalDateTime): AdminAttendancesResponse {
         val activeGeneration = generationFindService.findActiveGeneration()
-        val sessions = sessionFindService.findSessionsInGeneration(activeGeneration)
-        val users = userFindService.findUsersActiveOfGeneration(activeGeneration)
-        val attendances = attendanceFindService.findAttendancesOfGeneration(activeGeneration)
-
         return AdminAttendancesResponse.from(
-            sessions = sessions,
-            users = users,
-            attendances = attendances,
-            now = now
+            AttendanceBook(
+                generation = activeGeneration,
+                users = userFindService.findUsersActiveOfGeneration(activeGeneration),
+                sessions = sessionFindService.findSessionsInGeneration(activeGeneration),
+                attendanceEntities = attendanceFindService.findAttendancesOfGeneration(activeGeneration),
+                latePasses = latePassFindService.findLatePasses(activeGeneration),
+                now = now
+            )
         )
     }
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
@@ -6,7 +6,7 @@ import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponse
 import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponse
-import co.yappuworld.schedule.domain.AttendanceError
+import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
 import co.yappuworld.schedule.infrastructure.AttendanceFindService

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
@@ -8,7 +8,7 @@ import co.yappuworld.schedule.client.dto.request.AdminSessionPageRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
-import co.yappuworld.schedule.domain.ScheduleError
+import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.ScheduleCommandService
 import co.yappuworld.schedule.infrastructure.SessionFindService
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -6,7 +6,7 @@ import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.UpcomingSessionAttendanceResponse
-import co.yappuworld.schedule.domain.ScheduleError
+import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.ScheduleFindService

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminAttendanceUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminAttendanceUpdateRequest.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.schedule.client.dto.request
 
-import co.yappuworld.schedule.domain.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.schedule.client.dto.request
 
-import co.yappuworld.schedule.domain.ScheduleType
-import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.domain.vo.ScheduleType
+import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.entity.ScheduleEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import io.swagger.v3.oas.annotations.media.Schema

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionUpdateRequest.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.schedule.client.dto.request
 
-import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
@@ -1,12 +1,12 @@
 package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.global.util.DatetimeUtils.korean
-import co.yappuworld.schedule.domain.SessionProgressPhase
-import co.yappuworld.schedule.domain.SessionProgressPhase.DONE
-import co.yappuworld.schedule.domain.SessionProgressPhase.PENDING
-import co.yappuworld.schedule.domain.SessionProgressPhase.TODAY
-import co.yappuworld.schedule.domain.SessionProgressPhase.UPCOMING
-import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase.DONE
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase.PENDING
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase.TODAY
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase.UPCOMING
+import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendance
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponse.kt
@@ -1,10 +1,13 @@
 package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.global.util.DatetimeUtils.korean
-import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
+import co.yappuworld.schedule.domain.AttendanceBook
+import co.yappuworld.schedule.domain.SessionAttendanceStatistics
+import co.yappuworld.schedule.domain.UserAttendanceStatistics
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
@@ -23,29 +26,21 @@ data class AdminAttendancesResponse(
 
     companion object {
 
-        fun from(
-            sessions: List<SessionEntity>,
-            users: List<UserWithActivityUnit>,
-            attendances: List<AttendanceEntity>,
-            now: LocalDateTime
-        ): AdminAttendancesResponse {
-            val sortedSessions = sessions.sortedBy { it.date }
-
-            return AdminAttendancesResponse(
-                sessions = sortedSessions.map { AdminAttendanceSessionResponse(it) },
-                users = users
-                    .map { AdminAttendanceUserResponse(it) }
-                    .sortedBy { Position.valueOf(it.position).ordinal },
-                attendancesGroupedBySession = sortedSessions.map { session ->
+        fun from(attendanceBook: AttendanceBook): AdminAttendancesResponse =
+            AdminAttendancesResponse(
+                sessions = attendanceBook.sessions.map {
+                    AdminAttendanceSessionResponse(it, attendanceBook.sessionAttendanceStatistics(it.id))
+                },
+                users = attendanceBook.users.map {
+                    AdminAttendanceUserResponse(it, attendanceBook.userAttendanceStatistics(it.userId))
+                },
+                attendancesGroupedBySession = attendanceBook.sessions.map { session ->
                     AdminSessionAttendanceGroupResponse.from(
-                        session = session,
-                        users = users,
-                        attendances = attendances,
-                        now = now
+                        sessionId = session.id,
+                        attendanceByUserId = attendanceBook.getSessionStatuses(session.id)
                     )
                 }
             )
-        }
     }
 }
 
@@ -65,10 +60,22 @@ data class AdminAttendanceSessionResponse(
     @Schema(description = "세션 시작 시간")
     val startTime: LocalTime,
     @Schema(description = "세션 종료 시간")
-    val endTime: LocalTime
+    val endTime: LocalTime,
+    @Schema(description = "총 인원")
+    val totalPersonCount: Int,
+    @Schema(description = "출석 인원")
+    val totalOnTimeCount: Int,
+    @Schema(description = "지각 인원")
+    val totalLateCount: Int,
+    @Schema(description = "결석 인원")
+    val totalAbsentCount: Int,
+    @Schema(description = "조퇴 인원")
+    val totalEarlyCheckOutCount: Int,
+    @Schema(description = "공결 인원")
+    val totalExcusedAbsenceCount: Int
 ) {
 
-    constructor(session: SessionEntity) : this(
+    constructor(session: SessionEntity, statistics: SessionAttendanceStatistics) : this(
         sessionId = session.id,
         name = session.name,
         startDate = session.date,
@@ -76,7 +83,13 @@ data class AdminAttendanceSessionResponse(
         endDate = session.endDate,
         endDayOfWeek = session.endDate.dayOfWeek.korean(),
         startTime = session.time,
-        endTime = session.endTime
+        endTime = session.endTime,
+        totalPersonCount = statistics.totalPersonCount,
+        totalOnTimeCount = statistics.totalOnTimeCount,
+        totalLateCount = statistics.totalLateCount,
+        totalAbsentCount = statistics.totalAbsentCount,
+        totalEarlyCheckOutCount = statistics.totalEarlyCheckOutCount,
+        totalExcusedAbsenceCount = statistics.totalExcusedAbsenceCount
     )
 }
 
@@ -86,13 +99,43 @@ data class AdminAttendanceUserResponse(
     @Schema(description = "이름")
     val name: String,
     @Schema(description = "직군", allowableValues = ["PM", "Design", "Web", "Android", "iOS", "Flutter", "Server", "운영진"])
-    val position: String
+    val position: String,
+    @Schema(description = "출석 횟수")
+    val onTimeCount: Int,
+    @Schema(description = "지각 횟수")
+    val lateCount: Int,
+    @Schema(description = "결석 횟수")
+    val absentCount: Int,
+    @Schema(description = "조퇴 횟수")
+    val earlyCheckOutCount: Int,
+    @Schema(description = "공결 횟수")
+    val excusedAbsenceCount: Int,
+    @Schema(description = "지각 면제권 개수")
+    val latePassCount: Int,
+    @Schema(description = "총점, 100점이 최대")
+    val totalPoint: Int,
+    @Schema(description = "감점")
+    val penaltyPoint: Int,
+    @Schema(description = "가점")
+    val bonusPoint: Int
 ) {
 
-    constructor(user: UserWithActivityUnit) : this(
+    constructor(
+        user: UserWithActivityUnit,
+        statistics: UserAttendanceStatistics
+    ) : this(
         userId = user.userId,
         name = user.name,
-        position = user.position.name
+        position = user.position.name,
+        onTimeCount = statistics.onTimeCount,
+        lateCount = statistics.lateCount,
+        absentCount = statistics.absentCount,
+        earlyCheckOutCount = statistics.earlyCheckOutCount,
+        excusedAbsenceCount = statistics.excusedAbsenceCount,
+        latePassCount = statistics.latePassCount,
+        totalPoint = statistics.totalPoint,
+        penaltyPoint = statistics.penaltyPoint,
+        bonusPoint = statistics.bonusPoint
     )
 }
 
@@ -127,6 +170,20 @@ data class AdminSessionAttendanceGroupResponse(
                 }
             )
         }
+
+        fun from(
+            sessionId: UUID,
+            attendanceByUserId: Map<UUID, AttendanceStatus?>
+        ): AdminSessionAttendanceGroupResponse =
+            AdminSessionAttendanceGroupResponse(
+                sessionId = sessionId,
+                attendances = attendanceByUserId.map { (userId, status) ->
+                    AdminUserAttendanceResponse(
+                        userId = userId,
+                        status = status?.label
+                    )
+                }
+            )
     }
 }
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponse.kt
@@ -2,7 +2,7 @@ package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.global.util.DatetimeUtils.korean
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
-import co.yappuworld.schedule.domain.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.infrastructure.model.UserWithActivityUnit

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.domain.vo.SessionType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionOverviewResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionOverviewResponse.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.domain.vo.SessionType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponse.kt
@@ -1,9 +1,9 @@
 package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
-import co.yappuworld.schedule.domain.AttendanceStatus.ABSENT
-import co.yappuworld.schedule.domain.AttendanceStatus.LATE
-import co.yappuworld.schedule.domain.AttendanceStatus.ON_TIME
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.LATE
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ON_TIME
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
@@ -4,12 +4,12 @@ import co.yappuworld.global.util.LocalDateRange
 import co.yappuworld.global.util.DatetimeUtils.korean
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
-import co.yappuworld.schedule.domain.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
 import co.yappuworld.schedule.infrastructure.entity.ScheduleEntity
-import co.yappuworld.schedule.domain.ScheduleProgressPhase
-import co.yappuworld.schedule.domain.ScheduleType
+import co.yappuworld.schedule.domain.vo.ScheduleProgressPhase
+import co.yappuworld.schedule.domain.vo.ScheduleType
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.entity.TaskEntity
 import co.yappuworld.schedule.domain.getProgressPhase
 import co.yappuworld.user.domain.model.UserWithActivityUnits

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminAttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminAttendanceApi.kt
@@ -41,7 +41,13 @@ interface AdminAttendanceApi {
                                                     "endDate": "2025-04-18",
                                                     "endDayOfWeek": "금",
                                                     "startTime": "13:30:00",
-                                                    "endTime": "17:00:00"
+                                                    "endTime": "17:00:00",
+                                                    "totalPersonCount": 2,
+                                                    "totalOnTimeCount": 1,
+                                                    "totalLateCount": 0,
+                                                    "totalAbsentCount": 1,
+                                                    "totalEarlyCheckOutCount": 0,
+                                                    "totalExcusedAbsenceCount": 0
                                                 },
                                                 {
                                                     "sessionId": "c07afa8b-1b30-11f0-add0-0242ac140002",
@@ -51,19 +57,43 @@ interface AdminAttendanceApi {
                                                     "endDate": "2025-05-08",
                                                     "endDayOfWeek": "목",
                                                     "startTime": "13:30:00",
-                                                    "endTime": "17:00:00"
+                                                    "endTime": "17:00:00",
+                                                    "totalPersonCount": 2,
+                                                    "totalOnTimeCount": 0,
+                                                    "totalLateCount": 0,
+                                                    "totalAbsentCount": 0,
+                                                    "totalEarlyCheckOutCount": 0,
+                                                    "totalExcusedAbsenceCount": 0
                                                 }
                                             ],
                                             "users": [
                                                 {
                                                     "userId": "01954809-38fd-1268-e0d6-d3fda39f6b4c",
                                                     "name": "홍길동",
-                                                    "position": "PM"
+                                                    "position": "PM",
+                                                    "onTimeCount": 1,
+                                                    "lateCount": 0,
+                                                    "absentCount": 0,
+                                                    "earlyCheckOutCount": 0,
+                                                    "excusedAbsenceCount": 0,
+                                                    "latePassCount": 0,
+                                                    "totalPoint": 100,
+                                                    "penaltyPoint": 0,
+                                                    "bonusPoint": 0
                                                 },
                                                 {
                                                     "userId": "12954809-38fd-1268-e0d6-d3fda39f6b4c",
                                                     "name": "임꺽정",
-                                                    "position": "Server"
+                                                    "position": "Server",
+                                                    "onTimeCount": 0,
+                                                    "lateCount": 0,
+                                                    "absentCount": 1,
+                                                    "earlyCheckOutCount": 0,
+                                                    "excusedAbsenceCount": 0,
+                                                    "latePassCount": 1,
+                                                    "totalPoint": 90,
+                                                    "penaltyPoint": 20,
+                                                    "bonusPoint": 10
                                                 }
                                             ],
                                             "attendancesGroupedBySession": [

--- a/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
@@ -1,0 +1,73 @@
+package co.yappuworld.schedule.domain
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.schedule.domain.vo.AttendanceError
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
+import co.yappuworld.schedule.infrastructure.entity.LatePassEntity
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
+import java.time.LocalDateTime
+import java.util.UUID
+
+class AttendanceBook(
+    val generation: Int,
+    users: List<UserWithActivityUnit>,
+    sessionEntities: List<SessionEntity>,
+    attendanceEntities: List<AttendanceEntity>,
+    latePassEntities: List<LatePassEntity>,
+    private val now: LocalDateTime
+) {
+
+    // sessionId to userId to AttendanceStatus
+    private val bySession: Map<UUID, Map<UUID, AttendanceStatus?>>
+
+    // userId to sessionId to AttendanceStatus
+    private val byUser: Map<UUID, Map<UUID, AttendanceStatus?>>
+
+    // userId to latePass
+    private val latePassByUserId = latePassEntities.groupBy { it.userId }
+
+    init {
+        require(users.all { it.generation == generation } || sessionEntities.all { it.generation == generation })
+
+        // (userId to sessionId) to AttendanceStatus
+        val attendanceMatrix = attendanceEntities.associate { (it.userId to it.scheduleId) to it.status }
+
+        this.bySession = sessionEntities.associate { session ->
+            session.id to users.associate { user ->
+                val status = attendanceMatrix[user.userId to session.id]
+                    ?: if (session.isFinished(now)) AttendanceStatus.ABSENT else null
+                user.userId to status
+            }
+        }
+
+        this.byUser = users.associate { user ->
+            user.userId to sessionEntities.associate { session ->
+                val status = attendanceMatrix[user.userId to session.id]
+                    ?: if (session.isFinished(now)) AttendanceStatus.ABSENT else null
+                session.id to status
+            }
+        }
+    }
+
+    fun getStatus(
+        sessionId: UUID,
+        userId: UUID
+    ): AttendanceStatus? {
+        if (!bySession.containsKey(sessionId)) throw BusinessException(AttendanceError.SESSION_NOT_FOUND)
+        val sessionAttendances = bySession[sessionId] ?: throw BusinessException(AttendanceError.SESSION_NOT_FOUND)
+        if (!sessionAttendances.containsKey(userId)) throw BusinessException(AttendanceError.USER_NOT_FOUND)
+        return sessionAttendances[userId]
+    }
+
+    fun userAttendanceStatistics(userId: UUID): UserAttendanceStatistics {
+        val userAttendances = byUser[userId] ?: throw BusinessException(AttendanceError.USER_NOT_FOUND)
+        return UserAttendanceStatistics.from(userAttendances.map { it.value }, latePassByUserId[userId]?.size ?: 0)
+    }
+
+    fun sessionAttendanceStatistics(sessionId: UUID): SessionAttendanceStatistics {
+        val sessionAttendances = bySession[sessionId] ?: throw BusinessException(AttendanceError.SESSION_NOT_FOUND)
+        return SessionAttendanceStatistics.from(sessionAttendances.map { it.value })
+    }
+}

--- a/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
@@ -12,10 +12,10 @@ import java.util.UUID
 
 class AttendanceBook(
     val generation: Int,
-    users: List<UserWithActivityUnit>,
-    sessionEntities: List<SessionEntity>,
+    val users: List<UserWithActivityUnit>,
+    val sessions: List<SessionEntity>,
     attendanceEntities: List<AttendanceEntity>,
-    latePassEntities: List<LatePassEntity>,
+    val latePasses: List<LatePassEntity>,
     private val now: LocalDateTime
 ) {
 
@@ -26,15 +26,15 @@ class AttendanceBook(
     private val byUser: Map<UUID, Map<UUID, AttendanceStatus?>>
 
     // userId to latePass
-    private val latePassByUserId = latePassEntities.groupBy { it.userId }
+    private val latePassByUserId = latePasses.groupBy { it.userId }
 
     init {
-        require(users.all { it.generation == generation } || sessionEntities.all { it.generation == generation })
+        require(users.all { it.generation == generation } || sessions.all { it.generation == generation })
 
         // (userId to sessionId) to AttendanceStatus
         val attendanceMatrix = attendanceEntities.associate { (it.userId to it.scheduleId) to it.status }
 
-        this.bySession = sessionEntities.associate { session ->
+        this.bySession = sessions.associate { session ->
             session.id to users.associate { user ->
                 val status = attendanceMatrix[user.userId to session.id]
                     ?: if (session.isFinished(now)) AttendanceStatus.ABSENT else null
@@ -43,13 +43,16 @@ class AttendanceBook(
         }
 
         this.byUser = users.associate { user ->
-            user.userId to sessionEntities.associate { session ->
+            user.userId to sessions.associate { session ->
                 val status = attendanceMatrix[user.userId to session.id]
                     ?: if (session.isFinished(now)) AttendanceStatus.ABSENT else null
                 session.id to status
             }
         }
     }
+
+    fun getSessionStatuses(sessionId: UUID): Map<UUID, AttendanceStatus?> =
+        bySession[sessionId] ?: throw BusinessException(AttendanceError.SESSION_NOT_FOUND)
 
     fun getStatus(
         sessionId: UUID,

--- a/src/main/kotlin/co/yappuworld/schedule/domain/AttendancePolicy.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/AttendancePolicy.kt
@@ -1,0 +1,8 @@
+package co.yappuworld.schedule.domain
+
+object AttendancePolicy {
+    const val ATTENDANCE_DEFAULT_POINT = 100
+    const val LATE_PENALTY = 10
+    const val ABSENT_PENALTY = 20
+    const val LATE_PASS_BONUS = 10
+}

--- a/src/main/kotlin/co/yappuworld/schedule/domain/ScheduleProgressPhaseEvaluator.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/ScheduleProgressPhaseEvaluator.kt
@@ -1,8 +1,9 @@
 package co.yappuworld.schedule.domain
 
-import co.yappuworld.schedule.domain.ScheduleProgressPhase.DONE
-import co.yappuworld.schedule.domain.ScheduleProgressPhase.ONGOING
-import co.yappuworld.schedule.domain.ScheduleProgressPhase.PENDING
+import co.yappuworld.schedule.domain.vo.ScheduleProgressPhase
+import co.yappuworld.schedule.domain.vo.ScheduleProgressPhase.DONE
+import co.yappuworld.schedule.domain.vo.ScheduleProgressPhase.ONGOING
+import co.yappuworld.schedule.domain.vo.ScheduleProgressPhase.PENDING
 import co.yappuworld.schedule.infrastructure.entity.ScheduleEntity
 import java.time.LocalDateTime
 

--- a/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
@@ -4,6 +4,8 @@ import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.util.DatetimeUtils.dDayFrom
 import co.yappuworld.global.util.DatetimeUtils.isBeforeOrEqual
 import co.yappuworld.global.util.DatetimeUtils.korean
+import co.yappuworld.schedule.domain.vo.AttendanceError
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.user.domain.vo.UserRole

--- a/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendanceStatistics.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendanceStatistics.kt
@@ -1,0 +1,25 @@
+package co.yappuworld.schedule.domain
+
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+
+data class SessionAttendanceStatistics(
+    val totalPersonCount: Int,
+    val totalOnTimeCount: Int,
+    val totalLateCount: Int,
+    val totalAbsentCount: Int,
+    val totalEarlyCheckOutCount: Int,
+    val totalExcusedAbsenceCount: Int
+) {
+
+    companion object {
+        fun from(statuses: List<AttendanceStatus?>): SessionAttendanceStatistics =
+            SessionAttendanceStatistics(
+                totalPersonCount = statuses.size,
+                totalOnTimeCount = statuses.count { it == AttendanceStatus.ON_TIME },
+                totalLateCount = statuses.count { it == AttendanceStatus.LATE },
+                totalAbsentCount = statuses.count { it == AttendanceStatus.ABSENT },
+                totalEarlyCheckOutCount = statuses.count { it == AttendanceStatus.EARLY_CHECK_OUT },
+                totalExcusedAbsenceCount = statuses.count { it == AttendanceStatus.EXCUSED_ABSENCE }
+            )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/schedule/domain/UserAttendanceStatistics.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/UserAttendanceStatistics.kt
@@ -1,0 +1,53 @@
+package co.yappuworld.schedule.domain
+
+import co.yappuworld.schedule.domain.AttendancePolicy.ABSENT_PENALTY
+import co.yappuworld.schedule.domain.AttendancePolicy.ATTENDANCE_DEFAULT_POINT
+import co.yappuworld.schedule.domain.AttendancePolicy.LATE_PASS_BONUS
+import co.yappuworld.schedule.domain.AttendancePolicy.LATE_PENALTY
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import kotlin.math.min
+
+data class UserAttendanceStatistics(
+    val totalSessionCount: Int,
+    val onTimeCount: Int,
+    val lateCount: Int,
+    val absentCount: Int,
+    val earlyCheckOutCount: Int,
+    val excusedAbsenceCount: Int,
+    val latePassCount: Int,
+    val totalPoint: Int,
+    val penaltyPoint: Int,
+    val bonusPoint: Int
+) {
+
+    companion object {
+        fun from(
+            attendances: List<AttendanceStatus?>,
+            latePassCount: Int
+        ): UserAttendanceStatistics {
+            val totalSessionCount = attendances.size
+            val onTimeCount = attendances.count { it == AttendanceStatus.ON_TIME }
+            val lateCount = attendances.count { it == AttendanceStatus.LATE }
+            val absentCount = attendances.count { it == AttendanceStatus.ABSENT }
+            val earlyCheckOutCount = attendances.count { it == AttendanceStatus.EARLY_CHECK_OUT }
+            val excusedAbsenceCount = attendances.count { it == AttendanceStatus.EXCUSED_ABSENCE }
+
+            val penaltyPoint = (lateCount * LATE_PENALTY) + (absentCount * ABSENT_PENALTY)
+            val bonusPoint = latePassCount * LATE_PASS_BONUS
+            val totalPoint = min(ATTENDANCE_DEFAULT_POINT - penaltyPoint + bonusPoint, ATTENDANCE_DEFAULT_POINT)
+
+            return UserAttendanceStatistics(
+                totalSessionCount = totalSessionCount,
+                onTimeCount = onTimeCount,
+                lateCount = lateCount,
+                absentCount = absentCount,
+                earlyCheckOutCount = earlyCheckOutCount,
+                excusedAbsenceCount = excusedAbsenceCount,
+                latePassCount = latePassCount,
+                totalPoint = totalPoint,
+                penaltyPoint = penaltyPoint,
+                bonusPoint = bonusPoint
+            )
+        }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceError.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceError.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.schedule.domain
+package co.yappuworld.schedule.domain.vo
 
 import co.yappuworld.global.exception.Error
 import co.yappuworld.global.exception.ErrorType
@@ -62,6 +62,11 @@ enum class AttendanceError : Error {
         override val message: String = "출석할 수 있는 권한이 없습니다."
         override val code: String = "ATD_2004"
         override val type: ErrorType = ErrorType.FORBIDDEN
+    },
+    USER_NOT_FOUND {
+        override val message: String = "유저의 출석 정보를 찾을 수 없습니다."
+        override val code: String = "ATD_2005"
+        override val type: ErrorType = ErrorType.NOT_FOUND
     },
 
     // 4000번대 - 어드민

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceStatus.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceStatus.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.schedule.domain
+package co.yappuworld.schedule.domain.vo
 
 /**
  * @property ON_TIME 제 시간에 정상적으로 출석

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/ScheduleError.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/ScheduleError.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.schedule.domain
+package co.yappuworld.schedule.domain.vo
 
 import co.yappuworld.global.exception.Error
 import co.yappuworld.global.exception.ErrorType

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/ScheduleProgressPhase.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/ScheduleProgressPhase.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.schedule.domain
+package co.yappuworld.schedule.domain.vo
 
 enum class ScheduleProgressPhase(
     private val label: String

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/ScheduleType.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/ScheduleType.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.schedule.domain
+package co.yappuworld.schedule.domain.vo
 
 enum class ScheduleType {
     SESSION,

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/SessionProgressPhase.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/SessionProgressPhase.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.schedule.domain
+package co.yappuworld.schedule.domain.vo
 
 enum class SessionProgressPhase(
     val label: String

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/SessionType.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/SessionType.kt
@@ -1,4 +1,4 @@
-package co.yappuworld.schedule.domain
+package co.yappuworld.schedule.domain.vo
 
 enum class SessionType(
     val label: String

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassFindService.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.infrastructure
 
+import co.yappuworld.schedule.infrastructure.entity.LatePassEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -14,4 +15,6 @@ class LatePassFindService(
         generation: Int,
         userId: UUID
     ): Int = latePassRepository.countAllByGenerationAndUserId(generation, userId)
+
+    fun findLatePasses(generation: Int): List<LatePassEntity> = latePassRepository.findAllByGeneration(generation)
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassRepository.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassRepository.kt
@@ -10,4 +10,6 @@ interface LatePassRepository : JpaRepository<LatePassEntity, Long> {
         generation: Int,
         userId: UUID
     ): Int
+
+    fun findAllByGeneration(generation: Int): List<LatePassEntity>
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.schedule.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.schedule.domain.ScheduleError
+import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendance
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendance.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendance.kt
@@ -1,8 +1,8 @@
 package co.yappuworld.schedule.infrastructure.dto
 
 import co.yappuworld.global.util.DatetimeUtils.isBeforeOrEqual
-import co.yappuworld.schedule.domain.AttendanceStatus
-import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.SessionType
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
@@ -2,7 +2,7 @@ package co.yappuworld.schedule.infrastructure.entity
 
 import co.yappuworld.global.persistence.BaseEntity
 import co.yappuworld.global.util.DatetimeUtils.isBeforeOrEqual
-import co.yappuworld.schedule.domain.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/ScheduleEntity.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/ScheduleEntity.kt
@@ -2,7 +2,7 @@ package co.yappuworld.schedule.infrastructure.entity
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.persistence.BaseEntity
-import co.yappuworld.schedule.domain.ScheduleError
+import co.yappuworld.schedule.domain.vo.ScheduleError
 import jakarta.persistence.DiscriminatorColumn
 import jakarta.persistence.DiscriminatorType
 import jakarta.persistence.Entity

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/SessionEntity.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/SessionEntity.kt
@@ -1,9 +1,9 @@
 package co.yappuworld.schedule.infrastructure.entity
 
 import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.schedule.domain.AttendanceError
-import co.yappuworld.schedule.domain.AttendanceStatus
-import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.domain.vo.AttendanceError
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.SessionType
 import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
@@ -4,7 +4,7 @@ import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.operation.infrastructure.ConfigFindService
 import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
-import co.yappuworld.schedule.domain.AttendanceError
+import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.LatePassFindService

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleServiceSessionProgressPhaseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleServiceSessionProgressPhaseTest.kt
@@ -1,10 +1,10 @@
 package co.yappuworld.schedule.client.application
 
 import co.yappuworld.operation.infrastructure.GenerationFindService
-import co.yappuworld.schedule.domain.SessionProgressPhase.DONE
-import co.yappuworld.schedule.domain.SessionProgressPhase.PENDING
-import co.yappuworld.schedule.domain.SessionProgressPhase.TODAY
-import co.yappuworld.schedule.domain.SessionProgressPhase.UPCOMING
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase.DONE
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase.PENDING
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase.TODAY
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase.UPCOMING
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.ScheduleFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
@@ -2,9 +2,9 @@ package co.yappuworld.schedule.client.application
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.operation.infrastructure.GenerationFindService
-import co.yappuworld.schedule.domain.AttendanceError
-import co.yappuworld.schedule.domain.AttendanceStatus
-import co.yappuworld.schedule.domain.ScheduleError
+import co.yappuworld.schedule.domain.vo.AttendanceError
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.ScheduleFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
@@ -1,8 +1,8 @@
 package co.yappuworld.schedule.client.dto.response
 
-import co.yappuworld.schedule.domain.AttendanceStatus.ABSENT
-import co.yappuworld.schedule.domain.AttendanceStatus.LATE
-import co.yappuworld.schedule.domain.AttendanceStatus.ON_TIME
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.LATE
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ON_TIME
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitFixture

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.client.dto.response
 
+import co.yappuworld.schedule.domain.AttendanceBook
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.LATE
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ON_TIME
@@ -41,10 +42,14 @@ class AdminAttendancesResponseTest :
 
             scenario("세션, 유저, 출석 정보를 기반으로 AdminAttendancesResponse를 생성한다.") {
                 val response = AdminAttendancesResponse.from(
-                    sessions = sessions,
-                    users = users,
-                    attendances = attendances,
-                    now = now
+                    AttendanceBook(
+                        generation = generation,
+                        users = users,
+                        sessions = sessions,
+                        attendanceEntities = attendances,
+                        latePasses = emptyList(),
+                        now = now
+                    )
                 )
 
                 response.users shouldHaveSize 3

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.schedule.client.dto.response
 
-import co.yappuworld.schedule.domain.AttendanceStatus
-import co.yappuworld.schedule.domain.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import io.kotest.core.spec.style.FeatureSpec

--- a/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
@@ -72,9 +72,9 @@ class AttendanceBookTest :
                     AttendanceBook(
                         generation = generation,
                         users = users,
-                        sessionEntities = sessions,
+                        sessions = sessions,
                         attendanceEntities = attendances,
-                        latePassEntities = latePassEntities,
+                        latePasses = latePassEntities,
                         now = now
                     )
                 }
@@ -84,9 +84,9 @@ class AttendanceBookTest :
                 val attendanceBook = AttendanceBook(
                     generation = generation,
                     users = users,
-                    sessionEntities = sessions,
+                    sessions = sessions,
                     attendanceEntities = attendances,
-                    latePassEntities = latePassEntities,
+                    latePasses = latePassEntities,
                     now = now
                 )
 
@@ -134,9 +134,9 @@ class AttendanceBookTest :
                 val attendanceBook = AttendanceBook(
                     generation = generation,
                     users = users,
-                    sessionEntities = sessions,
+                    sessions = sessions,
                     attendanceEntities = attendances,
-                    latePassEntities = latePassEntities,
+                    latePasses = latePassEntities,
                     now = now
                 )
 
@@ -172,9 +172,9 @@ class AttendanceBookTest :
                 val attendanceBook = AttendanceBook(
                     generation = generation,
                     users = users,
-                    sessionEntities = sessions,
+                    sessions = sessions,
                     attendanceEntities = attendances,
-                    latePassEntities = listOf(
+                    latePasses = listOf(
                         LatePassEntity(
                             userId = users[0].userId,
                             generation = generation
@@ -194,9 +194,9 @@ class AttendanceBookTest :
                 val attendanceBook = AttendanceBook(
                     generation = generation,
                     users = users,
-                    sessionEntities = sessions,
+                    sessions = sessions,
                     attendanceEntities = attendances,
-                    latePassEntities = latePassEntities,
+                    latePasses = latePassEntities,
                     now = now
                 )
 

--- a/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
@@ -1,0 +1,215 @@
+package co.yappuworld.schedule.domain
+
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.infrastructure.entity.LatePassEntity
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitFixture
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class AttendanceBookTest :
+    FeatureSpec({
+        val now = LocalDateTime.of(2024, 12, 10, 0, 0)
+        val generation = 25
+        val users = List(3) { getUserWithActivityUnitFixture(generation = generation) }
+        val sessions = listOf(
+            getSessionEntityFixture(
+                name = "1",
+                date = now.toLocalDate().minusDays(2),
+                endDate = now.toLocalDate().minusDays(2),
+                generation = generation
+            ),
+            getSessionEntityFixture(
+                name = "2",
+                date = now.toLocalDate().minusDays(1),
+                endDate = now.toLocalDate().minusDays(1),
+                generation = generation
+            ),
+            getSessionEntityFixture(
+                name = "3",
+                date = now.toLocalDate().plusDays(1),
+                endDate = now.toLocalDate().plusDays(1),
+                generation = generation
+            )
+        )
+
+        feature("임의의 데이터로 AttendanceBook을 생성한다.") {
+
+            val attendances = listOf(
+                getAttendanceEntityFixture(
+                    userId = users[0].userId,
+                    scheduleId = sessions[0].id,
+                    status = AttendanceStatus.ON_TIME
+                ),
+                getAttendanceEntityFixture(
+                    userId = users[0].userId,
+                    scheduleId = sessions[1].id,
+                    status = AttendanceStatus.LATE
+                ),
+                getAttendanceEntityFixture(
+                    userId = users[1].userId,
+                    scheduleId = sessions[0].id,
+                    status = AttendanceStatus.ABSENT
+                ),
+                getAttendanceEntityFixture(
+                    userId = users[2].userId,
+                    scheduleId = sessions[1].id,
+                    status = AttendanceStatus.LATE
+                )
+            )
+            val latePassEntities = listOf(
+                LatePassEntity(
+                    userId = users[0].userId,
+                    generation = generation
+                )
+            )
+
+            scenario("AttendanceBook을 생성한다.") {
+                shouldNotThrowAny {
+                    AttendanceBook(
+                        generation = generation,
+                        users = users,
+                        sessionEntities = sessions,
+                        attendanceEntities = attendances,
+                        latePassEntities = latePassEntities,
+                        now = now
+                    )
+                }
+            }
+
+            scenario("유저 출석 통계가 정상적으로 생성된다.") {
+                val attendanceBook = AttendanceBook(
+                    generation = generation,
+                    users = users,
+                    sessionEntities = sessions,
+                    attendanceEntities = attendances,
+                    latePassEntities = latePassEntities,
+                    now = now
+                )
+
+                attendanceBook.userAttendanceStatistics(users[0].userId).let {
+                    it.totalSessionCount shouldBe 3
+                    it.onTimeCount shouldBe 1
+                    it.lateCount shouldBe 1
+                    it.absentCount shouldBe 0
+                    it.earlyCheckOutCount shouldBe 0
+                    it.excusedAbsenceCount shouldBe 0
+                    it.latePassCount shouldBe 1
+                    it.totalPoint shouldBe 100
+                    it.penaltyPoint shouldBe 10
+                    it.bonusPoint shouldBe 10
+                }
+
+                attendanceBook.userAttendanceStatistics(users[1].userId).let {
+                    it.totalSessionCount shouldBe 3
+                    it.onTimeCount shouldBe 0
+                    it.lateCount shouldBe 0
+                    it.absentCount shouldBe 2
+                    it.earlyCheckOutCount shouldBe 0
+                    it.excusedAbsenceCount shouldBe 0
+                    it.latePassCount shouldBe 0
+                    it.totalPoint shouldBe 60
+                    it.penaltyPoint shouldBe 40
+                    it.bonusPoint shouldBe 0
+                }
+
+                attendanceBook.userAttendanceStatistics(users[2].userId).let {
+                    it.totalSessionCount shouldBe 3
+                    it.onTimeCount shouldBe 0
+                    it.lateCount shouldBe 1
+                    it.absentCount shouldBe 1
+                    it.earlyCheckOutCount shouldBe 0
+                    it.excusedAbsenceCount shouldBe 0
+                    it.latePassCount shouldBe 0
+                    it.totalPoint shouldBe 70
+                    it.penaltyPoint shouldBe 30
+                    it.bonusPoint shouldBe 0
+                }
+            }
+
+            scenario("세션 출석 통계가 정상적으로 생성된다.") {
+                val attendanceBook = AttendanceBook(
+                    generation = generation,
+                    users = users,
+                    sessionEntities = sessions,
+                    attendanceEntities = attendances,
+                    latePassEntities = latePassEntities,
+                    now = now
+                )
+
+                attendanceBook.sessionAttendanceStatistics(sessions[0].id).let {
+                    it.totalPersonCount shouldBe 3
+                    it.totalOnTimeCount shouldBe 1
+                    it.totalLateCount shouldBe 0
+                    it.totalAbsentCount shouldBe 2
+                    it.totalEarlyCheckOutCount shouldBe 0
+                    it.totalExcusedAbsenceCount shouldBe 0
+                }
+
+                attendanceBook.sessionAttendanceStatistics(sessions[1].id).let {
+                    it.totalPersonCount shouldBe 3
+                    it.totalOnTimeCount shouldBe 0
+                    it.totalLateCount shouldBe 2
+                    it.totalAbsentCount shouldBe 1
+                    it.totalEarlyCheckOutCount shouldBe 0
+                    it.totalExcusedAbsenceCount shouldBe 0
+                }
+
+                attendanceBook.sessionAttendanceStatistics(sessions[2].id).let {
+                    it.totalPersonCount shouldBe 3
+                    it.totalOnTimeCount shouldBe 0
+                    it.totalLateCount shouldBe 0
+                    it.totalAbsentCount shouldBe 0
+                    it.totalEarlyCheckOutCount shouldBe 0
+                    it.totalExcusedAbsenceCount shouldBe 0
+                }
+            }
+
+            scenario("지각 면제권이 100점을 초과하도록 주어져도, total point는 100점을 넘지 않는다.") {
+                val attendanceBook = AttendanceBook(
+                    generation = generation,
+                    users = users,
+                    sessionEntities = sessions,
+                    attendanceEntities = attendances,
+                    latePassEntities = listOf(
+                        LatePassEntity(
+                            userId = users[0].userId,
+                            generation = generation
+                        ),
+                        LatePassEntity(
+                            userId = users[0].userId,
+                            generation = generation
+                        )
+                    ),
+                    now = now
+                )
+
+                attendanceBook.userAttendanceStatistics(users[0].userId).totalPoint shouldBe 100
+            }
+
+            scenario("출석 데이터가 정상적으로 생성된다.") {
+                val attendanceBook = AttendanceBook(
+                    generation = generation,
+                    users = users,
+                    sessionEntities = sessions,
+                    attendanceEntities = attendances,
+                    latePassEntities = latePassEntities,
+                    now = now
+                )
+
+                for (user in users) {
+                    for (session in sessions) {
+                        val expected = attendanceBook.getStatus(session.id, user.userId)
+                        val actual = attendances
+                            .find { it.userId == user.userId && it.scheduleId == session.id }
+                            ?.status
+                            ?: if (session.isFinished(now)) AttendanceStatus.ABSENT else null
+                        expected shouldBe actual
+                    }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandServiceTest.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.schedule.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.schedule.domain.AttendanceError
+import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getSessionAttendanceFixture

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.schedule.infrastructure
 
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
-import co.yappuworld.schedule.domain.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.support.environment.CustomDataJpaTest
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture

--- a/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
@@ -2,7 +2,7 @@ package co.yappuworld.support.fixture
 
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
-import co.yappuworld.schedule.domain.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture

--- a/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
@@ -1,8 +1,8 @@
 package co.yappuworld.support.fixture
 
-import co.yappuworld.schedule.domain.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.schedule.domain.SessionType
+import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.entity.TaskEntity
 import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendance
 import java.time.LocalDate


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 어드민에서 출석 정보를 조회할 때, 유저와 세션에 대한 통계 정보도 포함되어야 합니다.


## ⭐️ 어떻게 해결했나요?
- AttendanceBook(출석부) 도메인을 생성하였습니다.
- 해당 도메인에서 byUser(유저별), bySession(세션별) 변수를 통해, 다양한 도메인 요구사항을 처리합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
