### PR TITLE
fix: 미래 세션에 대한 출석 데이터 검증 제거

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
@@ -25,6 +25,8 @@ class AttendanceBook(
     // userId to sessionId to AttendanceStatus
     private val byUser: Map<UUID, Map<UUID, AttendanceStatus?>>
 
+    val finishedSessionCount = sessions.count { it.isFinished(now) }
+
     init {
         require(users.all { it.generation == generation } || sessions.all { it.generation == generation })
 
@@ -86,7 +88,11 @@ class AttendanceBook(
 
     fun getUserAttendanceStatistics(userId: UUID): UserAttendanceStatistics {
         val userAttendances = byUser[userId] ?: throw BusinessException(AttendanceError.USER_NOT_FOUND)
-        return UserAttendanceStatistics.from(userAttendances.map { it.value }, latePassCountByUserId[userId] ?: 0)
+        return UserAttendanceStatistics.from(
+            userAttendances.map { it.value },
+            finishedSessionCount,
+            latePassCountByUserId[userId] ?: 0
+        )
     }
 
     fun getSessionAttendanceStatistics(sessionId: UUID): SessionAttendanceStatistics {

--- a/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
@@ -30,12 +30,15 @@ class AttendanceBook(
 
         // (userId to sessionId) to AttendanceStatus
         val attendanceMatrix = attendances.associate { (it.userId to it.scheduleId) to it.status }
-        val decideStatus: (UserWithActivityUnit, SessionEntity) -> AttendanceStatus? = { user, session ->
+
+        fun decideStatus(
+            user: UserWithActivityUnit,
+            session: SessionEntity
+        ): AttendanceStatus? =
             when (session.isFinished(now)) {
                 true -> attendanceMatrix[user.userId to session.id] ?: AttendanceStatus.ABSENT
-                false -> attendanceMatrix[user.userId to session.id].also { require(it == null) }
+                false -> attendanceMatrix[user.userId to session.id]
             }
-        }
 
         this.bySession = sessions.associate { session ->
             session.id to users.associate { user ->

--- a/src/main/kotlin/co/yappuworld/schedule/domain/UserAttendanceStatistics.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/UserAttendanceStatistics.kt
@@ -24,10 +24,11 @@ data class UserAttendanceStatistics(
     companion object {
         fun from(
             attendances: List<AttendanceStatus?>,
+            finishedSessionCount: Int,
             latePassCount: Int
         ): UserAttendanceStatistics {
             val totalSessionCount = attendances.size
-            val leftSessionCount = attendances.count { it == null }
+            val leftSessionCount = totalSessionCount - finishedSessionCount
             val onTimeCount = attendances.count { it == AttendanceStatus.ON_TIME }
             val lateCount = attendances.count { it == AttendanceStatus.LATE }
             val absentCount = attendances.count { it == AttendanceStatus.ABSENT }

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceError.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceError.kt
@@ -68,6 +68,11 @@ enum class AttendanceError : Error {
         override val code: String = "ATD_2005"
         override val type: ErrorType = ErrorType.NOT_FOUND
     },
+    CANNOT_EXISTS_ATTENDANCE_FUTURE_SESSION {
+        override val message: String = "미래 세션에 출석할 수 없습니다."
+        override val code: String = "ATD_2006"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    },
 
     // 4000번대 - 어드민
     CANNOT_UPDATE_STATUS {

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/SessionEntity.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/SessionEntity.kt
@@ -74,7 +74,7 @@ class SessionEntity(
 
     fun isFinished(now: LocalDateTime): Boolean =
         endDate.isBefore(now.toLocalDate()) ||
-            (endDate.isEqual(now.toLocalDate()) && (endTime.isBefore(now.toLocalTime()) == true))
+            (endDate.isEqual(now.toLocalDate()) && endTime.isBefore(now.toLocalTime()))
 
     fun decideCheckInStatus(now: LocalDateTime): AttendanceStatus =
         when {


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 기존에 미래 세션에 대한 출석 데이터가 존재하는 경우 예외를 발생시키는 로직 존재
- 어드민에서 미래 세션에 대한 출석 데이터 수정이 가능하므로, 정합성 충돌 발생

## ⭐️ 어떻게 해결했나요?
- 미래 세션에 대한 출석 데이터가 존재하더라도 예외를 발생시키지 않습니다.
- 세션 진행률을 계산하는 방식을 변경합니다.
	- 기존에는 출석 데이터가 null인 개수를 카운트합니다.
	- 미래 세션에 대한 출석 데이터를 수정하는 경우, 실제 세션 진행률과 데이터 차이가 발생합니다.
	- 각 세션의 진행 여부를 판단하여 진행률을 체크합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
