### PR TITLE
fix: 어드민 유저 정보 변경 시 역할도 함께 받아서 처리 (#129)

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/co/yappuworld/global/config/SecurityConfig.kt
@@ -49,6 +49,7 @@ class SecurityConfig(
                     allowedHeaders = listOf("*")
                     allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                     allowedOriginPatterns = listOf("*")
+                    exposedHeaders = listOf("Location")
                 }
             )
         }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- Location 헤더가 웹 클라이언트 응답에 노출되지 않습니다.
- 세션, 공지사항 생성 후, Location 헤더로 상세 조회 엔드포인트를 전달하고자 했는데, 전달되지 않는 이슈가 있습니다.


## ⭐️ 어떻게 해결했나요?
- security 설정에서 exposedHeader 설정을 진행했습니다.
- exposedHeader 설정이 없으면 웹 클라이언트에서 기본 헤더들만 읽어들인다고 합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
