### PR TITLE
chore: prod 병합 이후 dev 브랜치에 merge

### DIFF
--- a/.github/workflows/yappu-world-prod-cd.yaml
+++ b/.github/workflows/yappu-world-prod-cd.yaml
@@ -151,5 +151,5 @@ jobs:
                 run: |
                     git fetch
                     git checkout -b dev origin/dev
-                    git rebase origin/prod
+                    git merge origin/prod --no-edit
                     git push origin dev --force-with-lease


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- dev -> prod로 merge 이후, dev가 prod의 merge commit을 똑같이 덮어쓰지 못합니다.


## ⭐️ 어떻게 해결했나요?
- 기존에 rebase이던 구문을 merge로 변경하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
