### PR TITLE
fix: 이번 기수 세션 목록 정렬

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
@@ -36,22 +36,22 @@ data class ActiveGenerationSessionsResponse(
         ): ActiveGenerationSessionsResponse {
             if (sessions.isEmpty()) return ActiveGenerationSessionsResponse(emptyList(), null)
 
-            val orderedSessions = sessions.sortedBy { it.date }
+            val orderedSessions = sessions.sortedWith(compareBy({ it.date }, { it.time }))
             val (upcomingSessionIndex, upcomingSessionStatus) = getUpcomingSessionIndexAndStatus(orderedSessions, now)
                 ?: return ActiveGenerationSessionsResponse(
-                    sessions.map { ActiveGenerationSessionResponse(it, DONE, now) },
-                    sessions.last().id
+                    orderedSessions.map { ActiveGenerationSessionResponse(it, DONE, now) },
+                    orderedSessions.last().id
                 )
 
             return ActiveGenerationSessionsResponse(
-                sessions = sessions.mapIndexed { index, session ->
+                sessions = orderedSessions.mapIndexed { index, session ->
                     when {
                         index < upcomingSessionIndex -> ActiveGenerationSessionResponse(session, DONE, now)
                         index > upcomingSessionIndex -> ActiveGenerationSessionResponse(session, PENDING, now)
                         else -> ActiveGenerationSessionResponse(session, upcomingSessionStatus, now)
                     }
                 },
-                upcomingSessionId = sessions[upcomingSessionIndex].id
+                upcomingSessionId = orderedSessions[upcomingSessionIndex].id
             )
         }
 

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
@@ -34,7 +34,7 @@ class SessionWithAttendanceDto(
 
     fun isFinished(now: LocalDateTime): Boolean =
         endDate.isBefore(now.toLocalDate()) ||
-            (endDate.isEqual(now.toLocalDate()) && (endTime.isBefore(now.toLocalTime()) == true))
+            (endDate.isEqual(now.toLocalDate()) && endTime.isBefore(now.toLocalTime()))
 
     fun isToday(now: LocalDateTime): Boolean =
         date.isBeforeOrEqual(now.toLocalDate()) && now.toLocalDate().isBeforeOrEqual(endDate)


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 세션이 정렬되지 않아서, upcomingIndex를 정상 계산하고도 엉뚱한 라벨이 붙어있는 경우 발생


## ⭐️ 어떻게 해결했나요?
- upcomingIndex 계산 시에 사용한 sortedSessions를 이외 응답 만들 때도 사용


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료
종료된된 세션인데 `임박` 태그가 노출

<img width="375" alt="image" src="https://github.com/user-attachments/assets/40c4f6d0-db52-4a6b-ba49-21cf18308867" />


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
