### PR TITLE
fix: 어드민 세션 정렬

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponse.kt
@@ -28,7 +28,7 @@ data class AttendanceStatisticsResponse(
                 AttendanceStatisticsResponse(
                     totalSessionCount = it.totalSessionCount,
                     remainingSessionCount = it.leftSessionCount,
-                    sessionProgressRate = (it.totalSessionCount - it.leftSessionCount) * 100 / it.totalSessionCount,
+                    sessionProgressRate = ((it.totalSessionCount - it.leftSessionCount) / it.totalSessionCount) * 100,
                     attendancePoint = it.totalPoint,
                     attendanceCount = it.onTimeCount,
                     lateCount = it.lateCount,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponse.kt
@@ -28,7 +28,7 @@ data class AttendanceStatisticsResponse(
                 AttendanceStatisticsResponse(
                     totalSessionCount = it.totalSessionCount,
                     remainingSessionCount = it.leftSessionCount,
-                    sessionProgressRate = ((it.totalSessionCount - it.leftSessionCount) / it.totalSessionCount) * 100,
+                    sessionProgressRate = ((1.0 - it.leftSessionCount.toDouble() / it.totalSessionCount) * 100).toInt(),
                     attendancePoint = it.totalPoint,
                     attendanceCount = it.onTimeCount,
                     lateCount = it.lateCount,

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
@@ -115,15 +115,13 @@ class SessionFindService(
                             path(AttendanceEntity::userId).equal(userId)
                         )
                     )
-                ).where(
-                    and(
-                        path(SessionEntity::generation).equal(generation),
-                        or(
-                            path(SessionEntity::endDate).lessThan(now.toLocalDate()),
-                            and(
-                                path(SessionEntity::endDate).equal(now.toLocalDate()),
-                                path(SessionEntity::endTime).lessThan(now.toLocalTime())
-                            )
+                ).whereAnd(
+                    path(SessionEntity::generation).equal(generation),
+                    or(
+                        path(SessionEntity::endDate).lessThan(now.toLocalDate()),
+                        and(
+                            path(SessionEntity::endDate).equal(now.toLocalDate()),
+                            path(SessionEntity::endTime).lessThan(now.toLocalTime())
                         )
                     )
                 )
@@ -136,6 +134,12 @@ class SessionFindService(
         val result = scheduleRepository.findPage(pageRequest) {
             select(entity(SessionEntity::class))
                 .from(entity(SessionEntity::class))
+                .orderBy(
+                    path(SessionEntity::date).desc(),
+                    path(SessionEntity::time).desc(),
+                    path(SessionEntity::endDate).desc(),
+                    path(SessionEntity::endTime).desc()
+                )
         }
 
         return PageImpl(result.content.filterNotNull(), result.pageable, result.totalElements)
@@ -149,6 +153,12 @@ class SessionFindService(
             select(entity(SessionEntity::class))
                 .from(entity(SessionEntity::class))
                 .where(path(SessionEntity::generation).equal(generation))
+                .orderBy(
+                    path(SessionEntity::date).desc(),
+                    path(SessionEntity::time).desc(),
+                    path(SessionEntity::endDate).desc(),
+                    path(SessionEntity::endTime).desc()
+                )
         }
 
         return PageImpl(result.content.filterNotNull(), result.pageable, result.totalElements)


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 어드민 세션 목록에서, 세션이 날짜 오름차순으로 정렬되는 이슈가 있었습니다.


## ⭐️ 어떻게 해결했나요?
- 세션 정렬 기준을 시작일, 시작시간, 종료일, 종료시간 순으로 내림차순 정렬을 진행합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
