### PR TITLE
feat: 특정 세션의 출석 정보 일괄 수정

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
@@ -2,6 +2,7 @@ package co.yappuworld.schedule.client.application
 
 import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.AdminAttendanceUpdateRequest
+import co.yappuworld.schedule.client.dto.request.AdminSessionAttendanceUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminAttendancesResponse
 import co.yappuworld.schedule.domain.AttendanceBook
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
@@ -60,5 +61,27 @@ class AdminAttendanceService(
         }
 
         if (newAttendances.isNotEmpty()) attendanceCommandService.saveAll(newAttendances)
+    }
+
+    @Transactional
+    fun updateSessionAttendances(request: AdminSessionAttendanceUpdateRequest) {
+        val activeGeneration = generationFindService.findActiveGeneration()
+        val users = userFindService.findUsersActiveOfGeneration(activeGeneration)
+        val existAttendances = attendanceFindService
+            .findAttendances(request.sessionId)
+            .associateBy { it.userId }
+
+        val allAttendances = users.map { user ->
+            when (existAttendances.containsKey(user.userId)) {
+                true -> existAttendances[user.userId]!!.apply { updateStatus(request.attendanceStatus) }
+                false -> AttendanceEntity(
+                    status = request.attendanceStatus,
+                    userId = user.userId,
+                    scheduleId = request.sessionId
+                )
+            }
+        }
+
+        attendanceCommandService.saveAll(allAttendances)
     }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionAttendanceUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionAttendanceUpdateRequest.kt
@@ -1,0 +1,12 @@
+package co.yappuworld.schedule.client.dto.request
+
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+data class AdminSessionAttendanceUpdateRequest(
+    @Schema(description = "일괄 업데이트 대상 세션 ID")
+    val sessionId: UUID,
+    @Schema(description = "업데이트 상태")
+    val attendanceStatus: AttendanceStatus
+)

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminAttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminAttendanceApi.kt
@@ -2,6 +2,7 @@ package co.yappuworld.schedule.client.presentation
 
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.schedule.client.dto.request.AdminAttendanceUpdateRequest
+import co.yappuworld.schedule.client.dto.request.AdminSessionAttendanceUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminAttendancesResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 
-@Tag(name = "어드민 출석 API", description = "_")
+@Tag(name = "어드민 일정 API", description = "일정 및 출석 관리")
 interface AdminAttendanceApi {
 
     @Operation(summary = "활성화 된 기수의 출석 목록 조회")
@@ -168,5 +169,36 @@ interface AdminAttendanceApi {
     @PutMapping("/admin/v1/attendances")
     fun updateAttendances(
         @RequestBody request: AdminAttendanceUpdateRequest
+    ): ResponseEntity<Unit>
+
+    @Operation(summary = "특정 세션의 출석 일괄 수정")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                content = [Content()]
+            ),
+            ApiResponse(
+                responseCode = "409",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                value = """
+                                    {
+                                        "isSuccess": false,
+                                        "errorCode": "ATD_4000",
+                                        "message": "출석 상태를 변경할 수 없습니다."
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    fun updateSessionAttendances(
+        @RequestBody request: AdminSessionAttendanceUpdateRequest
     ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminAttendanceController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminAttendanceController.kt
@@ -4,6 +4,7 @@ import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.util.DatetimeUtils.getCurrentDateTimeInKST
 import co.yappuworld.schedule.client.application.AdminAttendanceService
 import co.yappuworld.schedule.client.dto.request.AdminAttendanceUpdateRequest
+import co.yappuworld.schedule.client.dto.request.AdminSessionAttendanceUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminAttendancesResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -20,6 +21,11 @@ class AdminAttendanceController(
 
     override fun updateAttendances(request: AdminAttendanceUpdateRequest): ResponseEntity<Unit> {
         adminAttendanceService.updateAttendance(request)
+        return ResponseEntity.noContent().build()
+    }
+
+    override fun updateSessionAttendances(request: AdminSessionAttendanceUpdateRequest): ResponseEntity<Unit> {
+        adminAttendanceService.updateSessionAttendances(request)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 
-@Tag(name = "출석 API", description = "_")
+@Tag(name = "스케줄 API", description = "일정 및 출석")
 interface AttendanceApi {
 
     @Operation(summary = "출석")

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import java.util.UUID
 
-@Tag(name = "어드민 세션 API", description = "세션 관리")
+@Tag(name = "어드민 일정 API", description = "일정 및 출석 관리")
 interface ScheduleAdminApi {
 
     @Operation(summary = "세션 생성")

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -20,7 +20,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 
-@Tag(name = "스케줄 API", description = "세션 및 기타 일정 조회")
+@Tag(name = "스케줄 API", description = "일정 및 출석")
 interface ScheduleApi {
 
     @Operation(summary = "활동 중인 기수의 세션 목록")

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
@@ -67,4 +67,12 @@ class AttendanceFindService(
                     .from(entity(AttendanceEntity::class))
                     .where(or(*predicates.toTypedArray()))
             }.filterNotNull()
+
+    fun findAttendances(sessionId: UUID): List<AttendanceEntity> =
+        attendanceRepository
+            .findAll {
+                select(entity(AttendanceEntity::class))
+                    .from(entity(AttendanceEntity::class))
+                    .where(path(AttendanceEntity::scheduleId).equal(sessionId))
+            }.filterNotNull()
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceRepository.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceRepository.kt
@@ -18,4 +18,6 @@ interface AttendanceRepository :
         userId: UUID,
         scheduleId: UUID
     ): AttendanceEntity?
+
+    fun findAllByScheduleId(scheduleId: UUID): List<AttendanceEntity>
 }

--- a/src/test/kotlin/co/yappuworld/operation/infrastructure/ConfigCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/operation/infrastructure/ConfigCommandServiceTest.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.operation.infrastructure
 
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.user.domain.model.SignUpCodeBook
 import co.yappuworld.user.domain.vo.UserRole
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired
 class ConfigCommandServiceTest @Autowired constructor(
     private val configRepository: ConfigRepository,
     private val entityManager: EntityManager
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val configCommandService = ConfigCommandService(configRepository)
 

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceServiceTest.kt
@@ -1,0 +1,94 @@
+package co.yappuworld.schedule.client.application
+
+import co.yappuworld.schedule.client.dto.request.AdminSessionAttendanceUpdateRequest
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.infrastructure.AttendanceRepository
+import co.yappuworld.schedule.infrastructure.ScheduleRepository
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import co.yappuworld.support.environment.SpringBootTestFeatureSpec
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getActivityUnitParamFixture
+import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
+import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.infrastructure.UserCommandService
+import co.yappuworld.user.infrastructure.entity.UserEntity
+import io.kotest.inspectors.shouldForAll
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import org.springframework.beans.factory.annotation.Autowired
+
+class AdminAttendanceServiceTest @Autowired constructor(
+    private val adminAttendanceService: AdminAttendanceService,
+    private val userCommandService: UserCommandService,
+    private val scheduleRepository: ScheduleRepository,
+    private val attendanceRepository: AttendanceRepository
+) : SpringBootTestFeatureSpec({
+
+        feature("특정 세션의 출석 일괄 업데이트") {
+            val activeGeneration = 25
+
+            lateinit var users: List<UserEntity>
+            lateinit var session: SessionEntity
+
+            beforeTest {
+                users = List(2) {
+                    getSignUpApplicationEntityFixture(
+                        activityUnitParams = listOf(getActivityUnitParamFixture())
+                    )
+                }.map { userCommandService.signUp(it, UserRole.ACTIVE) }
+                session = scheduleRepository.save(getSessionEntityFixture(generation = activeGeneration))
+            }
+
+            scenario("출석 데이터가 아무것도 없다면, 모두 새로 생성한다.") {
+                adminAttendanceService.updateSessionAttendances(
+                    AdminSessionAttendanceUpdateRequest(
+                        sessionId = session.id,
+                        attendanceStatus = ABSENT
+                    )
+                )
+
+                attendanceRepository.findAllByScheduleId(session.id) shouldHaveSize 2
+            }
+
+            scenario("출석 데이터 중 일부 유저의 데이터가 없다면 새로 생성한다.") {
+                val attendance = getAttendanceEntityFixture(
+                    status = ABSENT,
+                    scheduleId = session.id,
+                    userId = users[0].id
+                )
+                attendanceRepository.save(attendance)
+
+                adminAttendanceService.updateSessionAttendances(
+                    AdminSessionAttendanceUpdateRequest(
+                        sessionId = session.id,
+                        attendanceStatus = ABSENT
+                    )
+                )
+
+                val attendances = attendanceRepository.findAllByScheduleId(session.id)
+                attendances shouldHaveSize 2
+                attendances.filterNot { it.userId == users[0].id }.shouldNotBeEmpty()
+            }
+
+            scenario("존재하는 출석 데이터는 상태가 업데이트 된다.") {
+                val attendance = getAttendanceEntityFixture(
+                    status = ABSENT,
+                    scheduleId = session.id,
+                    userId = users[0].id
+                )
+                attendanceRepository.save(attendance)
+
+                adminAttendanceService.updateSessionAttendances(
+                    AdminSessionAttendanceUpdateRequest(
+                        sessionId = session.id,
+                        attendanceStatus = ABSENT
+                    )
+                )
+
+                val attendances = attendanceRepository.findAllByScheduleId(session.id)
+                attendances shouldHaveSize 2
+                attendances.shouldForAll { it.status == ABSENT }
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandServiceTest.kt
@@ -2,7 +2,7 @@ package co.yappuworld.schedule.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.schedule.domain.vo.AttendanceError
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getSessionAttendanceFixture
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 
 class AttendanceCommandServiceTest @Autowired constructor(
     private val attendanceRepository: AttendanceRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val attendanceCommandService = AttendanceCommandService(attendanceRepository)
 

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindServiceTest.kt
@@ -2,7 +2,7 @@ package co.yappuworld.schedule.infrastructure
 
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired
 class AttendanceFindServiceTest @Autowired constructor(
     private val sessionRepository: ScheduleRepository,
     private val attendanceRepository: AttendanceRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val attendanceFindService = AttendanceFindService(attendanceRepository)
 

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
@@ -5,7 +5,7 @@ import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import io.kotest.assertions.throwables.shouldThrowExactly
@@ -21,7 +21,7 @@ import java.util.UUID
 class SessionFindServiceTest @Autowired constructor(
     private val scheduleRepository: ScheduleRepository,
     private val attendanceRepository: AttendanceRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val sessionFindService = SessionFindService(scheduleRepository)
 

--- a/src/test/kotlin/co/yappuworld/support/environment/CustomDataJpaTestFeatureSpec.kt
+++ b/src/test/kotlin/co/yappuworld/support/environment/CustomDataJpaTestFeatureSpec.kt
@@ -1,0 +1,12 @@
+package co.yappuworld.support.environment
+
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+
+@CustomDataJpaTest
+abstract class CustomDataJpaTestFeatureSpec(
+    body: FeatureSpec.() -> Unit
+) : FeatureSpec(body) {
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Test))
+}

--- a/src/test/kotlin/co/yappuworld/support/environment/SpringBootTestFeatureSpec.kt
+++ b/src/test/kotlin/co/yappuworld/support/environment/SpringBootTestFeatureSpec.kt
@@ -3,9 +3,12 @@ package co.yappuworld.support.environment
 import io.kotest.core.spec.style.FeatureSpec
 import io.kotest.extensions.spring.SpringTestExtension
 import io.kotest.extensions.spring.SpringTestLifecycleMode
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
 
-@CustomDataJpaTest
-abstract class CustomDataJpaFeatureSpec(
+@SpringBootTest
+@Transactional
+abstract class SpringBootTestFeatureSpec(
     body: FeatureSpec.() -> Unit
 ) : FeatureSpec(body) {
     override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Test))

--- a/src/test/kotlin/co/yappuworld/support/fixture/UserFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/UserFixture.kt
@@ -1,6 +1,9 @@
 package co.yappuworld.support.fixture
 
 import co.yappuworld.global.util.EncryptUtils
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.domain.vo.SignUpApplicationStatus
+import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
 import co.yappuworld.user.infrastructure.entity.ActivityUnitParam
 import co.yappuworld.user.infrastructure.entity.ApplicationDetails
@@ -8,9 +11,6 @@ import co.yappuworld.user.infrastructure.entity.SignUpApplicationEntity
 import co.yappuworld.user.infrastructure.entity.UserAlarmSettingEntity
 import co.yappuworld.user.infrastructure.entity.UserDeviceEntity
 import co.yappuworld.user.infrastructure.entity.UserEntity
-import co.yappuworld.user.domain.vo.Position
-import co.yappuworld.user.domain.vo.SignUpApplicationStatus
-import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
 import co.yappuworld.user.infrastructure.model.UserWithLastActivityUnit
 import java.time.LocalDateTime
@@ -38,7 +38,7 @@ object UserFixture {
         email: String = "email@email.com",
         plainPassword: String = "abcabC!!",
         name: String = "name",
-        activityUnitParams: List<ActivityUnitParam> = getActivityUnitParams(),
+        activityUnitParams: List<ActivityUnitParam> = getActivityUnitParamsFixture(),
         fcmToken: String = "bk3RNwTe3H0:CI2k_HHwgIpoDKCIZvvDMExUdFQ3P1",
         masterAlarmToggle: Boolean = true,
         status: SignUpApplicationStatus = SignUpApplicationStatus.PENDING,
@@ -62,7 +62,7 @@ object UserFixture {
         email: String = "email@email.com",
         plainPassword: String = "abcabC!!",
         name: String = "name",
-        activityUnitParams: List<ActivityUnitParam> = getActivityUnitParams(),
+        activityUnitParams: List<ActivityUnitParam> = getActivityUnitParamsFixture(),
         fcmToken: String = "bk3RNwTe3H0:CI2k_HHwgIpoDKCIZvvDMExUdFQ3P1",
         masterAlarmToggle: Boolean = true
     ): ApplicationDetails =
@@ -75,7 +75,7 @@ object UserFixture {
             masterAlarmToggle
         )
 
-    fun getActivityUnitParams(
+    fun getActivityUnitParamsFixture(
         vararg activityUnitParams: ActivityUnitParam = arrayOf(
             ActivityUnitParam(1, Position.PM)
         )
@@ -147,6 +147,15 @@ object UserFixture {
             email = email,
             name = name,
             role = role,
+            generation = generation,
+            position = position
+        )
+
+    fun getActivityUnitParamFixture(
+        generation: Int = 25,
+        position: Position = Position.SERVER
+    ): ActivityUnitParam =
+        ActivityUnitParam(
             generation = generation,
             position = position
         )

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/ActivityUnitCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/ActivityUnitCommandServiceTest.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.infrastructure
 
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.ActivityUnitFixture.getActivityUnitFixture
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
@@ -13,7 +13,7 @@ import java.util.UUID
 
 class ActivityUnitCommandServiceTest @Autowired constructor(
     private val activityUnitRepository: ActivityUnitRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val activityUnitCommandService = ActivityUnitCommandService(activityUnitRepository)
 

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/ActivityUnitFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/ActivityUnitFindServiceTest.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.infrastructure
 
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.ActivityUnitFixture.getActivityUnitFixture
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
@@ -11,7 +11,7 @@ import java.util.UUID
 
 class ActivityUnitFindServiceTest @Autowired constructor(
     private val activityUnitRepository: ActivityUnitRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val activityUnitFindService = ActivityUnitFindService(activityUnitRepository)
 

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationCommandServiceTest.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.infrastructure
 
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
 import co.yappuworld.user.infrastructure.jpa.SignUpApplicationRepository
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -9,7 +9,7 @@ import org.springframework.data.repository.findByIdOrNull
 
 class SignUpApplicationCommandServiceTest @Autowired constructor(
     private val signUpApplicationRepository: SignUpApplicationRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
         val signUpApplicationCommandService = SignUpApplicationCommandService(signUpApplicationRepository)
 
         feature("회원 가입 신청서 제출") {

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationFindServiceTest.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.jpa.SignUpApplicationRepository
@@ -21,7 +21,7 @@ import java.util.UUID
 
 class SignUpApplicationFindServiceTest @Autowired constructor(
     private val signUpApplicationRepository: SignUpApplicationRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val signUpApplicationFindService = SignUpApplicationFindService(signUpApplicationRepository)
 

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/UserAlarmSettingFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/UserAlarmSettingFindServiceTest.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.UserFixture.getUserAlarmSettingEntityFixture
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.jpa.UserAlarmSettingRepository
@@ -13,7 +13,7 @@ import java.util.UUID
 
 class UserAlarmSettingFindServiceTest @Autowired constructor(
     private val userAlarmSettingRepository: UserAlarmSettingRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val userAlarmSettingFindService = UserAlarmSettingFindService(userAlarmSettingRepository)
 

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/UserCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/UserCommandServiceTest.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.user.infrastructure
 
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
 import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
@@ -18,7 +18,7 @@ class UserCommandServiceTest @Autowired constructor(
     private val activityUnitRepository: ActivityUnitRepository,
     private val userAlarmSettingRepository: UserAlarmSettingRepository,
     private val userDeviceRepository: UserDeviceRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val userCommandService = UserCommandService(
             userRepository = userRepository,

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/UserDeviceFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/UserDeviceFindServiceTest.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.UserFixture.getUserDeviceEntityFixture
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.jpa.UserDeviceRepository
@@ -12,7 +12,7 @@ import java.util.UUID
 
 class UserDeviceFindServiceTest @Autowired constructor(
     private val userDeviceRepository: UserDeviceRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val userDeviceFindService = UserDeviceFindService(userDeviceRepository)
 

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.support.environment.CustomDataJpaFeatureSpec
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.UserFixture.getActivityUnitEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
 import co.yappuworld.user.domain.vo.Position
@@ -30,7 +30,7 @@ class UserFindServiceTest @Autowired constructor(
     private val entityManager: EntityManager,
     private val context: JpqlRenderContext,
     private val activityUnitRepository: ActivityUnitRepository
-) : CustomDataJpaFeatureSpec({
+) : CustomDataJpaTestFeatureSpec({
 
         val userFindService = UserFindService(userRepository, entityManager, context)
 


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 어드민에서 특정 세션의 출석 상태를 일괄로 변경하는 API를 제공합니다.


## ⭐️ 어떻게 해결했나요?
### 로직 플로우
- 유저 목록을 조회합니다.
- 특정 세션의 모든 출석 정보를 불러옵니다.
- 유저 목록과 출석 정보를 비교하여, 출석 정보가 없는 유저는 새로 생성합니다.
- 기존에 존재하는 출석 정보는 상태를 업데이트 합니다.
- 모두 저장합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
