### PR TITLE
fix: 회원가입, 가입 신청서 제출 시 동시성 이슈 해결

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/co/yappuworld/global/exception/GlobalExceptionHandler.kt
@@ -16,12 +16,10 @@ private val logger = KotlinLogging.logger { }
 class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException::class)
-    fun handleBusinessException(e: BusinessException): ResponseEntity<ErrorResponse> {
-        logger.warn { e.message }
-        return ResponseEntity
+    fun handleBusinessException(e: BusinessException): ResponseEntity<ErrorResponse> =
+        ResponseEntity
             .status(getHttpStatusBy(e.error.type))
             .body(ErrorResponse.of(e.error))
-    }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {

--- a/src/main/kotlin/co/yappuworld/user/client/application/AdminSignUpService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/AdminSignUpService.kt
@@ -1,7 +1,7 @@
 package co.yappuworld.user.client.application
 
 import co.yappuworld.global.response.OffsetPageResponse
-import co.yappuworld.user.client.application.usecase.SignUpApplicationExecutor
+import co.yappuworld.user.client.application.usecase.SignUpExecutor
 import co.yappuworld.user.client.dto.request.AdminSignUpApplicationPageRequest
 import co.yappuworld.user.client.dto.request.SignUpApplicationApproveRequest
 import co.yappuworld.user.client.dto.request.SignUpApplicationRejectRequest
@@ -16,7 +16,7 @@ import java.util.UUID
 
 @Service
 class AdminSignUpService(
-    private val signUpApplicationExecutor: SignUpApplicationExecutor,
+    private val signUpExecutor: SignUpExecutor,
     private val userFindService: UserFindService,
     private val signUpApplicationFindService: SignUpApplicationFindService
 ) {
@@ -45,11 +45,11 @@ class AdminSignUpService(
 
     @Transactional
     fun approveSignUpApplication(request: SignUpApplicationApproveRequest) {
-        signUpApplicationExecutor.approve(request.applicationIds, request.role)
+        signUpExecutor.approve(request.applicationIds, request.role)
     }
 
     @Transactional
     fun rejectSignUpApplication(request: SignUpApplicationRejectRequest) {
-        signUpApplicationExecutor.reject(request.applicationIds, request.reason)
+        signUpExecutor.reject(request.applicationIds, request.reason)
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/client/application/SignUpService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/SignUpService.kt
@@ -1,13 +1,10 @@
 package co.yappuworld.user.client.application
 
-import co.yappuworld.global.security.JwtGenerator
-import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.security.Token
 import co.yappuworld.operation.infrastructure.ConfigFindService
-import co.yappuworld.user.client.application.usecase.SignUpApplicationExecutor
+import co.yappuworld.user.client.application.usecase.SignUpExecutor
 import co.yappuworld.user.client.dto.request.CheckingEmailAvailabilityRequest
 import co.yappuworld.user.client.dto.request.UserSignUpRequest
-import co.yappuworld.user.infrastructure.UserCommandService
 import co.yappuworld.user.infrastructure.UserSystemNotifier
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,40 +12,33 @@ import java.time.LocalDateTime
 
 @Service
 class SignUpService(
-    private val userCommandService: UserCommandService,
-    private val signUpApplicationExecutor: SignUpApplicationExecutor,
-    private val jwtGenerator: JwtGenerator,
+    private val signUpExecutor: SignUpExecutor,
     private val configFindService: ConfigFindService,
     private val userSystemNotifier: UserSystemNotifier
 ) {
 
-    @Transactional
     fun submitSignUpRequest(
         request: UserSignUpRequest,
         now: LocalDateTime
     ) {
         val signUpApplication = request.toSignUpApplication()
         signUpApplication.run {
-            signUpApplicationExecutor.submit(this)
+            signUpExecutor.submit(this)
             userSystemNotifier.notifySignUpRequestReceived(this)
         }
     }
 
-    @Transactional
     fun signUpWithCode(
         request: UserSignUpRequest,
         now: LocalDateTime
-    ): Token {
-        signUpApplicationExecutor.checkEmailAvailability(request.email)
-
-        return userCommandService
-            .signUp(
-                application = request.toSignUpApplication(),
-                role = configFindService.findSignUpCodeBook().decideRole(checkNotNull(request.signUpCode))
-            ).let { user -> jwtGenerator.generateToken(SecurityUser.from(user), now) }
-    }
+    ): Token =
+        signUpExecutor.signUp(
+            application = request.toSignUpApplication(),
+            role = configFindService.findSignUpCodeBook().decideRole(checkNotNull(request.signUpCode)),
+            now = now
+        )
 
     @Transactional(readOnly = true)
     fun checkEmailAvailability(request: CheckingEmailAvailabilityRequest) =
-        signUpApplicationExecutor.checkEmailAvailability(request.email)
+        signUpExecutor.checkEmailAvailability(request.email)
 }

--- a/src/main/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutor.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutor.kt
@@ -1,33 +1,51 @@
 package co.yappuworld.user.client.application.usecase
 
 import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.user.infrastructure.entity.SignUpApplicationEntity
+import co.yappuworld.global.security.JwtGenerator
+import co.yappuworld.global.security.SecurityUser
+import co.yappuworld.global.security.Token
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.SignUpApplicationCommandService
 import co.yappuworld.user.infrastructure.SignUpApplicationFindService
 import co.yappuworld.user.infrastructure.UserCommandService
 import co.yappuworld.user.infrastructure.UserFindService
+import co.yappuworld.user.infrastructure.entity.SignUpApplicationEntity
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 import java.util.UUID
 
 private val logger = KotlinLogging.logger { }
 
 @Component
 @Transactional
-class SignUpApplicationExecutor(
+class SignUpExecutor(
     private val userFindService: UserFindService,
     private val userCommandService: UserCommandService,
     private val signUpApplicationFindService: SignUpApplicationFindService,
-    private val signUpApplicationCommandService: SignUpApplicationCommandService
+    private val signUpApplicationCommandService: SignUpApplicationCommandService,
+    private val jwtGenerator: JwtGenerator
 ) {
 
     fun submit(application: SignUpApplicationEntity) {
-        checkSubmitApplicationAvailability(application)
-        signUpApplicationCommandService.submit(application)
+        executeWithLock(application.applicantEmail) {
+            checkSubmitApplicationAvailability(application)
+            signUpApplicationCommandService.submit(application)
+        }
     }
+
+    fun signUp(
+        application: SignUpApplicationEntity,
+        role: UserRole,
+        now: LocalDateTime
+    ): Token =
+        executeWithLockReturning(application.applicantEmail) {
+            checkEmailAvailability(application.applicantEmail)
+            val user = userCommandService.signUp(application, role)
+            jwtGenerator.generateToken(SecurityUser.from(user), now)
+        }
 
     fun approve(
         applicationIds: List<UUID>,
@@ -51,7 +69,7 @@ class SignUpApplicationExecutor(
 
     fun checkEmailAvailability(email: String) {
         if (userFindService.existsEmail(email)) {
-            logger.error { "${email}은 이미 가입된 이메일입니다." }
+            logger.warn { "${email}은 이미 가입된 이메일입니다." }
             throw BusinessException(UserError.ALREADY_SIGNED_UP_EMAIL)
         }
     }
@@ -60,7 +78,7 @@ class SignUpApplicationExecutor(
         checkEmailAvailability(application.applicantEmail)
 
         if (signUpApplicationFindService.existsPendingApplication(application.applicantEmail)) {
-            logger.error { "${application.applicantEmail}의 처리되지 않은 기존 신청이 존재합니다." }
+            logger.warn { "${application.applicantEmail}의 처리되지 않은 기존 신청이 존재합니다." }
             throw BusinessException(UserError.UNPROCESSED_APPLICATION_EXISTS)
         }
     }
@@ -69,7 +87,7 @@ class SignUpApplicationExecutor(
         val applications = signUpApplicationFindService.findSignUpApplications(applicationIds)
 
         if (applicationIds.size != applications.size) {
-            logger.error {
+            logger.warn {
                 buildString {
                     appendLine("존재하지 않는 신청서 ID가 포함되어 있어서 처리에 실패했습니다.")
                     appendLine("요청한 ID: $applicationIds")
@@ -81,7 +99,7 @@ class SignUpApplicationExecutor(
 
         val processedApplications = applications.filter(SignUpApplicationEntity::isProcessed)
         if (processedApplications.isNotEmpty()) {
-            logger.error {
+            logger.warn {
                 buildString {
                     appendLine("이미 처리된 신청서의 ID가 포함되어 있어서 처리에 실패했습니다.")
                     appendLine("처리된 신청서 ID: ${processedApplications.map { it.id }}")
@@ -91,5 +109,46 @@ class SignUpApplicationExecutor(
         }
 
         return applications
+    }
+
+    private fun executeWithLock(
+        email: String,
+        action: () -> Unit
+    ) {
+        if (signUpApplicationCommandService.getLock(email) != 1) {
+            logger.warn { "${email}의 잠금을 획득하지 못했습니다." }
+            throw BusinessException(UserError.ALREADY_PROCESSED_EMAIL)
+        }
+
+        action()
+        /**
+         * return try {
+         *             action()
+         *         } finally {
+         *             TODO: 명시적으로 release를 처리하기 위해선 별도 클래스에서 action()을 수행해야 하고, Tx는 새롭게 열어야 함
+         *             signUpApplicationCommandService.releaseLock(email)
+         *         }
+         */
+    }
+
+    private fun <T> executeWithLockReturning(
+        email: String,
+        action: () -> T
+    ): T {
+        if (userCommandService.getLock(email) != 1) {
+            logger.warn { "${email}의 잠금을 획득하지 못했습니다." }
+            throw BusinessException(UserError.ALREADY_PROCESSED_EMAIL)
+        }
+
+        return action()
+
+        /**
+         * return try {
+         *             action()
+         *         } finally {
+         *             TODO: 명시적으로 release를 처리하기 위해선 별도 클래스에서 action()을 수행해야 하고, Tx는 새롭게 열어야 함
+         *             userCommandService.releaseLock(email)
+         *         }
+         */
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthApi.kt
@@ -33,10 +33,9 @@ interface UserAuthApi {
             ApiResponse(
                 description = "가입 코드를 통해 별도 신청 절차 없이 가입 처리",
                 responseCode = "200",
-//                useReturnTypeSchema = true,
                 content = [
                     Content(
-                        schema = Schema(ref = "#/components/schemas/SuccessResponseToken"),
+                        schema = Schema(implementation = Token::class),
                         examples = [
                             ExampleObject(
                                 value = """
@@ -71,6 +70,16 @@ interface UserAuthApi {
                                         "isSuccess": "false",
                                         "errorCode": "USR_1001",
                                         "message": "잘못된 가입코드입니다."
+                                    }
+                                """
+                            ),
+                            ExampleObject(
+                                name = "회원가입 중복 요청 오류",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "errorCode": "USR_1098",
+                                        "message": "이미 처리 중인 이메일입니다."
                                     }
                                 """
                             )

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
@@ -63,6 +63,11 @@ enum class UserError : Error {
         override val code: String = "USR_1005"
         override val type: ErrorType = ErrorType.WRONG_ARGUMENT
     },
+    ALREADY_PROCESSED_EMAIL {
+        override val message: String = "이미 처리 중인 이메일입니다."
+        override val code: String = "USR_1098"
+        override val type: ErrorType = ErrorType.BAD_REQUEST
+    },
     NOT_FOUND_SIGN_UP_APPLICATION {
         override val message: String = "회원가입 신청 내역을 찾을 수 없습니다."
         override val code: String = "USR_1099"

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationCommandService.kt
@@ -14,4 +14,8 @@ class SignUpApplicationCommandService(
     fun submit(signUpApplication: SignUpApplicationEntity) {
         signUpApplicationRepository.save(signUpApplication)
     }
+
+    fun getLock(email: String): Int? = signUpApplicationRepository.getLock(email)
+
+    fun releaseLock(email: String): Int? = signUpApplicationRepository.releaseLock(email)
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserCommandService.kt
@@ -31,4 +31,8 @@ class UserCommandService(
             userAlarmSettingRepository.save(UserAlarmSettingEntity(user.id, application.getDeviceAlarmToggle()))
             userDeviceRepository.save(UserDeviceEntity(user.id, application.getFcmToken()))
         }
+
+    fun getLock(email: String): Int? = userRepository.getLock(email)
+
+    fun releaseLock(email: String): Int? = userRepository.releaseLock(email)
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/SignUpApplicationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/SignUpApplicationRepository.kt
@@ -3,6 +3,8 @@ package co.yappuworld.user.infrastructure.jpa
 import co.yappuworld.user.infrastructure.entity.SignUpApplicationEntity
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface SignUpApplicationRepository :
@@ -10,4 +12,15 @@ interface SignUpApplicationRepository :
     KotlinJdslJpqlExecutor {
 
     fun findAllByIdIn(ids: List<UUID>): List<SignUpApplicationEntity>
+
+    @Query(value = "select get_lock(:email, :timeoutSeconds)", nativeQuery = true)
+    fun getLock(
+        @Param("email") email: String,
+        @Param("timeoutSeconds") timeoutSeconds: Long = 3L
+    ): Int?
+
+    @Query(value = "select release_lock(:email)", nativeQuery = true)
+    fun releaseLock(
+        @Param("email") email: String
+    ): Int?
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/UserRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/UserRepository.kt
@@ -3,6 +3,8 @@ package co.yappuworld.user.infrastructure.jpa
 import co.yappuworld.user.infrastructure.entity.UserEntity
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface UserRepository :
@@ -14,4 +16,15 @@ interface UserRepository :
     fun findUserOrNullByEmail(email: String): UserEntity?
 
     fun findAllByIdIn(userIds: List<UUID>): List<UserEntity>
+
+    @Query(value = "select get_lock(:email, :timeoutSeconds)", nativeQuery = true)
+    fun getLock(
+        @Param("email") email: String,
+        @Param("timeoutSeconds") timeoutSeconds: Long = 3L
+    ): Int?
+
+    @Query(value = "select release_lock(:email)", nativeQuery = true)
+    fun releaseLock(
+        @Param("email") email: String
+    ): Int?
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
     profiles:
         active: local
         group:
-            local: console-logging, secret-local, sentry-logging
+            local: console-logging, secret-local
             test: console-logging
-            dev: console-logging, file-logging, sentry-logging
-            prod: file-logging, sentry-logging
+            dev: console-logging
+            prod: console-logging, sentry-logging

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,26 +1,6 @@
 <configuration>
     <property name="ROLLOVER_PERIOD_PATTERN" value="yyyy-MM-dd"/>
 
-    <springProfile name="file-logging">
-        <property name="LOG_PATH" value="./logs"/>
-        <property name="LOG_FILE_NAME" value="yappu_world"/>
-        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>
-                    ${LOG_PATH}/${LOG_FILE_NAME}-%d{${ROLLOVER_PERIOD_PATTERN}}.log
-                </fileNamePattern>
-                <maxHistory>7</maxHistory>
-            </rollingPolicy>
-            <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%level] [%thread] [%logger{36}] - %msg%n</pattern>
-            </encoder>
-        </appender>
-        <root level="INFO">
-            <appender-ref ref="FILE" />
-        </root>
-    </springProfile>
-
     <springProfile name="console-logging">
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
         <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>

--- a/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpFacadeConcurrencyTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpFacadeConcurrencyTest.kt
@@ -1,0 +1,77 @@
+package co.yappuworld.user.client.application.usecase
+
+import co.yappuworld.global.util.DatetimeUtils.getCurrentDateTimeInKST
+import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
+import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.infrastructure.jpa.SignUpApplicationRepository
+import co.yappuworld.user.infrastructure.jpa.UserRepository
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+@SpringBootTest
+class SignUpFacadeConcurrencyTest @Autowired constructor(
+    private val signUpExecutor: SignUpExecutor,
+    private val userRepository: UserRepository,
+    private val signUpApplicationRepository: SignUpApplicationRepository
+) : FeatureSpec({
+
+        afterTest {
+            userRepository.deleteAll()
+            signUpApplicationRepository.deleteAll()
+        }
+
+        feature("동시에 같은 이메일로") {
+
+            scenario("회원가입") {
+                val threadCount = 20
+                val executorService = Executors.newFixedThreadPool(32)
+                val latch = CountDownLatch(threadCount)
+
+                repeat(threadCount) {
+                    executorService.submit {
+                        try {
+                            signUpExecutor.signUp(
+                                application = getSignUpApplicationEntityFixture(
+                                    email = "abc@gmail.com"
+                                ),
+                                role = UserRole.ACTIVE,
+                                now = getCurrentDateTimeInKST()
+                            )
+                        } finally {
+                            latch.countDown()
+                        }
+                    }
+                }
+
+                latch.await()
+                userRepository.count() shouldBe 1
+            }
+
+            scenario("가입 신청") {
+                val threadCount = 20
+                val executorService = Executors.newFixedThreadPool(32)
+                val latch = CountDownLatch(threadCount)
+
+                repeat(threadCount) {
+                    executorService.submit {
+                        try {
+                            signUpExecutor.submit(
+                                application = getSignUpApplicationEntityFixture(
+                                    email = "abc@gmail.com"
+                                )
+                            )
+                        } finally {
+                            latch.countDown()
+                        }
+                    }
+                }
+
+                latch.await()
+                signUpApplicationRepository.count() shouldBe 1
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpFacadeUnitTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpFacadeUnitTest.kt
@@ -1,6 +1,7 @@
 package co.yappuworld.user.client.application.usecase
 
 import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.global.security.JwtGenerator
 import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
 import co.yappuworld.user.domain.vo.SignUpApplicationStatus
@@ -24,18 +25,20 @@ import io.mockk.mockk
 import io.mockk.verify
 import java.util.UUID
 
-class SignUpApplicationExecutorTest :
+class SignUpFacadeUnitTest :
     FeatureSpec({
         val userFindService = mockk<UserFindService>()
         val userCommandService = mockk<UserCommandService>()
         val signUpApplicationFindService = mockk<SignUpApplicationFindService>()
         val signUpApplicationCommandService = mockk<SignUpApplicationCommandService>()
+        val jwtGenerator = mockk<JwtGenerator>()
 
-        val executor = SignUpApplicationExecutor(
+        val executor = SignUpExecutor(
             userFindService,
             userCommandService,
             signUpApplicationFindService,
-            signUpApplicationCommandService
+            signUpApplicationCommandService,
+            jwtGenerator
         )
 
         feature("가입 신청서 제출") {

--- a/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpFacadeUnitTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpFacadeUnitTest.kt
@@ -43,6 +43,8 @@ class SignUpFacadeUnitTest :
 
         feature("가입 신청서 제출") {
 
+            every { signUpApplicationCommandService.getLock(any()) } returns 1
+
             scenario("이미 사용 중인 이메일이면 제출할 수 없다.") {
                 every { userFindService.existsEmail(any()) } returns true
                 shouldThrowExactly<BusinessException> {


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 회원가입 진행 시에, 가입 마무리 단계에서 `입력완료` 혹은 `코드가 없어요`를 더블 클릭하게 되면, 두 개의 데이터가 생성되는 이슈 존재


## ⭐️ 어떻게 해결했나요?
### 해결 포인트
- Named Lock을 활용하였습니다.
- 회원가입 단계에서 입력한 email을 Named Lock으로 잡고 로직을 진행한 뒤에 Lock을 해제합니다.
- 현재는 프로젝트 구조상 Lock 해제를 Tx 해제로 처리합니다.

### 추가 개선 포인트
- Lock의 해제는 명시적으로 처리하는게 좋을 거 같습니다.
- 추후 클래스 분리를 통해 Tx를 새로 열어(propagation = REQUIRES_._NEW) 선행 Tx의 변경점을 commit 한 후, Lock을 해제합니다.
- [참고](https://m.blog.naver.com/fbfbf1/222979238425)


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
