### PR TITLE
fix: 가입 코드 회원 가입 성공 후, PENDING 가입 신청서는 거절 처리

### DIFF
--- a/src/main/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutor.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutor.kt
@@ -44,8 +44,16 @@ class SignUpExecutor(
         executeWithLockReturning(application.applicantEmail) {
             checkEmailAvailability(application.applicantEmail)
             val user = userCommandService.signUp(application, role)
+            rejectPendingSignUpApplication(application.applicantEmail)
             jwtGenerator.generateToken(SecurityUser.from(user), now)
         }
+
+    private fun rejectPendingSignUpApplication(applicantEmail: String) {
+        signUpApplicationFindService
+            .findPendingApplicationOrNull(applicantEmail)
+            ?.apply { reject(reason = "가입 코드를 통해 회원가입을 완료하였습니다.") }
+            ?.also { signUpApplicationCommandService.update(it) }
+    }
 
     fun approve(
         applicationIds: List<UUID>,

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationCommandService.kt
@@ -15,6 +15,10 @@ class SignUpApplicationCommandService(
         signUpApplicationRepository.save(signUpApplication)
     }
 
+    fun update(signUpApplication: SignUpApplicationEntity) {
+        signUpApplicationRepository.save(signUpApplication)
+    }
+
     fun getLock(email: String): Int? = signUpApplicationRepository.getLock(email)
 
     fun releaseLock(email: String): Int? = signUpApplicationRepository.releaseLock(email)

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationFindService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/SignUpApplicationFindService.kt
@@ -31,6 +31,19 @@ class SignUpApplicationFindService(
                     ).orderBy(path(SignUpApplicationEntity::createdAt).desc())
             }.isNotEmpty()
 
+    fun findPendingApplicationOrNull(email: String): SignUpApplicationEntity? =
+        signUpApplicationRepository
+            .findAll(limit = 1) {
+                select(entity(SignUpApplicationEntity::class))
+                    .from(entity(SignUpApplicationEntity::class))
+                    .where(
+                        and(
+                            path(SignUpApplicationEntity::applicantEmail).equal(email),
+                            path(SignUpApplicationEntity::status).equal(SignUpApplicationStatus.PENDING)
+                        )
+                    ).orderBy(path(SignUpApplicationEntity::createdAt).desc())
+            }.singleOrNull()
+
     fun findSignUpApplications(ids: List<UUID>): List<SignUpApplicationEntity> {
         require(ids.isNotEmpty()) { "가입 신청서 조회 대상 ID 목록은 최소 하나 이상이어야 합니다." }
         return signUpApplicationRepository.findAllByIdIn(ids)

--- a/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutorConcurrencyTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutorConcurrencyTest.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 
 @SpringBootTest
-class SignUpFacadeConcurrencyTest @Autowired constructor(
+class SignUpExecutorConcurrencyTest @Autowired constructor(
     private val signUpExecutor: SignUpExecutor,
     private val userRepository: UserRepository,
     private val signUpApplicationRepository: SignUpApplicationRepository

--- a/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutorTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutorTest.kt
@@ -1,0 +1,44 @@
+package co.yappuworld.user.client.application.usecase
+
+import co.yappuworld.global.util.DatetimeUtils.getCurrentDateTimeInKST
+import co.yappuworld.support.environment.SpringBootTestFeatureSpec
+import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
+import co.yappuworld.user.domain.vo.SignUpApplicationStatus
+import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.infrastructure.jpa.SignUpApplicationRepository
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+
+class SignUpExecutorTest @Autowired constructor(
+    private val signUpExecutor: SignUpExecutor,
+    private val signUpApplicationRepository: SignUpApplicationRepository
+) : SpringBootTestFeatureSpec({
+
+        feature("가입코드를 이용한 회원가입") {
+
+            scenario("기존에 보류 상태의 가입 신청이 있었다면, 거절 처리된다.") {
+                val signUpApplication = getSignUpApplicationEntityFixture(
+                    email = "email@email.com",
+                    status = SignUpApplicationStatus.PENDING
+                )
+                signUpApplicationRepository.saveAndFlush(signUpApplication)
+
+                signUpExecutor.signUp(
+                    application = signUpApplication,
+                    role = UserRole.ACTIVE,
+                    now = getCurrentDateTimeInKST()
+                )
+
+                signUpApplicationRepository
+                    .findByIdOrNull(signUpApplication.id)
+                    .shouldNotBeNull()
+                    .let { rejectedApplication ->
+                        rejectedApplication.status shouldBe SignUpApplicationStatus.REJECTED
+                        rejectedApplication.rejectReason shouldBe "가입 코드를 통해 회원가입을 완료하였습니다."
+                    }
+            }
+        }
+
+    })


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
### 케이스: 회원 가입 신청서 제출 -> 가입 코드로 가입 성공
- 어드민에 가입 신청서는 PENDING 상태로 남아있음
- 해당 가입 신청서 처리 불가능


## ⭐️ 어떻게 해결했나요?
- 가입 코드를 통한 가입 성공 후, PENDING으로 남아있는 최신 가입 신청서를 거절 처리


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
