### PR TITLE
fix: 유저의 활동 내역을 모두 함께 조회하는 JDSL 쿼리 수정

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
@@ -94,7 +94,7 @@ class AttendanceService(
         sessionId: UUID
     ): SessionAttendance =
         SessionAttendance(
-            attendee = userFindService.findUserWithActivityUnits(userId),
+            attendee = userFindService.findUserWithActivities(userId),
             session = sessionFindService.findSession(sessionId),
             attendance = attendanceFindService.findSessionAttendance(userId, sessionId)
         )

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -6,8 +6,8 @@ import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.UpcomingSessionAttendanceResponse
-import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.domain.SessionAttendance
+import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.ScheduleFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService
@@ -67,7 +67,7 @@ class ScheduleService(
     ): UpcomingSessionAttendanceResponse {
         val activeGeneration = generationFindService.findActiveGenerationOrNull()
             ?: throw BusinessException(ScheduleError.NO_SESSION_WITHOUT_ACTIVE_GENERATION)
-        val attendee = userFindService.findUserWithActivityUnits(userId)
+        val attendee = userFindService.findUserWithActivities(userId)
         val session = sessionFindService.findUpcomingSession(activeGeneration, now)
         val attendanceOrNull = attendanceFindService.findSessionAttendance(userId, session.id)
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
@@ -4,11 +4,14 @@ import co.yappuworld.schedule.domain.vo.ScheduleType
 import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.entity.ScheduleEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 import java.time.LocalTime
+
+private val logger = KotlinLogging.logger {}
 
 data class AdminSessionCreateRequest(
     @Schema(description = "스케줄 이름", nullable = false, example = "데모데이")
@@ -34,6 +37,13 @@ data class AdminSessionCreateRequest(
     @Schema(description = "세션 종류", nullable = false, example = "OFFLINE")
     var sessionType: SessionType
 ) {
+
+    init {
+        logger.info { "세션 시작 날짜: $date" }
+        logger.info { "세션 시작 시간: $time" }
+        logger.info { "세션 종료 날짜: $endDate" }
+        logger.info { "세션 종료 시간: $endTime" }
+    }
 
     fun toDomain(): ScheduleEntity =
         when (type) {

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
@@ -1,11 +1,14 @@
 package co.yappuworld.schedule.client.dto.response
 
-import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.schedule.domain.vo.SessionType
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
 
 data class AdminSessionDetailResponse(
     @Schema(description = "세션 ID")
@@ -27,6 +30,13 @@ data class AdminSessionDetailResponse(
     @Schema(description = "세션 타입")
     val sessionType: SessionType
 ) {
+
+    init {
+        logger.info { "세션 시작 날짜: $date" }
+        logger.info { "세션 시작 시간: $time" }
+        logger.info { "세션 종료 날짜: $endDate" }
+        logger.info { "세션 종료 시간: $endTime" }
+    }
 
     constructor(session: SessionEntity) : this(
         id = session.id,

--- a/src/main/kotlin/co/yappuworld/user/domain/model/UserWithActivityUnits.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/UserWithActivityUnits.kt
@@ -17,11 +17,13 @@ class UserWithActivityUnits(
             check(elements.groupBy { it.userId }.size == 1)
 
             return UserWithActivityUnits(
-                userId = elements.single().userId,
-                email = elements.single().email,
-                name = elements.single().name,
-                role = elements.single().role,
-                activityUnits = elements.map { ActivityUnit(it.generation, it.position, it.userId) }
+                userId = elements.first().userId,
+                email = elements.first().email,
+                name = elements.first().name,
+                role = elements.first().role,
+                activityUnits = elements
+                    .map { ActivityUnit(it.generation, it.position, it.userId) }
+                    .sortedByDescending { au -> au.generation }
             )
         }
     }

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
@@ -155,5 +155,10 @@ enum class UserError : Error {
         override val message: String = "잘못된 전화번호 형식입니다."
         override val code: String = "USR_3001"
         override val type: ErrorType = ErrorType.BAD_REQUEST
+    },
+    NO_ACTIVITY_UNIT {
+        override val message: String = "활동 정보가 존재하지 않습니다."
+        override val code: String = "USR_3002"
+        override val type: ErrorType = ErrorType.WRONG_STATE
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
@@ -1,7 +1,6 @@
 package co.yappuworld.user.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.user.domain.model.ActivityUnit
 import co.yappuworld.user.domain.model.UserWithActivityUnits
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
@@ -107,23 +106,22 @@ class UserFindService(
                 ).from(
                     entity(UserEntity::class),
                     innerJoin(ActivityUnitEntity::class)
-                        .on(path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)))
-                ).where(path(UserEntity::getId).equal(userId))
-                    .orderBy(path(ActivityUnitEntity::generation).desc())
+                        .on(
+                            and(
+                                path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)),
+                                path(UserEntity::getId).equal(userId)
+                            )
+                        )
+                )
             }.filterNotNull()
 
-        if (result.isEmpty()) throw BusinessException(UserError.USER_NOT_FOUND)
+        if (result.isNotEmpty()) {
+            return result.let { UserWithActivityUnits.of(it) }
+        }
 
-        return result.let {
-            UserWithActivityUnits(
-                userId = it.first().userId,
-                email = it.first().email,
-                name = it.first().name,
-                role = it.first().role,
-                activityUnits = it
-                    .map { au -> ActivityUnit(au.generation, au.position, au.userId) }
-                    .sortedByDescending { au -> au.generation }
-            )
+        when (userRepository.existsById(userId)) {
+            true -> throw BusinessException(UserError.NO_ACTIVITY_UNIT)
+            false -> throw BusinessException(UserError.USER_NOT_FOUND)
         }
     }
 
@@ -175,29 +173,6 @@ class UserFindService(
                 )
             }.singleOrNull()
             ?: throw BusinessException(UserError.USER_NOT_FOUND_WITH_GENERATION_ACTIVITY)
-
-    fun findUserWithActivityUnits(userId: UUID): UserWithActivityUnits =
-        userRepository
-            .findAll {
-                selectNew<UserWithActivityUnit>(
-                    path(UserEntity::getId),
-                    path(UserEntity::email),
-                    path(UserEntity::name),
-                    path(UserEntity::role),
-                    path(ActivityUnitEntity::generation),
-                    path(ActivityUnitEntity::position)
-                ).from(
-                    entity(UserEntity::class),
-                    innerJoin(entity(ActivityUnitEntity::class))
-                        .on(
-                            and(
-                                path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)),
-                                path(UserEntity::getId).equal(userId)
-                            )
-                        )
-                )
-            }.filterNotNull()
-            .let { UserWithActivityUnits.of(it) }
 
     private fun Jpql.getUserWithLastActivityUnit(
         userId: UUID? = null

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
@@ -57,7 +57,7 @@ class AttendanceServiceTest :
 
         fun successConditionMocking() {
             every { generationFindService.findActiveGeneration() } returns activeGeneration
-            every { userFindService.findUserWithActivityUnits(any()) } returns user
+            every { userFindService.findUserWithActivities(any()) } returns user
             every { sessionFindService.findSession(any()) } returns session
             every { attendanceFindService.findSessionAttendance(any(), any()) } returns null
             every { configFindService.findAttendanceCode() } returns attendanceCode

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
@@ -65,7 +65,7 @@ class UpcomingSessionFindTest :
 
             fun setCheckInPossibleCircumstance() {
                 every { generationFindService.findActiveGenerationOrNull() } returns generation
-                every { userFindService.findUserWithActivityUnits(any()) } returns getUserWithActivityUnitsFixture(
+                every { userFindService.findUserWithActivities(any()) } returns getUserWithActivityUnitsFixture(
                     userId = userId,
                     activityUnits = listOf(
                         getActivityUnitFixture(
@@ -95,7 +95,7 @@ class UpcomingSessionFindTest :
 
             scenario("세션의 기수에 유저 활동기록이 없으면 예외가 발생한다.") {
                 setCheckInPossibleCircumstance()
-                every { userFindService.findUserWithActivityUnits(any()) } returns
+                every { userFindService.findUserWithActivities(any()) } returns
                     getUserWithActivityUnitsFixture(
                         activityUnits = listOf(
                             getActivityUnitFixture(
@@ -119,7 +119,7 @@ class UpcomingSessionFindTest :
                     row(UserRole.GRADUATE),
                     row(UserRole.ADMIN)
                 ) { role ->
-                    every { userFindService.findUserWithActivityUnits(any()) } returns
+                    every { userFindService.findUserWithActivities(any()) } returns
                         getUserWithActivityUnitsFixture(role = role)
 
                     shouldThrowExactly<BusinessException> {

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
@@ -290,7 +290,7 @@ class UserFindServiceTest @Autowired constructor(
 
                 shouldThrowExactly<BusinessException> {
                     userFindService.findUserWithActivities(user.id)
-                }.error shouldBe UserError.USER_NOT_FOUND
+                }.error shouldBe UserError.NO_ACTIVITY_UNIT
             }
 
             scenario("활동 기록이 하나만 있는 경우") {


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 여러 개의 활동 기록을 가지는 경우, first()가 아닌 single()을 사용하여 에러 발생


## ⭐️ 어떻게 해결했나요?
- single() -> first()
- 추가적으로, 같은 행위를 하는 메서드 두 개가 중복되어, 하나로 일원화
- 세션 생성, 조회 쪽에서 발생하는 시간 관련 이슈를 핸들링하기 위한 로깅도 추가


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
