### PR TITLE
fix: 출석부의 생성자를 참석자 기반으로 변경

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
@@ -31,7 +31,7 @@ class AdminAttendanceService(
         return AdminAttendancesResponse.from(
             AttendanceBook(
                 generation = activeGeneration,
-                users = userFindService.findUsersActiveOfGeneration(activeGeneration),
+                attendees = userFindService.findSessionAttendeesOfGeneration(activeGeneration),
                 sessions = sessionFindService.findSessionsInGeneration(activeGeneration),
                 attendances = attendanceFindService.findAttendancesOfGeneration(activeGeneration),
                 latePasses = latePassFindService.findLatePasses(activeGeneration),

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
@@ -7,6 +7,7 @@ import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponse
 import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponse
 import co.yappuworld.schedule.domain.AttendanceBook
+import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
@@ -54,18 +55,18 @@ class AttendanceService(
         now: LocalDateTime
     ): AttendanceStatisticsResponse {
         val activeGeneration = generationFindService.findActiveGeneration()
-        val user = userFindService.findUserWithActivityUnitOfGeneration(userId, activeGeneration)
-        val thisGenerationSessions = sessionFindService.findSessionsInGeneration(activeGeneration)
+        val user = userFindService.findUserWithActivities(userId)
+        val activeGenerationSessions = sessionFindService.findSessionsInGeneration(activeGeneration)
         val attendances = attendanceFindService.findAttendancesBySchedules(
             userId = userId,
-            scheduleIds = thisGenerationSessions.map { it.id }
+            scheduleIds = activeGenerationSessions.map { it.id }
         )
         val latePassCount = latePassFindService.countLatePasses(activeGeneration, userId)
 
         val attendanceBook = AttendanceBook(
             generation = activeGeneration,
-            users = listOf(user),
-            sessions = thisGenerationSessions,
+            attendees = listOf(Attendee(user, activeGeneration)),
+            sessions = activeGenerationSessions,
             attendances = attendances,
             latePassCountByUserId = mapOf(userId to latePassCount),
             now = now
@@ -94,7 +95,7 @@ class AttendanceService(
         sessionId: UUID
     ): SessionAttendance =
         SessionAttendance(
-            attendee = userFindService.findUserWithActivities(userId),
+            user = userFindService.findUserWithActivities(userId),
             session = sessionFindService.findSession(sessionId),
             attendance = attendanceFindService.findSessionAttendance(userId, sessionId)
         )

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
@@ -7,7 +7,6 @@ import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponse
 import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponse
 import co.yappuworld.schedule.domain.AttendanceBook
-import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
@@ -55,7 +54,7 @@ class AttendanceService(
         now: LocalDateTime
     ): AttendanceStatisticsResponse {
         val activeGeneration = generationFindService.findActiveGeneration()
-        val user = userFindService.findUserWithActivities(userId)
+        val attendee = userFindService.findSessionAttendee(userId, activeGeneration)
         val activeGenerationSessions = sessionFindService.findSessionsInGeneration(activeGeneration)
         val attendances = attendanceFindService.findAttendancesBySchedules(
             userId = userId,
@@ -65,7 +64,7 @@ class AttendanceService(
 
         val attendanceBook = AttendanceBook(
             generation = activeGeneration,
-            attendees = listOf(Attendee(user, activeGeneration)),
+            attendees = listOf(attendee),
             sessions = activeGenerationSessions,
             attendances = attendances,
             latePassCountByUserId = mapOf(userId to latePassCount),
@@ -93,12 +92,14 @@ class AttendanceService(
     private fun getSessionAttendance(
         userId: UUID,
         sessionId: UUID
-    ): SessionAttendance =
-        SessionAttendance(
-            user = userFindService.findUserWithActivities(userId),
-            session = sessionFindService.findSession(sessionId),
+    ): SessionAttendance {
+        val session = sessionFindService.findSession(sessionId)
+        return SessionAttendance(
+            attendee = userFindService.findSessionAttendee(userId, session.generation),
+            session = session,
             attendance = attendanceFindService.findSessionAttendance(userId, sessionId)
         )
+    }
 
     private fun checkAttendanceCode(attendanceCode: String) {
         val value = configFindService.findAttendanceCode()

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -67,13 +67,13 @@ class ScheduleService(
     ): UpcomingSessionAttendanceResponse {
         val activeGeneration = generationFindService.findActiveGenerationOrNull()
             ?: throw BusinessException(ScheduleError.NO_SESSION_WITHOUT_ACTIVE_GENERATION)
-        val attendee = userFindService.findUserWithActivities(userId)
+        val attendee = userFindService.findSessionAttendee(userId, activeGeneration)
         val session = sessionFindService.findUpcomingSession(activeGeneration, now)
         val attendanceOrNull = attendanceFindService.findSessionAttendance(userId, session.id)
 
         return UpcomingSessionAttendanceResponse.of(
             sessionAttendance = SessionAttendance(
-                user = attendee,
+                attendee = attendee,
                 session = session,
                 attendance = attendanceOrNull
             ),

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -73,7 +73,7 @@ class ScheduleService(
 
         return UpcomingSessionAttendanceResponse.of(
             sessionAttendance = SessionAttendance(
-                attendee = attendee,
+                user = attendee,
                 session = session,
                 attendance = attendanceOrNull
             ),

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponse.kt
@@ -2,6 +2,7 @@ package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.global.util.DatetimeUtils.korean
 import co.yappuworld.schedule.domain.AttendanceBook
+import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.schedule.domain.SessionAttendanceStatistics
 import co.yappuworld.schedule.domain.UserAttendanceStatistics
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
@@ -31,8 +32,8 @@ data class AdminAttendancesResponse(
                 sessions = attendanceBook.sessions.map {
                     AdminAttendanceSessionResponse(it, attendanceBook.getSessionAttendanceStatistics(it.id))
                 },
-                users = attendanceBook.users.map {
-                    AdminAttendanceUserResponse(it, attendanceBook.getUserAttendanceStatistics(it.userId))
+                users = attendanceBook.attendees.map { attendee ->
+                    AdminAttendanceUserResponse(attendee, attendanceBook.getUserAttendanceStatistics(attendee.id))
                 },
                 attendancesGroupedBySession = attendanceBook.sessions.map { session ->
                     AdminSessionAttendanceGroupResponse.from(
@@ -121,12 +122,12 @@ data class AdminAttendanceUserResponse(
 ) {
 
     constructor(
-        user: UserWithActivityUnit,
+        attendee: Attendee,
         statistics: UserAttendanceStatistics
     ) : this(
-        userId = user.userId,
-        name = user.name,
-        position = user.position.name,
+        userId = attendee.id,
+        name = attendee.name,
+        position = attendee.position.label,
         onTimeCount = statistics.onTimeCount,
         lateCount = statistics.lateCount,
         absentCount = statistics.absentCount,

--- a/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
@@ -6,13 +6,12 @@ import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.LatePassEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
 import java.time.LocalDateTime
 import java.util.UUID
 
 class AttendanceBook(
     val generation: Int,
-    val users: List<UserWithActivityUnit>,
+    val attendees: List<Attendee>,
     val sessions: List<SessionEntity>,
     attendances: List<AttendanceEntity>,
     private val latePassCountByUserId: Map<UUID, Int>,
@@ -28,28 +27,28 @@ class AttendanceBook(
     val finishedSessionCount = sessions.count { it.isFinished(now) }
 
     init {
-        require(users.all { it.generation == generation } || sessions.all { it.generation == generation })
+        require(sessions.all { it.generation == generation })
 
         // (userId to sessionId) to AttendanceStatus
         val attendanceMatrix = attendances.associate { (it.userId to it.scheduleId) to it.status }
 
         fun decideStatus(
-            user: UserWithActivityUnit,
+            user: Attendee,
             session: SessionEntity
         ): AttendanceStatus? =
             when (session.isFinished(now)) {
-                true -> attendanceMatrix[user.userId to session.id] ?: AttendanceStatus.ABSENT
-                false -> attendanceMatrix[user.userId to session.id]
+                true -> attendanceMatrix[user.id to session.id] ?: AttendanceStatus.ABSENT
+                false -> attendanceMatrix[user.id to session.id]
             }
 
         this.bySession = sessions.associate { session ->
-            session.id to users.associate { user ->
-                user.userId to decideStatus(user, session)
+            session.id to attendees.associate { user ->
+                user.id to decideStatus(user, session)
             }
         }
 
-        this.byUser = users.associate { user ->
-            user.userId to sessions.associate { session ->
+        this.byUser = attendees.associate { user ->
+            user.id to sessions.associate { session ->
                 session.id to decideStatus(user, session)
             }
         }
@@ -57,14 +56,14 @@ class AttendanceBook(
 
     constructor(
         generation: Int,
-        users: List<UserWithActivityUnit>,
+        attendees: List<Attendee>,
         sessions: List<SessionEntity>,
         attendances: List<AttendanceEntity>,
         latePasses: List<LatePassEntity>,
         now: LocalDateTime
     ) : this(
         generation = generation,
-        users = users,
+        attendees = attendees,
         sessions = sessions,
         attendances = attendances,
         latePassCountByUserId = latePasses

--- a/src/main/kotlin/co/yappuworld/schedule/domain/Attendee.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/Attendee.kt
@@ -2,6 +2,7 @@ package co.yappuworld.schedule.domain
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.schedule.domain.vo.AttendanceError
+import co.yappuworld.user.domain.model.ActivityUnit
 import co.yappuworld.user.domain.model.UserWithActivityUnits
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.vo.UserRole
@@ -9,39 +10,73 @@ import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
 import java.util.UUID
 
 class Attendee(
-    userWithActivityUnits: UserWithActivityUnits,
-    generation: Int
+    val id: UUID,
+    val name: String,
+    val role: UserRole,
+    val position: Position
 ) {
 
-    constructor(
-        userWithActivityUnit: UserWithActivityUnit,
-        generation: Int
-    ) : this(
-        userWithActivityUnits = UserWithActivityUnits(userWithActivityUnit),
-        generation = generation
-    )
+    companion object {
 
-    val id: UUID = userWithActivityUnits.userId
-    val name: String = userWithActivityUnits.name
-    val role: UserRole = userWithActivityUnits.role
-    val position: Position
+        fun from(
+            userWithActivityUnit: UserWithActivityUnit,
+            generation: Int
+        ): Attendee {
+            checkRole(userWithActivityUnit.role)
+            checkActivityUnit(userWithActivityUnit.getActivityUnit(), generation)
 
-    init {
-        if (userWithActivityUnits.role !in listOf(UserRole.ACTIVE, UserRole.STAFF)) {
-            throw BusinessException(AttendanceError.UNAUTHORIZED_CHECK_IN)
+            return Attendee(
+                id = userWithActivityUnit.userId,
+                name = userWithActivityUnit.name,
+                role = userWithActivityUnit.role,
+                position = userWithActivityUnit.position
+            )
         }
 
-        val sessionGenerationActivityUnits = userWithActivityUnits.activityUnits
-            .filter { it.generation == generation }
+        fun from(
+            userWithActivityUnits: UserWithActivityUnits,
+            generation: Int
+        ): Attendee {
+            checkRole(userWithActivityUnits.role)
 
-        if (sessionGenerationActivityUnits.isEmpty()) {
-            throw BusinessException(AttendanceError.NO_ATTENDEE_ACTIVITY_IN_GENERATION)
+            val sessionGenerationActivityUnits = userWithActivityUnits.activityUnits
+                .filter { it.generation == generation }
+
+            if (sessionGenerationActivityUnits.isEmpty()) {
+                throw BusinessException(AttendanceError.NO_ATTENDEE_ACTIVITY_IN_GENERATION)
+            }
+
+            val position = try {
+                sessionGenerationActivityUnits.single { it.position.isAttendeePosition() }.position
+            } catch (e: RuntimeException) {
+                throw BusinessException(AttendanceError.NO_ATTENDEE_POSITION_ACTIVITY_IN_GENERATION)
+            }
+
+            return Attendee(
+                id = userWithActivityUnits.userId,
+                name = userWithActivityUnits.name,
+                role = userWithActivityUnits.role,
+                position = position
+            )
         }
 
-        position = try {
-            sessionGenerationActivityUnits.single { it.position.isAttendeePosition() }.position
-        } catch (e: RuntimeException) {
-            throw BusinessException(AttendanceError.NO_ATTENDEE_POSITION_ACTIVITY_IN_GENERATION)
+        private fun checkRole(role: UserRole) {
+            if (role !in listOf(UserRole.ACTIVE, UserRole.STAFF)) {
+                throw BusinessException(AttendanceError.UNAUTHORIZED_CHECK_IN)
+            }
+        }
+
+        private fun checkActivityUnit(
+            activityUnit: ActivityUnit,
+            generation: Int
+        ) {
+            if (activityUnit.generation != generation) {
+                throw BusinessException(AttendanceError.NO_ATTENDEE_ACTIVITY_IN_GENERATION)
+            }
+
+            if (!activityUnit.position.isAttendeePosition()) {
+                throw BusinessException(AttendanceError.NO_ATTENDEE_POSITION_ACTIVITY_IN_GENERATION)
+            }
         }
     }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/domain/Attendee.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/Attendee.kt
@@ -2,16 +2,24 @@ package co.yappuworld.schedule.domain
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.schedule.domain.vo.AttendanceError
-import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.user.domain.model.UserWithActivityUnits
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
 import java.util.UUID
 
-class SessionAttendee(
+class Attendee(
     userWithActivityUnits: UserWithActivityUnits,
-    session: SessionEntity
+    generation: Int
 ) {
+
+    constructor(
+        userWithActivityUnit: UserWithActivityUnit,
+        generation: Int
+    ) : this(
+        userWithActivityUnits = UserWithActivityUnits(userWithActivityUnit),
+        generation = generation
+    )
 
     val id: UUID = userWithActivityUnits.userId
     val name: String = userWithActivityUnits.name
@@ -24,7 +32,7 @@ class SessionAttendee(
         }
 
         val sessionGenerationActivityUnits = userWithActivityUnits.activityUnits
-            .filter { it.generation == session.generation }
+            .filter { it.generation == generation }
 
         if (sessionGenerationActivityUnits.isEmpty()) {
             throw BusinessException(AttendanceError.NO_ATTENDEE_ACTIVITY_IN_GENERATION)
@@ -36,5 +44,4 @@ class SessionAttendee(
             throw BusinessException(AttendanceError.NO_ATTENDEE_POSITION_ACTIVITY_IN_GENERATION)
         }
     }
-
 }

--- a/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
@@ -19,17 +19,17 @@ private val logger = KotlinLogging.logger {}
  * 특정 세션의 출석 정보
  */
 class SessionAttendance private constructor(
-    private val attendee: SessionAttendee,
+    private val attendee: Attendee,
     private val session: SessionEntity,
     private var attendance: AttendanceEntity?
 ) {
 
     constructor(
-        attendee: UserWithActivityUnits,
+        user: UserWithActivityUnits,
         session: SessionEntity,
         attendance: AttendanceEntity?
     ) : this(
-        attendee = SessionAttendee(attendee, session),
+        attendee = Attendee(user, session.generation),
         session = session,
         attendance = attendance
     )

--- a/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
@@ -8,7 +8,6 @@ import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.user.domain.model.UserWithActivityUnits
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -18,21 +17,11 @@ private val logger = KotlinLogging.logger {}
 /**
  * 특정 세션의 출석 정보
  */
-class SessionAttendance private constructor(
+class SessionAttendance(
     private val attendee: Attendee,
     private val session: SessionEntity,
     private var attendance: AttendanceEntity?
 ) {
-
-    constructor(
-        user: UserWithActivityUnits,
-        session: SessionEntity,
-        attendance: AttendanceEntity?
-    ) : this(
-        attendee = Attendee(user, session.generation),
-        session = session,
-        attendance = attendance
-    )
 
     val sessionId = session.id
     val sessionName = session.name

--- a/src/main/kotlin/co/yappuworld/user/domain/model/UserWithActivityUnits.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/UserWithActivityUnits.kt
@@ -12,20 +12,6 @@ class UserWithActivityUnits(
     val activityUnits: List<ActivityUnit>
 ) {
 
-    constructor(user: UserWithActivityUnit) : this(
-        userId = user.userId,
-        email = user.email,
-        name = user.name,
-        role = user.role,
-        activityUnits = listOf(
-            ActivityUnit(
-                generation = user.generation,
-                position = user.position,
-                userId = user.userId
-            )
-        )
-    )
-
     companion object {
         fun of(elements: List<UserWithActivityUnit>): UserWithActivityUnits {
             check(elements.groupBy { it.userId }.size == 1)

--- a/src/main/kotlin/co/yappuworld/user/domain/model/UserWithActivityUnits.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/model/UserWithActivityUnits.kt
@@ -12,6 +12,20 @@ class UserWithActivityUnits(
     val activityUnits: List<ActivityUnit>
 ) {
 
+    constructor(user: UserWithActivityUnit) : this(
+        userId = user.userId,
+        email = user.email,
+        name = user.name,
+        role = user.role,
+        activityUnits = listOf(
+            ActivityUnit(
+                generation = user.generation,
+                position = user.position,
+                userId = user.userId
+            )
+        )
+    )
+
     companion object {
         fun of(elements: List<UserWithActivityUnit>): UserWithActivityUnits {
             check(elements.groupBy { it.userId }.size == 1)

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
@@ -160,5 +160,10 @@ enum class UserError : Error {
         override val message: String = "활동 정보가 존재하지 않습니다."
         override val code: String = "USR_3002"
         override val type: ErrorType = ErrorType.WRONG_STATE
+    },
+    DUPLICATE_ATTENDEE_ACTIVITY {
+        override val message: String = "한 기수에 둘 이상의 참가자 활동 기록이 있습니다."
+        override val code: String = "USR_3003"
+        override val type: ErrorType = ErrorType.WRONG_STATE
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
@@ -171,7 +171,45 @@ class UserFindService(
                         )
                 )
             }.filterNotNull()
-            .map { Attendee(it, generation) }
+            .map { Attendee.from(it, generation) }
+
+    fun findSessionAttendee(
+        userId: UUID,
+        generation: Int
+    ): Attendee {
+        val result = userRepository
+            .findAll {
+                selectNew<UserWithActivityUnit>(
+                    path(UserEntity::getId),
+                    path(UserEntity::email),
+                    path(UserEntity::name),
+                    path(UserEntity::role),
+                    path(ActivityUnitEntity::generation),
+                    path(ActivityUnitEntity::position)
+                ).from(
+                    entity(UserEntity::class),
+                    innerJoin(entity(ActivityUnitEntity::class))
+                        .on(
+                            and(
+                                path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)),
+                                path(UserEntity::getId).equal(userId),
+                                path(ActivityUnitEntity::generation).equal(generation),
+                                path(ActivityUnitEntity::position).notEqual(Position.STAFF)
+                            )
+                        )
+                )
+            }.filterNotNull()
+
+        if (result.size > 1) {
+            throw BusinessException(UserError.DUPLICATE_ATTENDEE_ACTIVITY)
+        }
+
+        if (result.isEmpty()) {
+            throw BusinessException(UserError.USER_NOT_FOUND_WITH_GENERATION_ACTIVITY)
+        }
+
+        return Attendee.from(result.single(), generation)
+    }
 
     fun findUserWithActivityUnitOfGeneration(
         userId: UUID,

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
@@ -1,7 +1,9 @@
 package co.yappuworld.user.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.user.domain.model.UserWithActivityUnits
+import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
 import co.yappuworld.user.infrastructure.entity.UserEntity
@@ -146,6 +148,30 @@ class UserFindService(
                         )
                 )
             }.filterNotNull()
+
+    fun findSessionAttendeesOfGeneration(generation: Int): List<Attendee> =
+        userRepository
+            .findAll {
+                selectNew<UserWithActivityUnit>(
+                    path(UserEntity::getId),
+                    path(UserEntity::email),
+                    path(UserEntity::name),
+                    path(UserEntity::role),
+                    path(ActivityUnitEntity::generation),
+                    path(ActivityUnitEntity::position)
+                ).from(
+                    entity(UserEntity::class),
+                    innerJoin(entity(ActivityUnitEntity::class))
+                        .on(
+                            and(
+                                path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)),
+                                path(ActivityUnitEntity::generation).equal(generation),
+                                path(ActivityUnitEntity::position).notEqual(Position.STAFF)
+                            )
+                        )
+                )
+            }.filterNotNull()
+            .map { Attendee(it, generation) }
 
     fun findUserWithActivityUnitOfGeneration(
         userId: UUID,

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/model/UserWithActivityUnit.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/model/UserWithActivityUnit.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.user.infrastructure.model
 
+import co.yappuworld.user.domain.model.ActivityUnit
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.vo.UserRole
 import java.util.UUID
@@ -11,4 +12,12 @@ data class UserWithActivityUnit(
     val role: UserRole,
     val generation: Int,
     val position: Position
-)
+) {
+
+    fun getActivityUnit() =
+        ActivityUnit(
+            generation = generation,
+            position = position,
+            userId = userId
+        )
+}

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
@@ -11,6 +11,7 @@ import co.yappuworld.schedule.infrastructure.LatePassFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.support.fixture.AttendanceFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getActivityUnitFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitsFixture
@@ -49,6 +50,10 @@ class AttendanceServiceTest :
         val user = getUserWithActivityUnitsFixture(
             activityUnits = listOf(getActivityUnitFixture(generation = activeGeneration))
         )
+        val attendee = getAttendeeFixture(
+            userWithActivityUnits = user,
+            generation = activeGeneration
+        )
         val session = getSessionEntityFixture()
         val request = AttendanceFixture.getAttendRequestFixture(
             attendanceCode = attendanceCode,
@@ -57,7 +62,7 @@ class AttendanceServiceTest :
 
         fun successConditionMocking() {
             every { generationFindService.findActiveGeneration() } returns activeGeneration
-            every { userFindService.findUserWithActivities(any()) } returns user
+            every { userFindService.findSessionAttendee(any(), any()) } returns attendee
             every { sessionFindService.findSession(any()) } returns session
             every { attendanceFindService.findSessionAttendance(any(), any()) } returns null
             every { configFindService.findAttendanceCode() } returns attendanceCode

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
@@ -2,18 +2,17 @@ package co.yappuworld.schedule.client.application
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.operation.infrastructure.GenerationFindService
-import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.ScheduleFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.support.fixture.AttendanceFixture
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.ScheduleFixture
 import co.yappuworld.support.fixture.UserFixture.getActivityUnitFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitsFixture
 import co.yappuworld.user.domain.vo.Position
-import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.UserFindService
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.FeatureSpec
@@ -51,6 +50,7 @@ class UpcomingSessionFindTest :
             val now = LocalDateTime.of(2024, 10, 22, 14, 0)
             val userId = UUID.randomUUID()
             val user = getUserWithActivityUnitsFixture(
+                userId = userId,
                 activityUnits = listOf(
                     getActivityUnitFixture(generation = generation, position = Position.PM, userId = userId)
                 )
@@ -65,15 +65,9 @@ class UpcomingSessionFindTest :
 
             fun setCheckInPossibleCircumstance() {
                 every { generationFindService.findActiveGenerationOrNull() } returns generation
-                every { userFindService.findUserWithActivities(any()) } returns getUserWithActivityUnitsFixture(
-                    userId = userId,
-                    activityUnits = listOf(
-                        getActivityUnitFixture(
-                            generation = generation,
-                            position = Position.PM,
-                            userId = userId
-                        )
-                    )
+                every { userFindService.findSessionAttendee(any(), any()) } returns getAttendeeFixture(
+                    userWithActivityUnits = user,
+                    generation = generation
                 )
                 every { sessionFindService.findUpcomingSession(any(), any()) } returns session
                 every { attendanceFindService.findSessionAttendance(any(), any()) } returns null
@@ -81,7 +75,7 @@ class UpcomingSessionFindTest :
 
             scenario("현재 테스트 조건에선 출석을 누를 수 있다.") {
                 setCheckInPossibleCircumstance()
-                scheduleService.getUpcomingSessionAttendance(userId, now).canCheckIn.shouldBeTrue()
+                scheduleService.getUpcomingSessionAttendance(user.userId, now).canCheckIn.shouldBeTrue()
             }
 
             scenario("활성화 된 기수가 없으면 예외가 발생한다.") {
@@ -89,43 +83,8 @@ class UpcomingSessionFindTest :
                 every { generationFindService.findActiveGenerationOrNull() } returns null
 
                 shouldThrowExactly<BusinessException> {
-                    scheduleService.getUpcomingSessionAttendance(userId, now)
+                    scheduleService.getUpcomingSessionAttendance(user.userId, now)
                 }.error shouldBe ScheduleError.NO_SESSION_WITHOUT_ACTIVE_GENERATION
-            }
-
-            scenario("세션의 기수에 유저 활동기록이 없으면 예외가 발생한다.") {
-                setCheckInPossibleCircumstance()
-                every { userFindService.findUserWithActivities(any()) } returns
-                    getUserWithActivityUnitsFixture(
-                        activityUnits = listOf(
-                            getActivityUnitFixture(
-                                generation = generation + 1,
-                                position = Position.PM,
-                                userId = userId
-                            )
-                        )
-                    )
-
-                shouldThrowExactly<BusinessException> {
-                    scheduleService.getUpcomingSessionAttendance(userId, now).canCheckIn.shouldBeFalse()
-                }.error shouldBe AttendanceError.NO_ATTENDEE_ACTIVITY_IN_GENERATION
-            }
-
-            scenario("운영진이나 활동회원이 아니면 출석이 불가하다.") {
-                setCheckInPossibleCircumstance()
-
-                forAll(
-                    row(UserRole.ALUMNI),
-                    row(UserRole.GRADUATE),
-                    row(UserRole.ADMIN)
-                ) { role ->
-                    every { userFindService.findUserWithActivities(any()) } returns
-                        getUserWithActivityUnitsFixture(role = role)
-
-                    shouldThrowExactly<BusinessException> {
-                        scheduleService.getUpcomingSessionAttendance(userId, now)
-                    }.error shouldBe AttendanceError.UNAUTHORIZED_CHECK_IN
-                }
             }
 
             scenario("이미 출석을 했다면 출석을 누를 수 없다.") {
@@ -140,12 +99,12 @@ class UpcomingSessionFindTest :
                 ) { status ->
                     every { attendanceFindService.findSessionAttendance(any(), any()) } returns
                         AttendanceFixture.getAttendanceEntityFixture(
-                            userId = userId,
+                            userId = user.userId,
                             scheduleId = session.id,
                             status = status
                         )
 
-                    scheduleService.getUpcomingSessionAttendance(userId, now).canCheckIn.shouldBeFalse()
+                    scheduleService.getUpcomingSessionAttendance(user.userId, now).canCheckIn.shouldBeFalse()
                 }
             }
 
@@ -160,7 +119,7 @@ class UpcomingSessionFindTest :
                     ),
                     row(LocalDateTime.of(session.endDate, session.endTime))
                 ) { now ->
-                    scheduleService.getUpcomingSessionAttendance(userId, now).canCheckIn.shouldBeFalse()
+                    scheduleService.getUpcomingSessionAttendance(user.userId, now).canCheckIn.shouldBeFalse()
                 }
             }
 
@@ -170,7 +129,7 @@ class UpcomingSessionFindTest :
                     row(LocalDateTime.of(session.date, session.time.minusMinutes(20) ?: LocalTime.MIN)),
                     row(LocalDateTime.of(session.endDate, session.endTime.minusNanos(1) ?: LocalTime.MAX))
                 ) { now ->
-                    scheduleService.getUpcomingSessionAttendance(userId, now).canCheckIn.shouldBeTrue()
+                    scheduleService.getUpcomingSessionAttendance(user.userId, now).canCheckIn.shouldBeTrue()
                 }
             }
         }

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
@@ -1,11 +1,11 @@
 package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.schedule.domain.AttendanceBook
-import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.LATE
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ON_TIME
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitFixture
 import io.kotest.core.spec.style.FeatureSpec
@@ -45,7 +45,7 @@ class AdminAttendancesResponseTest :
                 val response = AdminAttendancesResponse.from(
                     AttendanceBook(
                         generation = generation,
-                        attendees = users.map { Attendee(it, generation) },
+                        attendees = users.map { getAttendeeFixture(it, generation) },
                         sessions = sessions,
                         attendances = attendances,
                         latePasses = emptyList(),

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
@@ -1,6 +1,7 @@
 package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.schedule.domain.AttendanceBook
+import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.LATE
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ON_TIME
@@ -44,7 +45,7 @@ class AdminAttendancesResponseTest :
                 val response = AdminAttendancesResponse.from(
                     AttendanceBook(
                         generation = generation,
-                        users = users,
+                        attendees = users.map { Attendee(it, generation) },
                         sessions = sessions,
                         attendances = attendances,
                         latePasses = emptyList(),

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.client.dto.response
 
+import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceBookFixture
@@ -57,7 +58,7 @@ class AttendanceStatisticsResponseTest :
                     .from(
                         getAttendanceBookFixture(
                             generation = generation,
-                            users = listOf(user),
+                            attendees = listOf(Attendee(user, generation)),
                             sessions = sessions,
                             attendances = attendances,
                             now = datetime
@@ -76,7 +77,7 @@ class AttendanceStatisticsResponseTest :
                     .from(
                         getAttendanceBookFixture(
                             generation = generation,
-                            users = listOf(user),
+                            attendees = listOf(Attendee(user, generation)),
                             sessions = sessions,
                             attendances = attendances,
                             latePassCountByUserId = mapOf(user.userId to 0),
@@ -98,7 +99,7 @@ class AttendanceStatisticsResponseTest :
                     .from(
                         getAttendanceBookFixture(
                             generation = generation,
-                            users = listOf(user),
+                            attendees = listOf(Attendee(user, generation)),
                             sessions = sessions,
                             attendances = sessions.subList(0, 2).map {
                                 getAttendanceEntityFixture(
@@ -128,7 +129,7 @@ class AttendanceStatisticsResponseTest :
                         .from(
                             getAttendanceBookFixture(
                                 generation = generation,
-                                users = listOf(user),
+                                attendees = listOf(Attendee(user, generation)),
                                 sessions = sessions,
                                 attendances = attendances,
                                 now = datetime
@@ -150,7 +151,7 @@ class AttendanceStatisticsResponseTest :
                         .from(
                             getAttendanceBookFixture(
                                 generation = generation,
-                                users = listOf(user),
+                                attendees = listOf(Attendee(user, generation)),
                                 sessions = sessions,
                                 attendances = attendances,
                                 now = datetime
@@ -177,7 +178,7 @@ class AttendanceStatisticsResponseTest :
                         .from(
                             getAttendanceBookFixture(
                                 generation = generation,
-                                users = listOf(user),
+                                attendees = listOf(Attendee(user, generation)),
                                 sessions = sessions,
                                 attendances = attendances,
                                 latePassCountByUserId = mapOf(user.userId to latePassCount),

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
@@ -1,10 +1,10 @@
 package co.yappuworld.schedule.client.dto.response
 
-import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceBookFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitFixture
 import io.kotest.core.spec.style.FeatureSpec
@@ -58,7 +58,7 @@ class AttendanceStatisticsResponseTest :
                     .from(
                         getAttendanceBookFixture(
                             generation = generation,
-                            attendees = listOf(Attendee(user, generation)),
+                            attendees = listOf(getAttendeeFixture(user, generation)),
                             sessions = sessions,
                             attendances = attendances,
                             now = datetime
@@ -77,7 +77,7 @@ class AttendanceStatisticsResponseTest :
                     .from(
                         getAttendanceBookFixture(
                             generation = generation,
-                            attendees = listOf(Attendee(user, generation)),
+                            attendees = listOf(getAttendeeFixture(user, generation)),
                             sessions = sessions,
                             attendances = attendances,
                             latePassCountByUserId = mapOf(user.userId to 0),
@@ -99,7 +99,7 @@ class AttendanceStatisticsResponseTest :
                     .from(
                         getAttendanceBookFixture(
                             generation = generation,
-                            attendees = listOf(Attendee(user, generation)),
+                            attendees = listOf(getAttendeeFixture(user, generation)),
                             sessions = sessions,
                             attendances = sessions.subList(0, 2).map {
                                 getAttendanceEntityFixture(
@@ -129,7 +129,7 @@ class AttendanceStatisticsResponseTest :
                         .from(
                             getAttendanceBookFixture(
                                 generation = generation,
-                                attendees = listOf(Attendee(user, generation)),
+                                attendees = listOf(getAttendeeFixture(user, generation)),
                                 sessions = sessions,
                                 attendances = attendances,
                                 now = datetime
@@ -151,7 +151,7 @@ class AttendanceStatisticsResponseTest :
                         .from(
                             getAttendanceBookFixture(
                                 generation = generation,
-                                attendees = listOf(Attendee(user, generation)),
+                                attendees = listOf(getAttendeeFixture(user, generation)),
                                 sessions = sessions,
                                 attendances = attendances,
                                 now = datetime
@@ -178,7 +178,7 @@ class AttendanceStatisticsResponseTest :
                         .from(
                             getAttendanceBookFixture(
                                 generation = generation,
-                                attendees = listOf(Attendee(user, generation)),
+                                attendees = listOf(getAttendeeFixture(user, generation)),
                                 sessions = sessions,
                                 attendances = attendances,
                                 latePassCountByUserId = mapOf(user.userId to latePassCount),

--- a/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
@@ -3,6 +3,7 @@ package co.yappuworld.schedule.domain
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.infrastructure.entity.LatePassEntity
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitFixture
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -71,7 +72,7 @@ class AttendanceBookTest :
                 shouldNotThrowAny {
                     AttendanceBook(
                         generation = generation,
-                        attendees = users.map { Attendee(it, generation) },
+                        attendees = users.map { getAttendeeFixture(it, generation) },
                         sessions = sessions,
                         attendances = attendances,
                         latePasses = latePassEntities,
@@ -83,7 +84,7 @@ class AttendanceBookTest :
             scenario("유저 출석 통계가 정상적으로 생성된다.") {
                 val attendanceBook = AttendanceBook(
                     generation = generation,
-                    attendees = users.map { Attendee(it, generation) },
+                    attendees = users.map { getAttendeeFixture(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
                     latePasses = latePassEntities,
@@ -133,7 +134,7 @@ class AttendanceBookTest :
             scenario("세션 출석 통계가 정상적으로 생성된다.") {
                 val attendanceBook = AttendanceBook(
                     generation = generation,
-                    attendees = users.map { Attendee(it, generation) },
+                    attendees = users.map { getAttendeeFixture(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
                     latePasses = latePassEntities,
@@ -171,7 +172,7 @@ class AttendanceBookTest :
             scenario("지각 면제권이 100점을 초과하도록 주어져도, total point는 100점을 넘지 않는다.") {
                 val attendanceBook = AttendanceBook(
                     generation = generation,
-                    attendees = users.map { Attendee(it, generation) },
+                    attendees = users.map { getAttendeeFixture(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
                     latePasses = listOf(
@@ -193,7 +194,7 @@ class AttendanceBookTest :
             scenario("출석 데이터가 정상적으로 생성된다.") {
                 val attendanceBook = AttendanceBook(
                     generation = generation,
-                    attendees = users.map { Attendee(it, generation) },
+                    attendees = users.map { getAttendeeFixture(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
                     latePasses = latePassEntities,

--- a/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
@@ -71,7 +71,7 @@ class AttendanceBookTest :
                 shouldNotThrowAny {
                     AttendanceBook(
                         generation = generation,
-                        users = users,
+                        attendees = users.map { Attendee(it, generation) },
                         sessions = sessions,
                         attendances = attendances,
                         latePasses = latePassEntities,
@@ -83,7 +83,7 @@ class AttendanceBookTest :
             scenario("유저 출석 통계가 정상적으로 생성된다.") {
                 val attendanceBook = AttendanceBook(
                     generation = generation,
-                    users = users,
+                    attendees = users.map { Attendee(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
                     latePasses = latePassEntities,
@@ -133,7 +133,7 @@ class AttendanceBookTest :
             scenario("세션 출석 통계가 정상적으로 생성된다.") {
                 val attendanceBook = AttendanceBook(
                     generation = generation,
-                    users = users,
+                    attendees = users.map { Attendee(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
                     latePasses = latePassEntities,
@@ -171,7 +171,7 @@ class AttendanceBookTest :
             scenario("지각 면제권이 100점을 초과하도록 주어져도, total point는 100점을 넘지 않는다.") {
                 val attendanceBook = AttendanceBook(
                     generation = generation,
-                    users = users,
+                    attendees = users.map { Attendee(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
                     latePasses = listOf(
@@ -193,7 +193,7 @@ class AttendanceBookTest :
             scenario("출석 데이터가 정상적으로 생성된다.") {
                 val attendanceBook = AttendanceBook(
                     generation = generation,
-                    users = users,
+                    attendees = users.map { Attendee(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
                     latePasses = latePassEntities,

--- a/src/test/kotlin/co/yappuworld/schedule/domain/SessionAttendanceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/SessionAttendanceTest.kt
@@ -1,9 +1,9 @@
 package co.yappuworld.schedule.domain
 
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getSessionAttendanceFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
-import co.yappuworld.support.fixture.UserFixture.getActivityUnitFixture
-import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitsFixture
+import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitFixture
 import io.kotest.core.spec.style.FeatureSpec
 import io.kotest.data.forAll
 import io.kotest.data.row
@@ -18,9 +18,7 @@ class SessionAttendanceTest :
 
         feature("출석 가능한 지 확인") {
             val generation = 25
-            val user = getUserWithActivityUnitsFixture(
-                activityUnits = listOf(getActivityUnitFixture(generation = generation))
-            )
+            val attendee = getAttendeeFixture(getUserWithActivityUnitFixture(generation = generation), generation)
             val session = getSessionEntityFixture(
                 generation = generation,
                 date = LocalDate.of(2024, 12, 12),
@@ -31,7 +29,7 @@ class SessionAttendanceTest :
 
             scenario("세션 시작 20분 전보다 더 이전이면 출석할 수 없다.") {
                 val now = LocalDateTime.of(2024, 12, 12, 13, 40).minusNanos(1)
-                getSessionAttendanceFixture(user, session, null).canCheckIn(now).shouldBeFalse()
+                getSessionAttendanceFixture(attendee, session, null).canCheckIn(now).shouldBeFalse()
             }
 
             scenario("세션 시작 20분 전부터, 세션 종료 직전까지 출석할 수 있다.") {
@@ -39,13 +37,13 @@ class SessionAttendanceTest :
                     row(LocalDateTime.of(2024, 12, 12, 13, 40)),
                     row(LocalDateTime.of(2024, 12, 13, 10, 0).minusNanos(1))
                 ) { now ->
-                    getSessionAttendanceFixture(user, session, null).canCheckIn(now).shouldBeTrue()
+                    getSessionAttendanceFixture(attendee, session, null).canCheckIn(now).shouldBeTrue()
                 }
             }
 
             scenario("종료 시간부터는 출석할 수 없다.") {
                 val now = LocalDateTime.of(session.endDate, session.endTime)
-                getSessionAttendanceFixture(user, session, null).canCheckIn(now).shouldBeFalse()
+                getSessionAttendanceFixture(attendee, session, null).canCheckIn(now).shouldBeFalse()
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/schedule/domain/SessionAttendeeTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/SessionAttendeeTest.kt
@@ -2,6 +2,7 @@ package co.yappuworld.schedule.domain
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.schedule.domain.vo.AttendanceError
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getActivityUnitFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitsFixture
@@ -27,7 +28,7 @@ class SessionAttendeeTest :
                 )
 
                 shouldThrowExactly<BusinessException> {
-                    Attendee(
+                    getAttendeeFixture(
                         userWithActivityUnits = userWithActivityUnits,
                         generation = session.generation
                     )
@@ -40,7 +41,7 @@ class SessionAttendeeTest :
                 )
 
                 shouldThrowExactly<BusinessException> {
-                    Attendee(
+                    getAttendeeFixture(
                         userWithActivityUnits = userWithActivityUnits,
                         generation = session.generation
                     )
@@ -62,7 +63,7 @@ class SessionAttendeeTest :
                     )
 
                     shouldNotThrowAny {
-                        Attendee(
+                        getAttendeeFixture(
                             userWithActivityUnits = userWithActivityUnits,
                             generation = session.generation
                         )
@@ -88,7 +89,7 @@ class SessionAttendeeTest :
                     )
 
                     shouldNotThrowAny {
-                        Attendee(
+                        getAttendeeFixture(
                             userWithActivityUnits = userWithActivityUnits,
                             generation = session.generation
                         )

--- a/src/test/kotlin/co/yappuworld/schedule/domain/SessionAttendeeTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/SessionAttendeeTest.kt
@@ -27,9 +27,9 @@ class SessionAttendeeTest :
                 )
 
                 shouldThrowExactly<BusinessException> {
-                    SessionAttendee(
+                    Attendee(
                         userWithActivityUnits = userWithActivityUnits,
-                        session = session
+                        generation = session.generation
                     )
                 }.error shouldBe AttendanceError.NO_ATTENDEE_ACTIVITY_IN_GENERATION
             }
@@ -40,9 +40,9 @@ class SessionAttendeeTest :
                 )
 
                 shouldThrowExactly<BusinessException> {
-                    SessionAttendee(
+                    Attendee(
                         userWithActivityUnits = userWithActivityUnits,
-                        session = session
+                        generation = session.generation
                     )
                 }.error shouldBe AttendanceError.NO_ATTENDEE_POSITION_ACTIVITY_IN_GENERATION
             }
@@ -62,9 +62,9 @@ class SessionAttendeeTest :
                     )
 
                     shouldNotThrowAny {
-                        SessionAttendee(
+                        Attendee(
                             userWithActivityUnits = userWithActivityUnits,
-                            session = session
+                            generation = session.generation
                         )
                     }
                 }
@@ -88,9 +88,9 @@ class SessionAttendeeTest :
                     )
 
                     shouldNotThrowAny {
-                        SessionAttendee(
+                        Attendee(
                             userWithActivityUnits = userWithActivityUnits,
-                            session = session
+                            generation = session.generation
                         )
                     }
                 }

--- a/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
@@ -2,6 +2,7 @@ package co.yappuworld.support.fixture
 
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.domain.AttendanceBook
+import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
@@ -22,7 +23,7 @@ object AttendanceFixture {
         attendance: AttendanceEntity? = null
     ): SessionAttendance =
         SessionAttendance(
-            attendee = user,
+            user = user,
             session = session,
             attendance = attendance
         )
@@ -48,7 +49,7 @@ object AttendanceFixture {
 
     fun getAttendanceBookFixture(
         generation: Int = 25,
-        users: List<UserWithActivityUnit> = listOf(getUserWithActivityUnitFixture(generation = generation)),
+        attendees: List<Attendee> = listOf(getAttendeeFixture()),
         sessions: List<SessionEntity> = listOf(getSessionEntityFixture(generation = generation)),
         attendances: List<AttendanceEntity> = emptyList(),
         latePassCountByUserId: Map<UUID, Int> = emptyMap(),
@@ -56,10 +57,19 @@ object AttendanceFixture {
     ): AttendanceBook =
         AttendanceBook(
             generation = generation,
-            users = users,
+            attendees = attendees,
             sessions = sessions,
             attendances = attendances,
             latePassCountByUserId = latePassCountByUserId,
             now = now
+        )
+
+    fun getAttendeeFixture(
+        user: UserWithActivityUnit = getUserWithActivityUnitFixture(),
+        generation: Int = 25
+    ): Attendee =
+        Attendee(
+            userWithActivityUnit = user,
+            generation = generation
         )
 }

--- a/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
@@ -11,6 +11,8 @@ import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitsFixture
 import co.yappuworld.user.domain.model.UserWithActivityUnits
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
 import java.time.LocalDateTime
 import java.util.UUID
@@ -18,12 +20,12 @@ import java.util.UUID
 object AttendanceFixture {
 
     fun getSessionAttendanceFixture(
-        user: UserWithActivityUnits = getUserWithActivityUnitsFixture(),
+        attendee: Attendee = getAttendeeFixture(getUserWithActivityUnitFixture()),
         session: SessionEntity = getSessionEntityFixture(),
         attendance: AttendanceEntity? = null
     ): SessionAttendance =
         SessionAttendance(
-            user = user,
+            attendee = attendee,
             session = session,
             attendance = attendance
         )
@@ -49,7 +51,7 @@ object AttendanceFixture {
 
     fun getAttendanceBookFixture(
         generation: Int = 25,
-        attendees: List<Attendee> = listOf(getAttendeeFixture()),
+        attendees: List<Attendee> = listOf(getAttendeeFixture(getUserWithActivityUnitFixture())),
         sessions: List<SessionEntity> = listOf(getSessionEntityFixture(generation = generation)),
         attendances: List<AttendanceEntity> = emptyList(),
         latePassCountByUserId: Map<UUID, Int> = emptyMap(),
@@ -65,11 +67,33 @@ object AttendanceFixture {
         )
 
     fun getAttendeeFixture(
-        user: UserWithActivityUnit = getUserWithActivityUnitFixture(),
-        generation: Int = 25
+        id: UUID = UUID.randomUUID(),
+        name: String = "test",
+        role: UserRole = UserRole.ACTIVE,
+        position: Position = Position.PM
     ): Attendee =
         Attendee(
-            userWithActivityUnit = user,
+            id = id,
+            name = name,
+            role = role,
+            position = position
+        )
+
+    fun getAttendeeFixture(
+        userWithActivityUnit: UserWithActivityUnit = getUserWithActivityUnitFixture(),
+        generation: Int = 25
+    ): Attendee =
+        Attendee.from(
+            userWithActivityUnit = userWithActivityUnit,
+            generation = generation
+        )
+
+    fun getAttendeeFixture(
+        userWithActivityUnits: UserWithActivityUnits = getUserWithActivityUnitsFixture(),
+        generation: Int = 25
+    ): Attendee =
+        Attendee.from(
+            userWithActivityUnits = userWithActivityUnits,
             generation = generation
         )
 }

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
@@ -319,6 +319,36 @@ class UserFindServiceTest @Autowired constructor(
             }
         }
 
+        feature("특정 기수의 모든 세션 참석자를 조회한다.") {
+
+            scenario("데이터가 없으면 빈 리스트가 반환된다.") {
+                userFindService.findSessionAttendeesOfGeneration(99).shouldBeEmpty()
+            }
+
+            scenario("운영진 활동 기록은 제외된다.") {
+                val user = getUserEntityFixture()
+                userRepository.saveAndFlush(user)
+                activityUnitRepository.saveAllAndFlush(
+                    listOf(getActivityUnitEntityFixture(generation = 99, position = Position.STAFF, userId = user.id))
+                )
+
+                userFindService.findSessionAttendeesOfGeneration(99).shouldHaveSize(0)
+            }
+
+            scenario("운영진 활동 기록과 다른 기록이 함께 있으면, 운영진 기록은 제외하고 다른 활동 기록이 포함된다.") {
+                val user = getUserEntityFixture()
+                userRepository.saveAndFlush(user)
+                activityUnitRepository.saveAllAndFlush(
+                    listOf(
+                        getActivityUnitEntityFixture(generation = 99, position = Position.STAFF, userId = user.id),
+                        getActivityUnitEntityFixture(generation = 99, position = Position.PM, userId = user.id)
+                    )
+                )
+
+                userFindService.findSessionAttendeesOfGeneration(99).shouldHaveSize(1)
+            }
+        }
+
         feature("특정 기수에 활동한 모든 유저를 조회한다.") {
 
             scenario("해당 기수에 활동한 유저가 없다면 빈 리스트를 반환한다.") {

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
@@ -319,6 +319,40 @@ class UserFindServiceTest @Autowired constructor(
             }
         }
 
+        feature("특정 기수의 세션 참석자를 조회한다.") {
+
+            scenario("데이터가 없으면 빈 리스트가 반환된다.") {
+                shouldThrowExactly<BusinessException> { userFindService.findSessionAttendee(UUID.randomUUID(), 99) }
+                    .error shouldBe UserError.USER_NOT_FOUND_WITH_GENERATION_ACTIVITY
+            }
+
+            scenario("운영진 활동 기록은 제외된다.") {
+                val user = getUserEntityFixture()
+                userRepository.saveAndFlush(user)
+                activityUnitRepository.saveAllAndFlush(
+                    listOf(getActivityUnitEntityFixture(generation = 99, position = Position.STAFF, userId = user.id))
+                )
+
+                shouldThrowExactly<BusinessException> { userFindService.findSessionAttendee(user.id, 99) }
+                    .error shouldBe UserError.USER_NOT_FOUND_WITH_GENERATION_ACTIVITY
+            }
+
+            scenario("운영진 활동 기록과 다른 기록이 함께 있으면, 운영진 기록은 제외하고 다른 활동 기록이 포함된다.") {
+                val user = getUserEntityFixture()
+                userRepository.saveAndFlush(user)
+                activityUnitRepository.saveAllAndFlush(
+                    listOf(
+                        getActivityUnitEntityFixture(generation = 99, position = Position.STAFF, userId = user.id),
+                        getActivityUnitEntityFixture(generation = 99, position = Position.PM, userId = user.id)
+                    )
+                )
+
+                userFindService
+                    .findSessionAttendee(user.id, 99)
+                    .position shouldBe Position.PM
+            }
+        }
+
         feature("특정 기수의 모든 세션 참석자를 조회한다.") {
 
             scenario("데이터가 없으면 빈 리스트가 반환된다.") {


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 출석부(AttendaceBook)의 생성자가 다양한 유저 도메인을 기반으로 함
- 복잡도가 너무 높아지는 문제


## ⭐️ 어떻게 해결했나요?
- 출석부를 참석자(Attendee) 기반으로 변경
- 참석자 조회 쿼리 생성
  - STAFF가 아닌 직군(Position)을 기반으로 조회


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
