### PR TITLE
feat: 어드민 기수 삭제

### DIFF
--- a/src/main/kotlin/co/yappuworld/operation/client/application/AdminUserOperationService.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/application/AdminUserOperationService.kt
@@ -2,10 +2,13 @@ package co.yappuworld.operation.client.application
 
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.operation.client.dto.request.AdminGenerationActiveUpdateRequest
+import co.yappuworld.operation.client.dto.request.AdminGenerationDeleteRequest
 import co.yappuworld.operation.client.dto.request.AdminGenerationPageRequest
 import co.yappuworld.operation.client.dto.request.AdminGenerationRegisterRequest
 import co.yappuworld.operation.client.dto.response.AdminGenerationActiveUpdateResponse
 import co.yappuworld.operation.client.dto.response.AdminGenerationResponse
+import co.yappuworld.operation.infrastructure.GenerationCommandService
+import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.operation.infrastructure.GenerationRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class AdminUserOperationService(
     private val generationActiveStateManager: GenerationActiveStateManager,
+    private val generationFindService: GenerationFindService,
+    private val generationCommandService: GenerationCommandService,
     private val generationRepository: GenerationRepository
 ) {
 
@@ -44,4 +49,9 @@ class AdminUserOperationService(
                 false -> generationActiveStateManager.deactivate(request.generation)
             }
         )
+
+    @Transactional
+    fun deleteGeneration(request: AdminGenerationDeleteRequest) {
+        generationCommandService.delete(request.generation)
+    }
 }

--- a/src/main/kotlin/co/yappuworld/operation/client/dto/request/AdminGenerationDeleteRequest.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/dto/request/AdminGenerationDeleteRequest.kt
@@ -1,0 +1,8 @@
+package co.yappuworld.operation.client.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AdminGenerationDeleteRequest(
+    @Schema(description = "삭제할 기수")
+    val generation: Int
+)

--- a/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminUserOperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminUserOperationApi.kt
@@ -4,6 +4,7 @@ import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.operation.client.dto.request.AdminGenerationActiveUpdateRequest
+import co.yappuworld.operation.client.dto.request.AdminGenerationDeleteRequest
 import co.yappuworld.operation.client.dto.request.AdminGenerationPageRequest
 import co.yappuworld.operation.client.dto.request.AdminGenerationRegisterRequest
 import co.yappuworld.operation.client.dto.request.AdminSignupCodeDeleteRequest
@@ -82,7 +83,6 @@ interface AdminUserOperationApi {
     @ApiResponses(
         value = [
             ApiResponse(
-                description = "성공",
                 responseCode = "201",
                 content = [Content()]
             )
@@ -92,6 +92,20 @@ interface AdminUserOperationApi {
     fun registerGeneration(
         @Valid @RequestBody request: AdminGenerationRegisterRequest
     ): ResponseEntity<Unit>
+
+    @Operation(summary = "기수 삭제")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                content = [Content()]
+            )
+        ]
+    )
+    @DeleteMapping("/admin/v1/operations/generations")
+    fun deleteGeneration(
+        @RequestBody request: AdminGenerationDeleteRequest
+    ): ResponseEntity<SuccessResponse<Unit>>
 
     @Operation(summary = "기수 활성화 상태 변경")
     @ApiResponses(

--- a/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminUserOperationController.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/presentation/AdminUserOperationController.kt
@@ -5,6 +5,7 @@ import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.operation.client.application.AdminUserOperationService
 import co.yappuworld.operation.client.application.ConfigInquiryComponent
 import co.yappuworld.operation.client.dto.request.AdminGenerationActiveUpdateRequest
+import co.yappuworld.operation.client.dto.request.AdminGenerationDeleteRequest
 import co.yappuworld.operation.client.dto.request.AdminGenerationPageRequest
 import co.yappuworld.operation.client.dto.request.AdminGenerationRegisterRequest
 import co.yappuworld.operation.client.dto.request.AdminSignupCodeDeleteRequest
@@ -36,6 +37,11 @@ class AdminUserOperationController(
     override fun registerGeneration(request: AdminGenerationRegisterRequest): ResponseEntity<Unit> {
         adminUserOperationService.registerGeneration(request)
         return ResponseEntity.created(URI("/admin/v1/operations")).build()
+    }
+
+    override fun deleteGeneration(request: AdminGenerationDeleteRequest): ResponseEntity<SuccessResponse<Unit>> {
+        adminUserOperationService.deleteGeneration(request)
+        return ResponseEntity.noContent().build()
     }
 
     override fun updateActiveGeneration(

--- a/src/main/kotlin/co/yappuworld/operation/client/presentation/OperationApi.kt
+++ b/src/main/kotlin/co/yappuworld/operation/client/presentation/OperationApi.kt
@@ -67,7 +67,7 @@ interface OperationApi {
                         examples = [
                             ExampleObject(
                                 name = "강제 업데이트 필요",
-//                                ref = "#/components/schemas/SuccessResponseForceUpdateResponse",
+                                //                                ref = "#/components/schemas/SuccessResponseForceUpdateResponse",
                                 value = """
                                     {
                                         "isSuccess": "true",

--- a/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/operation/infrastructure/GenerationCommandService.kt
@@ -1,0 +1,21 @@
+package co.yappuworld.operation.infrastructure
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.operation.domain.OperationError
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class GenerationCommandService(
+    private val generationRepository: GenerationRepository
+) {
+
+    fun delete(generation: Int) {
+        generationRepository
+            .findByIdOrNull(generation)
+            ?.also { generationRepository.delete(it) }
+            ?: throw BusinessException(OperationError.NOT_EXIST_GENERATION)
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 현재 어드민에서 기수를 삭제하는 기능이 없음
- 이로 인해 테스트 데이터가 무분별하게 누적되는데 막을 방법이 없음


## ⭐️ 어떻게 해결했나요?
- 기수 삭제 API를 제공합니다.
- 연관 관계는 없어서, 특정 기수에 의존하고 있는 데이터를 별도로 처리하지는 않습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
