### PR TITLE
fix: 이메일 중복 검사할 때 탈퇴한 회원의 이메일인지 확인

### DIFF
--- a/src/main/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutor.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutor.kt
@@ -76,9 +76,10 @@ class SignUpExecutor(
     }
 
     fun checkEmailAvailability(email: String) {
-        if (userFindService.existsEmail(email)) {
-            logger.warn { "${email}은 이미 가입된 이메일입니다." }
-            throw BusinessException(UserError.ALREADY_SIGNED_UP_EMAIL)
+        val user = userFindService.findUserOrNull(email) ?: return
+        when (user.isWithdrawn()) {
+            true -> throw BusinessException(UserError.WITHDRAWN_EMAIL)
+            false -> throw BusinessException(UserError.ALREADY_SIGNED_UP_EMAIL)
         }
     }
 

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserAuthApi.kt
@@ -310,6 +310,16 @@ interface UserAuthApi {
                                         "errorCode": "USR_1002"
                                     }
                                 """
+                            ),
+                            ExampleObject(
+                                name = "탈퇴한 이메일",
+                                value = """
+                                    {
+                                        "isSuccess": "false",
+                                        "message": "탈퇴한 이메일입니다.",
+                                        "errorCode": "USR_1006"
+                                    }
+                                """
                             )
                         ]
                     )

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/UserError.kt
@@ -63,6 +63,12 @@ enum class UserError : Error {
         override val code: String = "USR_1005"
         override val type: ErrorType = ErrorType.WRONG_ARGUMENT
     },
+    WITHDRAWN_EMAIL {
+        override val message: String = "탈퇴한 이메일입니다."
+        override val code: String = "USR_1006"
+        override val type: ErrorType = ErrorType.WRONG_STATE
+    },
+
     ALREADY_PROCESSED_EMAIL {
         override val message: String = "이미 처리 중인 이메일입니다."
         override val code: String = "USR_1098"

--- a/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpFacadeUnitTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpFacadeUnitTest.kt
@@ -46,14 +46,14 @@ class SignUpFacadeUnitTest :
             every { signUpApplicationCommandService.getLock(any()) } returns 1
 
             scenario("이미 사용 중인 이메일이면 제출할 수 없다.") {
-                every { userFindService.existsEmail(any()) } returns true
+                every { userFindService.findUserOrNull(any<String>()) } returns getUserEntityFixture()
                 shouldThrowExactly<BusinessException> {
                     executor.submit(getSignUpApplicationEntityFixture())
                 }.error shouldBe UserError.ALREADY_SIGNED_UP_EMAIL
             }
 
             scenario("이미 PENDING 상태의 신청서가 있으면 추가 제출이 불가") {
-                every { userFindService.existsEmail(any()) } returns false
+                every { userFindService.findUserOrNull(any<String>()) } returns null
                 every { signUpApplicationFindService.existsPendingApplication(any()) } returns true
 
                 shouldThrowExactly<BusinessException> {
@@ -62,7 +62,7 @@ class SignUpFacadeUnitTest :
             }
 
             scenario("정상적으로 신청서를 제출한다.") {
-                every { userFindService.existsEmail(any()) } returns false
+                every { userFindService.findUserOrNull(any<String>()) } returns null
                 every { signUpApplicationFindService.existsPendingApplication(any()) } returns false
                 justRun { signUpApplicationCommandService.submit(any()) }
 
@@ -111,8 +111,8 @@ class SignUpFacadeUnitTest :
             scenario("하나라도 이미 가입된 이메일이라면 예외가 발생한다.") {
                 val applications = List(2) { getSignUpApplicationEntityFixture(email = "email$it@email.com") }
                 every { signUpApplicationFindService.findSignUpApplications(ids = any()) } returns applications
-                every { userFindService.existsEmail(applications[0].applicantEmail) } returns true
-                every { userFindService.existsEmail(applications[1].applicantEmail) } returns false
+                every { userFindService.findUserOrNull(applications[0].applicantEmail) } returns getUserEntityFixture()
+                every { userFindService.findUserOrNull(applications[1].applicantEmail) } returns null
 
                 shouldThrowExactly<BusinessException> {
                     executor.approve(applications.map { it.id }, UserRole.ACTIVE)
@@ -122,7 +122,7 @@ class SignUpFacadeUnitTest :
             scenario("정상적으로 승인된다.") {
                 val applications = List(2) { getSignUpApplicationEntityFixture(email = "email$it@email.com") }
                 every { signUpApplicationFindService.findSignUpApplications(ids = any()) } returns applications
-                every { userFindService.existsEmail(any()) } returns false
+                every { userFindService.findUserOrNull(any<String>()) } returns null
                 val users = List(2) { getUserEntityFixture() }
                 applications.forEachIndexed { index, application ->
                     every { userCommandService.signUp(application, any()) } returns users[index]
@@ -188,14 +188,22 @@ class SignUpFacadeUnitTest :
         feature("이메일 사용 가능 검사") {
 
             scenario("이미 존재한다면 예외가 발생한다.") {
-                every { userFindService.existsEmail(any()) } returns true
+                every { userFindService.findUserOrNull(any<String>()) } returns getUserEntityFixture()
                 shouldThrowExactly<BusinessException> {
                     executor.checkEmailAvailability("email@email.com")
-                }
+                }.error shouldBe UserError.ALREADY_SIGNED_UP_EMAIL
+            }
+
+            scenario("탈퇴했으면 관련 에러를 발생시킨다.") {
+                every { userFindService.findUserOrNull(any<String>()) } returns
+                    getUserEntityFixture().apply { withdraw() }
+                shouldThrowExactly<BusinessException> {
+                    executor.checkEmailAvailability("email@email.com")
+                }.error shouldBe UserError.WITHDRAWN_EMAIL
             }
 
             scenario("존재하지 않으면 예외가 발생하지 않는다.") {
-                every { userFindService.existsEmail(any()) } returns false
+                every { userFindService.findUserOrNull(any<String>()) } returns null
                 shouldNotThrowAny {
                     executor.checkEmailAvailability("email@email.com")
                 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 현재 회원가입 과정에서 이메일 중복 검사를 진행하면, 중복에 대한 검사만 진행함
- 탈퇴 유저의 이메일인지에 대한 확인이 불가


## ⭐️ 어떻게 해결했나요?
- existsEmail(email: String)을 findUserOrNull(email:String)으로 변경하고, 해당 유저가 탈퇴했는지 확인
- 확인 결과에 따라 에러를 구분하여 응답


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
