### PR TITLE
feat: 세션 참석자 지정

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
@@ -12,7 +12,6 @@ import co.yappuworld.schedule.infrastructure.AttendanceCommandService
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.LatePassFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService
-import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.user.infrastructure.UserFindService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -58,24 +57,9 @@ class AdminAttendanceService(
 
     @Transactional
     fun updateSessionAttendances(request: AdminSessionAttendanceUpdateRequest) {
-        val activeGeneration = generationFindService.findActiveGeneration()
-        val users = userFindService.findActiveUsersOfGeneration(activeGeneration)
-        val existAttendances = attendanceFindService
+        attendanceFindService
             .findAttendances(request.sessionId)
-            .associateBy { it.userId }
-
-        val allAttendances = users.map { user ->
-            when (existAttendances.containsKey(user.userId)) {
-                true -> existAttendances[user.userId]!!.apply { updateStatus(request.attendanceStatus) }
-                false -> AttendanceEntity(
-                    status = request.attendanceStatus,
-                    userId = user.userId,
-                    scheduleId = request.sessionId
-                )
-            }
-        }
-
-        attendanceCommandService.saveAll(allAttendances)
+            .onEach { it.updateStatus(request.attendanceStatus) }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
@@ -50,21 +50,10 @@ class AdminAttendanceService(
             .findAttendances(request.getSessionAndUserIdPairs())
             .associateBy { it.scheduleId to it.userId }
 
-        val newAttendances = mutableListOf<AttendanceEntity>()
-
         request.targets.forEach { target ->
             attendanceBySessionAndUserId[target.sessionId to target.userId]
                 ?.apply { updateStatus(target.attendanceStatus) }
-                ?: newAttendances.add(
-                    AttendanceEntity(
-                        status = target.attendanceStatus,
-                        userId = target.userId,
-                        scheduleId = target.sessionId
-                    )
-                )
         }
-
-        if (newAttendances.isNotEmpty()) attendanceCommandService.saveAll(newAttendances)
     }
 
     @Transactional

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
@@ -59,7 +59,7 @@ class AdminAttendanceService(
     @Transactional
     fun updateSessionAttendances(request: AdminSessionAttendanceUpdateRequest) {
         val activeGeneration = generationFindService.findActiveGeneration()
-        val users = userFindService.findUsersActiveOfGeneration(activeGeneration)
+        val users = userFindService.findActiveUsersOfGeneration(activeGeneration)
         val existAttendances = attendanceFindService
             .findAttendances(request.sessionId)
             .associateBy { it.userId }

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
@@ -16,6 +16,7 @@ import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.ScheduleCommandService
 import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.user.infrastructure.UserFindService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -73,12 +74,29 @@ class AdminScheduleService(
 
     @Transactional
     fun updateSession(request: AdminSessionUpdateRequest) {
-        sessionFindService
-            .findSession(request.id)
-            .apply { request.applyTo(this) }
+        val session = sessionFindService.findSession(request.id)
+        request.applyTo(session)
+        handleAttendee(session, request.sessionAttendeeIds)
     }
 
     @Transactional(readOnly = true)
     fun getSessionEligibleUsers(request: AdminSessionEligibleUsersParamRequest): AdminSessionEligibleUsersResponse =
         AdminSessionEligibleUsersResponse.from(userFindService.findActiveUsersOfGeneration(request.generation))
+
+    private fun handleAttendee(
+        session: SessionEntity,
+        requestSessionAttendeeIds: List<UUID>
+    ) {
+        val attendances = attendanceFindService.findAttendances(session.id)
+        val attendeeIds = attendances.map { it.userId }
+
+        requestSessionAttendeeIds
+            .filter { attendeeId -> attendeeId !in attendeeIds }
+            .map { attendeeId -> AttendanceEntity(userId = attendeeId, scheduleId = session.id) }
+            .also { toCreate -> attendanceCommandService.saveAll(toCreate) }
+
+        attendances
+            .filter { attendance -> attendance.userId !in requestSessionAttendeeIds }
+            .also { toDelete -> attendanceCommandService.deleteAll(toDelete) }
+    }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
@@ -4,9 +4,11 @@ import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.schedule.client.dto.request.AdminSessionCreateRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionDeleteRequest
+import co.yappuworld.schedule.client.dto.request.AdminSessionEligibleUsersParamRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionPageRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
+import co.yappuworld.schedule.client.dto.response.AdminSessionEligibleUsersResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
 import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
@@ -14,16 +16,18 @@ import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.ScheduleCommandService
 import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
+import co.yappuworld.user.infrastructure.UserFindService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Service
-class ScheduleAdminService(
+class AdminScheduleService(
     private val sessionFindService: SessionFindService,
     private val scheduleCommandService: ScheduleCommandService,
     private val attendanceFindService: AttendanceFindService,
-    private val attendanceCommandService: AttendanceCommandService
+    private val attendanceCommandService: AttendanceCommandService,
+    private val userFindService: UserFindService
 ) {
 
     @Transactional
@@ -73,4 +77,8 @@ class ScheduleAdminService(
             .findSession(request.id)
             .apply { request.applyTo(this) }
     }
+
+    @Transactional(readOnly = true)
+    fun getSessionEligibleUsers(request: AdminSessionEligibleUsersParamRequest): AdminSessionEligibleUsersResponse =
+        AdminSessionEligibleUsersResponse.from(userFindService.findActiveUsersOfGeneration(request.generation))
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
@@ -10,6 +10,7 @@ import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
 import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
+import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.ScheduleCommandService
 import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
@@ -21,6 +22,7 @@ import java.util.UUID
 class ScheduleAdminService(
     private val sessionFindService: SessionFindService,
     private val scheduleCommandService: ScheduleCommandService,
+    private val attendanceFindService: AttendanceFindService,
     private val attendanceCommandService: AttendanceCommandService
 ) {
 
@@ -51,13 +53,13 @@ class ScheduleAdminService(
      * 어드민에서 요청하는 세션 삭제라, hard delete 구현
      */
     @Transactional
-    fun deleteSession(request: AdminSessionDeleteRequest) {
+    fun deleteSessions(request: AdminSessionDeleteRequest) {
         val sessions = sessionFindService.findSessions(request.ids)
-
         if (sessions.size != request.ids.size) {
             throw BusinessException(ScheduleError.CONTAIN_IMPROPER_ID_FOR_DELETE_SESSION)
         }
 
+        attendanceCommandService.deleteAllInSessions(request.ids)
         scheduleCommandService.deleteAll(sessions)
     }
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
@@ -9,8 +9,10 @@ import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
 import co.yappuworld.schedule.domain.vo.ScheduleError
+import co.yappuworld.schedule.infrastructure.AttendanceCommandService
 import co.yappuworld.schedule.infrastructure.ScheduleCommandService
 import co.yappuworld.schedule.infrastructure.SessionFindService
+import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -18,14 +20,18 @@ import java.util.UUID
 @Service
 class ScheduleAdminService(
     private val sessionFindService: SessionFindService,
-    private val scheduleCommandService: ScheduleCommandService
+    private val scheduleCommandService: ScheduleCommandService,
+    private val attendanceCommandService: AttendanceCommandService
 ) {
 
     @Transactional
     fun createSchedule(request: AdminSessionCreateRequest): UUID {
-        val schedule = request
-            .toDomain()
-            .also { scheduleCommandService.save(it) }
+        val schedule = request.toDomain()
+        scheduleCommandService.save(schedule)
+
+        request.sessionAttendeeIds
+            .map { attendeeId -> AttendanceEntity(userId = attendeeId, scheduleId = schedule.id) }
+            .also { attendanceCommandService.saveAll(it) }
 
         return schedule.id
     }

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminService.kt
@@ -32,8 +32,9 @@ class ScheduleAdminService(
         scheduleCommandService.save(schedule)
 
         request.sessionAttendeeIds
-            .map { attendeeId -> AttendanceEntity(userId = attendeeId, scheduleId = schedule.id) }
-            .also { attendanceCommandService.saveAll(it) }
+            .takeIf { it.isNotEmpty() }
+            ?.map { attendeeId -> AttendanceEntity(userId = attendeeId, scheduleId = schedule.id) }
+            ?.also { attendanceCommandService.saveAll(it) }
 
         return schedule.id
     }
@@ -47,7 +48,10 @@ class ScheduleAdminService(
 
     @Transactional(readOnly = true)
     fun getSession(id: UUID): AdminSessionDetailResponse =
-        AdminSessionDetailResponse(sessionFindService.findSession(id))
+        AdminSessionDetailResponse(
+            session = sessionFindService.findSession(id),
+            attendees = attendanceFindService.findAttendees(id)
+        )
 
     /**
      * 어드민에서 요청하는 세션 삭제라, hard delete 구현

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -3,7 +3,7 @@ package co.yappuworld.schedule.client.application
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
-import co.yappuworld.schedule.client.dto.request.SessionQueryParamRequest
+import co.yappuworld.schedule.client.dto.request.SessionParamRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.SessionOverviewResponse
@@ -64,7 +64,7 @@ class ScheduleService(
 
     fun getSessions(
         userId: UUID,
-        request: SessionQueryParamRequest,
+        request: SessionParamRequest,
         now: LocalDateTime
     ): SessionOverviewResponse {
         val generation = request.generation

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
@@ -34,7 +34,7 @@ data class AdminSessionCreateRequest(
     var type: ScheduleType,
     @Schema(description = "세션 종류", nullable = false, example = "OFFLINE")
     var sessionType: SessionType,
-    @Schema(description = "세션 참석자 ID", nullable = false, example = "OFFLINE")
+    @Schema(description = "세션 참석자 ID", nullable = false)
     val sessionAttendeeIds: List<UUID>
 ) {
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
@@ -4,14 +4,12 @@ import co.yappuworld.schedule.domain.vo.ScheduleType
 import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.entity.ScheduleEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 import java.time.LocalTime
-
-private val logger = KotlinLogging.logger {}
+import java.util.UUID
 
 data class AdminSessionCreateRequest(
     @Schema(description = "스케줄 이름", nullable = false, example = "데모데이")
@@ -35,24 +33,12 @@ data class AdminSessionCreateRequest(
     @field:NotNull
     var type: ScheduleType,
     @Schema(description = "세션 종류", nullable = false, example = "OFFLINE")
-    var sessionType: SessionType
+    var sessionType: SessionType,
+    @Schema(description = "세션 참석자 ID", nullable = false, example = "OFFLINE")
+    val sessionAttendeeIds: List<UUID>
 ) {
 
-    init {
-        logger.info { "세션 시작 날짜: $date" }
-        logger.info { "세션 시작 시간: $time" }
-        logger.info { "세션 종료 날짜: $endDate" }
-        logger.info { "세션 종료 시간: $endTime" }
-    }
-
     fun toDomain(): ScheduleEntity =
-        when (type) {
-            ScheduleType.SESSION -> convertToSession()
-            ScheduleType.TASK -> TODO()
-            ScheduleType.ETC -> TODO()
-        }
-
-    private fun convertToSession(): ScheduleEntity =
         SessionEntity(
             name = name,
             description = description,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionEligibleUsersParamRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionEligibleUsersParamRequest.kt
@@ -1,0 +1,8 @@
+package co.yappuworld.schedule.client.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AdminSessionEligibleUsersParamRequest(
+    @field:Schema(description = "세션 기수", required = true, nullable = false)
+    val generation: Int
+)

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionUpdateRequest.kt
@@ -25,7 +25,9 @@ data class AdminSessionUpdateRequest(
     @Schema(description = "종료 시간", example = "17:00:00", type = "string")
     val endTime: LocalTime,
     @Schema(description = "세션 종류", example = "OFFLINE")
-    val sessionType: SessionType
+    val sessionType: SessionType,
+    @Schema(description = "세션 참석자 ID", nullable = false)
+    val sessionAttendeeIds: List<UUID>
 ) {
 
     fun applyTo(session: SessionEntity) {

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/SessionParamRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/SessionParamRequest.kt
@@ -4,7 +4,7 @@ import co.yappuworld.global.util.LocalDateRange
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
-data class SessionQueryParamRequest(
+data class SessionParamRequest(
     @field:Schema(description = "기수, null이라면 현재 활성화 된 기수를 처리", nullable = true)
     val generation: Int? = null,
     @field:Schema(

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponse.kt
@@ -6,13 +6,9 @@ import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.schedule.domain.SessionAttendanceStatistics
 import co.yappuworld.schedule.domain.UserAttendanceStatistics
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
-import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
-import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.UUID
 
@@ -150,29 +146,6 @@ data class AdminSessionAttendanceGroupResponse(
     companion object {
 
         fun from(
-            session: SessionEntity,
-            users: List<UserWithActivityUnit>,
-            attendances: List<AttendanceEntity>,
-            now: LocalDateTime
-        ): AdminSessionAttendanceGroupResponse {
-            val attendancesInSessionByUserId = attendances
-                .filter { it.scheduleId == session.id }
-                .associateBy { it.userId }
-            val statusWithoutAttendanceData = if (session.isFinished(now)) ABSENT.label else null
-
-            return AdminSessionAttendanceGroupResponse(
-                sessionId = session.id,
-                attendances = users.map { user ->
-                    AdminUserAttendanceResponse(
-                        userId = user.userId,
-                        status = attendancesInSessionByUserId[user.userId]?.status?.label
-                            ?: statusWithoutAttendanceData
-                    )
-                }
-            )
-        }
-
-        fun from(
             sessionId: UUID,
             attendanceByUserId: Map<UUID, AttendanceStatus?>
         ): AdminSessionAttendanceGroupResponse =
@@ -181,7 +154,7 @@ data class AdminSessionAttendanceGroupResponse(
                 attendances = attendanceByUserId.map { (userId, status) ->
                     AdminUserAttendanceResponse(
                         userId = userId,
-                        status = status?.label
+                        status = status
                     )
                 }
             )
@@ -191,6 +164,6 @@ data class AdminSessionAttendanceGroupResponse(
 data class AdminUserAttendanceResponse(
     @Schema(description = "유저 ID")
     val userId: UUID,
-    @Schema(description = "출석 정보", allowableValues = ["출석", "지각", "결석", "조퇴", "공결"], nullable = true)
-    val status: String? = null
+    @Schema(description = "출석 정보, null이면 세션에 참석하지 않는 유저", nullable = true)
+    val status: AttendanceStatus? = null
 )

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
@@ -2,13 +2,10 @@ package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
-
-private val logger = KotlinLogging.logger {}
 
 data class AdminSessionDetailResponse(
     @Schema(description = "세션 ID")
@@ -30,13 +27,6 @@ data class AdminSessionDetailResponse(
     @Schema(description = "세션 타입")
     val sessionType: SessionType
 ) {
-
-    init {
-        logger.info { "세션 시작 날짜: $date" }
-        logger.info { "세션 시작 시간: $time" }
-        logger.info { "세션 종료 날짜: $endDate" }
-        logger.info { "세션 종료 시간: $endTime" }
-    }
 
     constructor(session: SessionEntity) : this(
         id = session.id,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
@@ -1,7 +1,9 @@
 package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.schedule.domain.vo.SessionType
+import co.yappuworld.schedule.infrastructure.dto.SessionAttendeeDto
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import co.yappuworld.user.domain.vo.Position
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime
@@ -25,10 +27,11 @@ data class AdminSessionDetailResponse(
     @Schema(description = "세션 종료 시간")
     val endTime: LocalTime,
     @Schema(description = "세션 타입")
-    val sessionType: SessionType
+    val sessionType: SessionType,
+    val attendees: List<AdminSessionAttendeeByPositionResponse>
 ) {
 
-    constructor(session: SessionEntity) : this(
+    constructor(session: SessionEntity, attendees: List<SessionAttendeeDto>) : this(
         id = session.id,
         name = session.name,
         generation = session.generation,
@@ -37,6 +40,35 @@ data class AdminSessionDetailResponse(
         endDate = session.endDate,
         time = session.time,
         endTime = session.endTime,
-        sessionType = session.sessionType
+        sessionType = session.sessionType,
+        attendees = attendees
+            .groupBy { it.position }
+            .let { attendeesGroupByPosition ->
+                Position.attendeePositions.map { position ->
+                    AdminSessionAttendeeByPositionResponse(
+                        position = position,
+                        attendees = attendeesGroupByPosition[position]?.map { AdminSessionAttendeeResponse(it) }
+                            ?: emptyList()
+                    )
+                }
+            }.sortedBy { it.position.ordinal }
+    )
+}
+
+data class AdminSessionAttendeeByPositionResponse(
+    val position: Position,
+    val attendees: List<AdminSessionAttendeeResponse>
+)
+
+data class AdminSessionAttendeeResponse(
+    val userId: UUID,
+    val name: String,
+    val position: Position
+) {
+
+    constructor(attendee: SessionAttendeeDto) : this(
+        userId = attendee.userId,
+        name = attendee.name,
+        position = attendee.position
     )
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
@@ -44,7 +44,7 @@ data class AdminSessionDetailResponse(
         attendees = attendees
             .groupBy { it.position }
             .let { attendeesGroupByPosition ->
-                Position.attendeePositions.map { position ->
+                Position.activeUserPositions.map { position ->
                     AdminSessionAttendeeByPositionResponse(
                         position = position,
                         attendees = attendeesGroupByPosition[position]?.map { AdminSessionAttendeeResponse(it) }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionEligibleUsersResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionEligibleUsersResponse.kt
@@ -1,0 +1,43 @@
+package co.yappuworld.schedule.client.dto.response
+
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
+import java.util.UUID
+
+data class AdminSessionEligibleUsersResponse(
+    val users: List<AdminSessionEligibleUsersGroupedByPositionResponse>
+) {
+
+    companion object {
+        fun from(users: List<UserWithActivityUnit>): AdminSessionEligibleUsersResponse =
+            AdminSessionEligibleUsersResponse(
+                users = users
+                    .groupBy { it.position }
+                    .let { userByPosition ->
+                        Position.activeUserPositions.map { position ->
+                            AdminSessionEligibleUsersGroupedByPositionResponse(
+                                position = position,
+                                users = userByPosition[position]?.map { user -> AdminSessionEligibleUserResponse(user) }
+                                    ?: emptyList()
+                            )
+                        }
+                    }
+            )
+    }
+}
+
+data class AdminSessionEligibleUsersGroupedByPositionResponse(
+    val position: Position,
+    val users: List<AdminSessionEligibleUserResponse>
+)
+
+data class AdminSessionEligibleUserResponse(
+    val userId: UUID,
+    val name: String
+) {
+
+    constructor(user: UserWithActivityUnit) : this(
+        userId = user.userId,
+        name = user.name
+    )
+}

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminAttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminAttendanceApi.kt
@@ -156,6 +156,7 @@ interface AdminAttendanceApi {
                     Content(
                         examples = [
                             ExampleObject(
+                                name = "출석 상태 변경 실패",
                                 value = """
                                     {
                                         "isSuccess": false,
@@ -188,6 +189,7 @@ interface AdminAttendanceApi {
                     Content(
                         examples = [
                             ExampleObject(
+                                name = "출석 상태 변경 실패",
                                 value = """
                                     {
                                         "isSuccess": false,
@@ -202,6 +204,7 @@ interface AdminAttendanceApi {
             )
         ]
     )
+    @PutMapping("/admin/v1/session-attendances")
     fun updateSessionAttendances(
         @RequestBody request: AdminSessionAttendanceUpdateRequest
     ): ResponseEntity<Unit>

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminScheduleApi.kt
@@ -5,9 +5,11 @@ import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.schedule.client.dto.request.AdminSessionCreateRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionDeleteRequest
+import co.yappuworld.schedule.client.dto.request.AdminSessionEligibleUsersParamRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionPageRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
+import co.yappuworld.schedule.client.dto.response.AdminSessionEligibleUsersResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -28,7 +30,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import java.util.UUID
 
 @Tag(name = "어드민 일정 API", description = "일정 및 출석 관리")
-interface ScheduleAdminApi {
+interface AdminScheduleApi {
 
     @Operation(summary = "세션 생성")
     @ApiResponses(
@@ -330,4 +332,82 @@ interface ScheduleAdminApi {
     fun updateSession(
         @RequestBody request: AdminSessionUpdateRequest
     ): ResponseEntity<Unit>
+
+    @Operation(summary = "세션 참석 가능한 유저 목록 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                content = [
+                    Content(
+                        schema = Schema(implementation = AdminSessionEligibleUsersResponse::class),
+                        examples = [
+                            ExampleObject(
+                                value = """
+                                    {
+                                        "data": {
+                                            "users": [
+                                                {
+                                                    "position": "PM",
+                                                    "users": [
+                                                        {
+                                                            "userId": "01971fa9-f620-7579-a0bf-eb79e3ffd31a",
+                                                            "name": "홍길동"
+                                                        },
+                                                        {
+                                                            "userId": "01971faa-2675-9a41-e1e1-ecf1f81504ca",
+                                                            "name": "임꺽정"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "position": "DESIGN",
+                                                    "users": []
+                                                },
+                                                {
+                                                    "position": "WEB",
+                                                    "users": [
+                                                        {
+                                                            "userId": "01971faa-6929-0843-8f00-91c31b7c6650",
+                                                            "name": "진달래"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "position": "ANDROID",
+                                                    "users": []
+                                                },
+                                                {
+                                                    "position": "IOS",
+                                                    "users": []
+                                                },
+                                                {
+                                                    "position": "FLUTTER",
+                                                    "users": []
+                                                },
+                                                {
+                                                    "position": "SERVER",
+                                                    "users": [
+                                                        {
+                                                            "userId": "01971faa-a1c3-7a64-2dd9-0aad37df97c7",
+                                                            "name": "장미"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/admin/v1/session-eligible-users")
+    fun getSessionEligibleUsers(
+        @Valid @ParameterObject request: AdminSessionEligibleUsersParamRequest
+    ): ResponseEntity<SuccessResponse<AdminSessionEligibleUsersResponse>>
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminScheduleController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminScheduleController.kt
@@ -2,12 +2,14 @@ package co.yappuworld.schedule.client.presentation
 
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
-import co.yappuworld.schedule.client.application.ScheduleAdminService
+import co.yappuworld.schedule.client.application.AdminScheduleService
 import co.yappuworld.schedule.client.dto.request.AdminSessionCreateRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionDeleteRequest
+import co.yappuworld.schedule.client.dto.request.AdminSessionEligibleUsersParamRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionPageRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
 import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
+import co.yappuworld.schedule.client.dto.response.AdminSessionEligibleUsersResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -15,12 +17,12 @@ import java.net.URI
 import java.util.UUID
 
 @RestController
-class ScheduleAdminController(
-    private val scheduleAdminService: ScheduleAdminService
-) : ScheduleAdminApi {
+class AdminScheduleController(
+    private val adminScheduleService: AdminScheduleService
+) : AdminScheduleApi {
 
     override fun createSession(request: AdminSessionCreateRequest): ResponseEntity<Unit> {
-        val scheduleId = scheduleAdminService.createSchedule(request)
+        val scheduleId = adminScheduleService.createSchedule(request)
         return ResponseEntity.created(URI.create("/v1/admin/schedules/$scheduleId")).build()
     }
 
@@ -28,21 +30,28 @@ class ScheduleAdminController(
         request: AdminSessionPageRequest
     ): ResponseEntity<SuccessResponse<OffsetPageResponse<AdminSessionOverviewResponse>>> =
         ResponseEntity.ok(
-            SuccessResponse(scheduleAdminService.getSessions(request))
+            SuccessResponse(adminScheduleService.getSessions(request))
         )
 
     override fun getSession(sessionId: UUID): ResponseEntity<SuccessResponse<AdminSessionDetailResponse>> =
-        scheduleAdminService
+        adminScheduleService
             .getSession(sessionId)
             .let { ResponseEntity.ok(SuccessResponse(it)) }
 
     override fun deleteSessions(request: AdminSessionDeleteRequest): ResponseEntity<Unit> {
-        scheduleAdminService.deleteSessions(request)
+        adminScheduleService.deleteSessions(request)
         return ResponseEntity.noContent().build()
     }
 
     override fun updateSession(request: AdminSessionUpdateRequest): ResponseEntity<Unit> {
-        scheduleAdminService.updateSession(request)
+        adminScheduleService.updateSession(request)
         return ResponseEntity.noContent().build()
     }
+
+    override fun getSessionEligibleUsers(
+        request: AdminSessionEligibleUsersParamRequest
+    ): ResponseEntity<SuccessResponse<AdminSessionEligibleUsersResponse>> =
+        ResponseEntity.ok(
+            SuccessResponse(adminScheduleService.getSessionEligibleUsers(request))
+        )
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
@@ -158,9 +158,45 @@ interface ScheduleAdminApi {
                                             "generation": 25,
                                             "place": null,
                                             "date": "2024-11-01",
-                                            "time": null,
-                                            "endTime": null,
-                                            "sessionType": "TEAM"
+                                            "time": "17:00:00",
+                                            "endTime": "20:00:00",
+                                            "sessionType": "TEAM",
+                                            "attendees": [
+                                                 {
+                                                     "position": "PM",
+                                                     "attendees": [
+                                                        {
+                                                            "userId": "f70dd5ff-ffe4-11ef-ad31-0242ac120002",
+                                                            "name": "홍길동",
+                                                            "position": "PM"
+                                                        }
+                                                     ]
+                                                 },
+                                                 {
+                                                     "position": "DESIGN",
+                                                     "attendees": []
+                                                 },
+                                                 {
+                                                     "position": "WEB",
+                                                     "attendees": []
+                                                 },
+                                                 {
+                                                     "position": "ANDROID",
+                                                     "attendees": []
+                                                 },
+                                                 {
+                                                     "position": "IOS",
+                                                     "attendees": []
+                                                 },
+                                                 {
+                                                     "position": "FLUTTER",
+                                                     "attendees": []
+                                                 },
+                                                 {
+                                                     "position": "SERVER",
+                                                     "attendees": []
+                                                 }
+                                            ]
                                         },
                                         "isSuccess": true
                                     }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
@@ -237,7 +237,7 @@ interface ScheduleAdminApi {
         ]
     )
     @DeleteMapping("/admin/v1/sessions")
-    fun deleteSession(
+    fun deleteSessions(
         @Valid @RequestBody request: AdminSessionDeleteRequest
     ): ResponseEntity<Unit>
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminApi.kt
@@ -60,7 +60,7 @@ interface ScheduleAdminApi {
         ]
     )
     @PostMapping("/admin/v1/sessions")
-    fun createSchedule(
+    fun createSession(
         @Valid @RequestBody request: AdminSessionCreateRequest
     ): ResponseEntity<Unit>
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminController.kt
@@ -36,8 +36,8 @@ class ScheduleAdminController(
             .getSession(sessionId)
             .let { ResponseEntity.ok(SuccessResponse(it)) }
 
-    override fun deleteSession(request: AdminSessionDeleteRequest): ResponseEntity<Unit> {
-        scheduleAdminService.deleteSession(request)
+    override fun deleteSessions(request: AdminSessionDeleteRequest): ResponseEntity<Unit> {
+        scheduleAdminService.deleteSessions(request)
         return ResponseEntity.noContent().build()
     }
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleAdminController.kt
@@ -19,7 +19,7 @@ class ScheduleAdminController(
     private val scheduleAdminService: ScheduleAdminService
 ) : ScheduleAdminApi {
 
-    override fun createSchedule(request: AdminSessionCreateRequest): ResponseEntity<Unit> {
+    override fun createSession(request: AdminSessionCreateRequest): ResponseEntity<Unit> {
         val scheduleId = scheduleAdminService.createSchedule(request)
         return ResponseEntity.created(URI.create("/v1/admin/schedules/$scheduleId")).build()
     }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -4,7 +4,7 @@ import co.yappuworld.global.response.ErrorResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
-import co.yappuworld.schedule.client.dto.request.SessionQueryParamRequest
+import co.yappuworld.schedule.client.dto.request.SessionParamRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.SessionOverviewResponse
@@ -239,7 +239,7 @@ interface ScheduleApi {
     @GetMapping("/v2/sessions")
     fun getSessions(
         @AuthenticationPrincipal securityUser: SecurityUser,
-        @Valid @ParameterObject request: SessionQueryParamRequest
+        @Valid @ParameterObject request: SessionParamRequest
     ): ResponseEntity<SuccessResponse<SessionOverviewResponse>>
 
     @Operation(summary = "임박한 세션의 출석 정보")

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleController.kt
@@ -5,7 +5,7 @@ import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.global.util.DatetimeUtils.getCurrentDateTimeInKST
 import co.yappuworld.schedule.client.application.ScheduleService
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
-import co.yappuworld.schedule.client.dto.request.SessionQueryParamRequest
+import co.yappuworld.schedule.client.dto.request.SessionParamRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.SessionOverviewResponse
@@ -46,7 +46,7 @@ class ScheduleController(
 
     override fun getSessions(
         @AuthenticationPrincipal securityUser: SecurityUser,
-        @Valid @ParameterObject request: SessionQueryParamRequest
+        @Valid @ParameterObject request: SessionParamRequest
     ): ResponseEntity<SuccessResponse<SessionOverviewResponse>> =
         ResponseEntity.ok(
             SuccessResponse(

--- a/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
@@ -3,6 +3,8 @@ package co.yappuworld.schedule.domain
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.PENDING
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.LatePassEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
@@ -24,22 +26,21 @@ class AttendanceBook(
     // userId to sessionId to AttendanceStatus
     private val byUser: Map<UUID, Map<UUID, AttendanceStatus?>>
 
-    val finishedSessionCount = sessions.count { it.isFinished(now) }
+    private val sessionById: Map<UUID, SessionEntity> = sessions.associateBy { it.id }
 
     init {
         require(sessions.all { it.generation == generation })
 
         // (userId to sessionId) to AttendanceStatus
-        val attendanceMatrix = attendances.associate { (it.userId to it.scheduleId) to it.status }
+        val attendanceMatrix = attendances.associateBy { (it.userId to it.scheduleId) }
 
         fun decideStatus(
             user: Attendee,
             session: SessionEntity
-        ): AttendanceStatus? =
-            when (session.isFinished(now)) {
-                true -> attendanceMatrix[user.id to session.id] ?: AttendanceStatus.ABSENT
-                false -> attendanceMatrix[user.id to session.id]
-            }
+        ): AttendanceStatus? {
+            val status = attendanceMatrix[user.id to session.id]?.status ?: return null
+            return if (status == PENDING && session.isFinished(now)) ABSENT else status
+        }
 
         this.bySession = sessions.associate { session ->
             session.id to attendees.associate { user ->
@@ -49,7 +50,7 @@ class AttendanceBook(
 
         this.byUser = attendees.associate { user ->
             user.id to sessions.associate { session ->
-                session.id to decideStatus(user, session)
+                session.id to bySession[session.id]?.get(user.id)
             }
         }
     }
@@ -85,14 +86,13 @@ class AttendanceBook(
         return sessionAttendances[userId]
     }
 
-    fun getUserAttendanceStatistics(userId: UUID): UserAttendanceStatistics {
-        val userAttendances = byUser[userId] ?: throw BusinessException(AttendanceError.USER_NOT_FOUND)
-        return UserAttendanceStatistics.from(
-            userAttendances.map { it.value },
-            finishedSessionCount,
-            latePassCountByUserId[userId] ?: 0
+    fun getUserAttendanceStatistics(userId: UUID): UserAttendanceStatistics =
+        UserAttendanceStatistics.from(
+            attendanceBySessionId = byUser[userId] ?: throw BusinessException(AttendanceError.USER_NOT_FOUND),
+            sessionById = sessionById,
+            latePassCount = latePassCountByUserId[userId] ?: 0,
+            now = now
         )
-    }
 
     fun getSessionAttendanceStatistics(sessionId: UUID): SessionAttendanceStatistics {
         val sessionAttendances = bySession[sessionId] ?: throw BusinessException(AttendanceError.SESSION_NOT_FOUND)

--- a/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendanceStatistics.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendanceStatistics.kt
@@ -12,14 +12,36 @@ data class SessionAttendanceStatistics(
 ) {
 
     companion object {
-        fun from(statuses: List<AttendanceStatus?>): SessionAttendanceStatistics =
-            SessionAttendanceStatistics(
-                totalPersonCount = statuses.size,
-                totalOnTimeCount = statuses.count { it == AttendanceStatus.ON_TIME },
-                totalLateCount = statuses.count { it == AttendanceStatus.LATE },
-                totalAbsentCount = statuses.count { it == AttendanceStatus.ABSENT },
-                totalEarlyCheckOutCount = statuses.count { it == AttendanceStatus.EARLY_CHECK_OUT },
-                totalExcusedAbsenceCount = statuses.count { it == AttendanceStatus.EXCUSED_ABSENCE }
+        fun from(statuses: List<AttendanceStatus?>): SessionAttendanceStatistics {
+            var totalPersonCount = 0
+            var totalOnTimeCount = 0
+            var totalLateCount = 0
+            var totalAbsentCount = 0
+            var totalEarlyCheckOutCount = 0
+            var totalExcusedAbsenceCount = 0
+
+            statuses.forEach { status ->
+                when (status) {
+                    AttendanceStatus.ON_TIME -> totalOnTimeCount++
+                    AttendanceStatus.LATE -> totalLateCount++
+                    AttendanceStatus.ABSENT -> totalAbsentCount++
+                    AttendanceStatus.EARLY_CHECK_OUT -> totalEarlyCheckOutCount++
+                    AttendanceStatus.EXCUSED_ABSENCE -> totalExcusedAbsenceCount++
+                    else -> Unit
+                }
+
+                if (status != null) totalPersonCount++
+            }
+
+            return SessionAttendanceStatistics(
+                totalPersonCount = totalPersonCount,
+                totalOnTimeCount = totalOnTimeCount,
+                totalLateCount = totalLateCount,
+                totalAbsentCount = totalAbsentCount,
+                totalEarlyCheckOutCount = totalEarlyCheckOutCount,
+                totalExcusedAbsenceCount = totalExcusedAbsenceCount
             )
+        }
+
     }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/domain/UserAttendanceStatistics.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/UserAttendanceStatistics.kt
@@ -5,6 +5,9 @@ import co.yappuworld.schedule.domain.AttendancePolicy.ATTENDANCE_DEFAULT_POINT
 import co.yappuworld.schedule.domain.AttendancePolicy.LATE_PASS_BONUS
 import co.yappuworld.schedule.domain.AttendancePolicy.LATE_PENALTY
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import java.time.LocalDateTime
+import java.util.UUID
 import kotlin.math.min
 
 data class UserAttendanceStatistics(
@@ -22,32 +25,96 @@ data class UserAttendanceStatistics(
 ) {
 
     companion object {
-        fun from(
-            attendances: List<AttendanceStatus?>,
-            finishedSessionCount: Int,
-            latePassCount: Int
-        ): UserAttendanceStatistics {
-            val totalSessionCount = attendances.size
-            val leftSessionCount = totalSessionCount - finishedSessionCount
-            val onTimeCount = attendances.count { it == AttendanceStatus.ON_TIME }
-            val lateCount = attendances.count { it == AttendanceStatus.LATE }
-            val absentCount = attendances.count { it == AttendanceStatus.ABSENT }
-            val earlyCheckOutCount = attendances.count { it == AttendanceStatus.EARLY_CHECK_OUT }
-            val excusedAbsenceCount = attendances.count { it == AttendanceStatus.EXCUSED_ABSENCE }
 
-            val penaltyPoint = (lateCount * LATE_PENALTY) + (absentCount * ABSENT_PENALTY)
-            val bonusPoint = latePassCount * LATE_PASS_BONUS
-            val totalPoint = min(ATTENDANCE_DEFAULT_POINT - penaltyPoint + bonusPoint, ATTENDANCE_DEFAULT_POINT)
+        fun from(
+            attendanceBySessionId: Map<UUID, AttendanceStatus?>,
+            sessionById: Map<UUID, SessionEntity>,
+            latePassCount: Int,
+            now: LocalDateTime
+        ): UserAttendanceStatistics {
+            val attendances = attendanceBySessionId.values.toList()
+
+            val totalSessionCount = attendances.count { it != null }
+            val finishedSessionCount = attendanceBySessionId.count {
+                it.value != null && sessionById[it.key]?.isFinished(now) == true
+            }
+
+            val attendanceCountStatistics = AttendanceCountStatistics.from(attendances)
+            val attendancePointStatistics = AttendancePointStatistics.from(attendanceCountStatistics, latePassCount)
 
             return UserAttendanceStatistics(
                 totalSessionCount = totalSessionCount,
-                leftSessionCount = leftSessionCount,
+                leftSessionCount = totalSessionCount - finishedSessionCount,
+                onTimeCount = attendanceCountStatistics.onTimeCount,
+                lateCount = attendanceCountStatistics.lateCount,
+                absentCount = attendanceCountStatistics.absentCount,
+                earlyCheckOutCount = attendanceCountStatistics.earlyCheckOutCount,
+                excusedAbsenceCount = attendanceCountStatistics.excusedAbsenceCount,
+                latePassCount = latePassCount,
+                totalPoint = attendancePointStatistics.totalPoint,
+                penaltyPoint = attendancePointStatistics.penaltyPoint,
+                bonusPoint = attendancePointStatistics.bonusPoint
+            )
+        }
+    }
+}
+
+data class AttendanceCountStatistics(
+    val onTimeCount: Int,
+    val lateCount: Int,
+    val absentCount: Int,
+    val earlyCheckOutCount: Int,
+    val excusedAbsenceCount: Int
+) {
+
+    companion object {
+        fun from(attendances: List<AttendanceStatus?>): AttendanceCountStatistics {
+            var onTimeCount = 0
+            var lateCount = 0
+            var absentCount = 0
+            var earlyCheckOutCount = 0
+            var excusedAbsenceCount = 0
+
+            attendances.forEach {
+                when (it) {
+                    AttendanceStatus.ON_TIME -> onTimeCount++
+                    AttendanceStatus.LATE -> lateCount++
+                    AttendanceStatus.ABSENT -> absentCount++
+                    AttendanceStatus.EARLY_CHECK_OUT -> earlyCheckOutCount++
+                    AttendanceStatus.EXCUSED_ABSENCE -> excusedAbsenceCount++
+                    else -> Unit
+                }
+            }
+
+            return AttendanceCountStatistics(
                 onTimeCount = onTimeCount,
                 lateCount = lateCount,
                 absentCount = absentCount,
                 earlyCheckOutCount = earlyCheckOutCount,
-                excusedAbsenceCount = excusedAbsenceCount,
-                latePassCount = latePassCount,
+                excusedAbsenceCount = excusedAbsenceCount
+            )
+        }
+    }
+}
+
+data class AttendancePointStatistics(
+    val totalPoint: Int,
+    val penaltyPoint: Int,
+    val bonusPoint: Int
+) {
+
+    companion object {
+        fun from(
+            attendanceCountStatistics: AttendanceCountStatistics,
+            latePassCount: Int
+        ): AttendancePointStatistics {
+            val penaltyPoint =
+                (attendanceCountStatistics.lateCount * LATE_PENALTY) +
+                    (attendanceCountStatistics.absentCount * ABSENT_PENALTY)
+            val bonusPoint = latePassCount * LATE_PASS_BONUS
+            val totalPoint = min(ATTENDANCE_DEFAULT_POINT - penaltyPoint + bonusPoint, ATTENDANCE_DEFAULT_POINT)
+
+            return AttendancePointStatistics(
                 totalPoint = totalPoint,
                 penaltyPoint = penaltyPoint,
                 bonusPoint = bonusPoint

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceStatus.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceStatus.kt
@@ -8,12 +8,14 @@ import co.yappuworld.user.domain.model.UserWithActivityUnits
 import java.time.LocalDateTime
 
 /**
+ * @property PENDING 유저의 출석 액션이 이뤄지지 않은 상태 - 유저에게는 결석으로 노출될 수 있음
  * @property ON_TIME 제 시간에 정상적으로 출석
  * @property EXCUSED_ABSENCE 출석으로 인정되는 결석
  */
 enum class AttendanceStatus(
     val label: String
 ) {
+    PENDING("미출석"),
     ON_TIME("출석"),
     LATE("지각"),
     ABSENT("결석"),

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandService.kt
@@ -4,6 +4,7 @@ import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Service
 @Transactional
@@ -18,5 +19,18 @@ class AttendanceCommandService(
     fun saveAll(attendances: List<AttendanceEntity>) {
         require(attendances.isNotEmpty()) { "저장을 위한 출석 데이터는 적어도 하나 이상이어야 합니다." }
         attendanceRepository.saveAll(attendances)
+    }
+
+    fun deleteAll(attendances: List<AttendanceEntity>) {
+        require(attendances.isNotEmpty()) { "삭제를 위한 출석 데이터는 적어도 하나 이상이어야 합니다." }
+        attendanceRepository.deleteAll(attendances)
+    }
+
+    fun deleteAllInSessions(sessionIds: List<UUID>) {
+        require(sessionIds.isNotEmpty()) { "삭제를 위한 세션 ID는 적어도 하나 이상이어야 합니다." }
+        attendanceRepository.delete {
+            deleteFrom(entity(AttendanceEntity::class))
+                .where(path(AttendanceEntity::scheduleId).`in`(sessionIds))
+        }
     }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
@@ -103,7 +103,7 @@ class AttendanceFindService(
                             and(
                                 path(ActivityUnitEntity::userId).equal(path(AttendanceEntity::userId)),
                                 path(ActivityUnitEntity::generation).equal(path(SessionEntity::generation)),
-                                path(ActivityUnitEntity::position).`in`(Position.attendeePositions)
+                                path(ActivityUnitEntity::position).notEqual(Position.STAFF)
                             )
                         ),
                     join(entity(UserEntity::class))

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
@@ -1,7 +1,11 @@
 package co.yappuworld.schedule.infrastructure
 
+import co.yappuworld.schedule.infrastructure.dto.SessionAttendeeDto
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
+import co.yappuworld.user.infrastructure.entity.UserEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -74,5 +78,36 @@ class AttendanceFindService(
                 select(entity(AttendanceEntity::class))
                     .from(entity(AttendanceEntity::class))
                     .where(path(AttendanceEntity::scheduleId).equal(sessionId))
+            }.filterNotNull()
+
+    fun findAttendees(sessionId: UUID): List<SessionAttendeeDto> =
+        attendanceRepository
+            .findAll {
+                selectNew<SessionAttendeeDto>(
+                    path(AttendanceEntity::scheduleId),
+                    path(AttendanceEntity::userId),
+                    path(SessionEntity::generation),
+                    path(ActivityUnitEntity::position),
+                    path(UserEntity::name)
+                ).from(
+                    entity(AttendanceEntity::class),
+                    join(entity(SessionEntity::class))
+                        .on(
+                            and(
+                                path(SessionEntity::getId).equal(sessionId),
+                                path(SessionEntity::getId).equal(path(AttendanceEntity::scheduleId))
+                            )
+                        ),
+                    join(entity(ActivityUnitEntity::class))
+                        .on(
+                            and(
+                                path(ActivityUnitEntity::userId).equal(path(AttendanceEntity::userId)),
+                                path(ActivityUnitEntity::generation).equal(path(SessionEntity::generation)),
+                                path(ActivityUnitEntity::position).`in`(Position.attendeePositions)
+                            )
+                        ),
+                    join(entity(UserEntity::class))
+                        .on(path(UserEntity::getId).equal(path(AttendanceEntity::userId)))
+                )
             }.filterNotNull()
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
@@ -51,8 +51,8 @@ class AttendanceFindService(
                         join(entity(SessionEntity::class))
                             .on(
                                 and(
-                                    path(SessionEntity::generation).equal(generation),
-                                    path(SessionEntity::getId).equal(path(AttendanceEntity::scheduleId))
+                                    path(SessionEntity::getId).equal(path(AttendanceEntity::scheduleId)),
+                                    path(SessionEntity::generation).equal(generation)
                                 )
                             )
                     )

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionAttendeeDto.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionAttendeeDto.kt
@@ -1,0 +1,12 @@
+package co.yappuworld.schedule.infrastructure.dto
+
+import co.yappuworld.user.domain.vo.Position
+import java.util.UUID
+
+data class SessionAttendeeDto(
+    val sessionId: UUID,
+    val userId: UUID,
+    val generation: Int,
+    val position: Position,
+    val name: String
+)

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 @Entity
 @Table(name = "attendances")
 class AttendanceEntity(
-    status: AttendanceStatus,
+    status: AttendanceStatus = AttendanceStatus.PENDING,
     @Column(name = "user_id", nullable = false)
     val userId: UUID,
     @Column(name = "schedule_id", nullable = false)

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
@@ -14,11 +14,11 @@ import java.util.UUID
 @Entity
 @Table(name = "attendances")
 class AttendanceEntity(
-    status: AttendanceStatus = AttendanceStatus.PENDING,
     @Column(name = "user_id", nullable = false)
     val userId: UUID,
     @Column(name = "schedule_id", nullable = false)
-    val scheduleId: UUID
+    val scheduleId: UUID,
+    status: AttendanceStatus = AttendanceStatus.PENDING
 ) : BaseEntity() {
 
     companion object {

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
@@ -1,18 +1,31 @@
 package co.yappuworld.user.domain.vo
 
 enum class Position(
-    val label: String
+    val label: String,
+    val order: Int
 ) {
-    PM("PM"),
-    DESIGN("Design"),
-    WEB("Web"),
-    ANDROID("Android"),
-    IOS("iOS"),
-    FLUTTER("Flutter"),
-    SERVER("Server"),
-    STAFF("운영진");
+    PM("PM", 0),
+    DESIGN("Design", 1),
+    WEB("Web", 2),
+    ANDROID("Android", 3),
+    IOS("iOS", 4),
+    FLUTTER("Flutter", 5),
+    SERVER("Server", 6),
+    STAFF("운영진", 7);
 
     fun isStaff(): Boolean = this == STAFF
 
     fun isAttendeePosition(): Boolean = this != STAFF
+
+    companion object {
+        val attendeePositions = listOf(
+            PM,
+            DESIGN,
+            WEB,
+            ANDROID,
+            IOS,
+            FLUTTER,
+            SERVER
+        )
+    }
 }

--- a/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
+++ b/src/main/kotlin/co/yappuworld/user/domain/vo/Position.kt
@@ -18,7 +18,7 @@ enum class Position(
     fun isAttendeePosition(): Boolean = this != STAFF
 
     companion object {
-        val attendeePositions = listOf(
+        val activeUserPositions = listOf(
             PM,
             DESIGN,
             WEB,

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/CustomUserDsl.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/CustomUserDsl.kt
@@ -1,0 +1,52 @@
+package co.yappuworld.user.infrastructure
+
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
+import co.yappuworld.user.infrastructure.entity.UserEntity
+import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
+import com.linecorp.kotlinjdsl.dsl.jpql.JpqlDsl
+import com.linecorp.kotlinjdsl.dsl.jpql.select.SelectQueryGroupByStep
+import com.linecorp.kotlinjdsl.dsl.jpql.select.SelectQueryWhereStep
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class CustomUserDsl : Jpql() {
+    companion object Constructor : JpqlDsl.Constructor<CustomUserDsl> {
+        override fun newInstance(): CustomUserDsl = CustomUserDsl()
+    }
+
+    fun selectFromUserWithActivityUnit(): SelectQueryWhereStep<UserWithActivityUnit> =
+        selectNew<UserWithActivityUnit>(
+            path(UserEntity::getId),
+            path(UserEntity::email),
+            path(UserEntity::name),
+            path(UserEntity::role),
+            path(ActivityUnitEntity::getId),
+            path(ActivityUnitEntity::generation),
+            path(ActivityUnitEntity::position)
+        ).from(
+            entity(ActivityUnitEntity::class),
+            innerJoin(entity(UserEntity::class))
+                .on(path(ActivityUnitEntity::userId).equal(path(UserEntity::getId)))
+        )
+
+    fun getActiveUser(generation: Int): SelectQueryGroupByStep<UserWithActivityUnit> =
+        selectFromUserWithActivityUnit()
+            .whereAnd(
+                path(ActivityUnitEntity::generation).equal(generation),
+                path(ActivityUnitEntity::position).notEqual(Position.STAFF)
+            )
+
+    fun getActiveUser(
+        userId: UUID,
+        generation: Int
+    ): SelectQueryGroupByStep<UserWithActivityUnit> =
+        selectFromUserWithActivityUnit()
+            .whereAnd(
+                path(UserEntity::getId).equal(userId),
+                path(ActivityUnitEntity::generation).equal(generation),
+                path(ActivityUnitEntity::position).notEqual(Position.STAFF)
+            )
+}

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
@@ -3,7 +3,6 @@ package co.yappuworld.user.infrastructure
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.user.domain.model.UserWithActivityUnits
-import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
 import co.yappuworld.user.infrastructure.entity.UserEntity
@@ -97,24 +96,9 @@ class UserFindService(
 
     fun findUserWithActivities(userId: UUID): UserWithActivityUnits {
         val result = userRepository
-            .findAll {
-                selectNew<UserWithActivityUnit>(
-                    path(UserEntity::getId),
-                    path(UserEntity::email),
-                    path(UserEntity::name),
-                    path(UserEntity::role),
-                    path(ActivityUnitEntity::generation),
-                    path(ActivityUnitEntity::position)
-                ).from(
-                    entity(UserEntity::class),
-                    innerJoin(ActivityUnitEntity::class)
-                        .on(
-                            and(
-                                path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)),
-                                path(UserEntity::getId).equal(userId)
-                            )
-                        )
-                )
+            .findAll(CustomUserDsl) {
+                selectFromUserWithActivityUnit()
+                    .where(path(UserEntity::getId).equal(userId))
             }.filterNotNull()
 
         if (result.isNotEmpty()) {
@@ -127,78 +111,21 @@ class UserFindService(
         }
     }
 
-    fun findUsersActiveOfGeneration(generation: Int): List<UserWithActivityUnit> =
+    fun findActiveUsersOfGeneration(generation: Int): List<UserWithActivityUnit> =
         userRepository
-            .findAll {
-                selectNew<UserWithActivityUnit>(
-                    path(UserEntity::getId),
-                    path(UserEntity::email),
-                    path(UserEntity::name),
-                    path(UserEntity::role),
-                    path(ActivityUnitEntity::generation),
-                    path(ActivityUnitEntity::position)
-                ).from(
-                    entity(ActivityUnitEntity::class),
-                    innerJoin(entity(UserEntity::class))
-                        .on(
-                            and(
-                                path(ActivityUnitEntity::userId).equal(path(UserEntity::getId)),
-                                path(ActivityUnitEntity::generation).equal(generation)
-                            )
-                        )
-                )
-            }.filterNotNull()
+            .findAll(CustomUserDsl) { getActiveUser(generation) }
+            .filterNotNull()
 
     fun findSessionAttendeesOfGeneration(generation: Int): List<Attendee> =
-        userRepository
-            .findAll {
-                selectNew<UserWithActivityUnit>(
-                    path(UserEntity::getId),
-                    path(UserEntity::email),
-                    path(UserEntity::name),
-                    path(UserEntity::role),
-                    path(ActivityUnitEntity::generation),
-                    path(ActivityUnitEntity::position)
-                ).from(
-                    entity(UserEntity::class),
-                    innerJoin(entity(ActivityUnitEntity::class))
-                        .on(
-                            and(
-                                path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)),
-                                path(ActivityUnitEntity::generation).equal(generation),
-                                path(ActivityUnitEntity::position).notEqual(Position.STAFF)
-                            )
-                        )
-                )
-            }.filterNotNull()
-            .map { Attendee.from(it, generation) }
+        findActiveUsersOfGeneration(generation).map { Attendee.from(it, generation) }
 
     fun findSessionAttendee(
         userId: UUID,
         generation: Int
     ): Attendee {
         val result = userRepository
-            .findAll {
-                selectNew<UserWithActivityUnit>(
-                    path(UserEntity::getId),
-                    path(UserEntity::email),
-                    path(UserEntity::name),
-                    path(UserEntity::role),
-                    path(ActivityUnitEntity::generation),
-                    path(ActivityUnitEntity::position)
-                ).from(
-                    entity(UserEntity::class),
-                    innerJoin(entity(ActivityUnitEntity::class))
-                        .on(
-                            and(
-                                path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)),
-                                path(UserEntity::getId).equal(userId),
-                                path(ActivityUnitEntity::generation).equal(generation),
-                                path(ActivityUnitEntity::position).notEqual(Position.STAFF)
-                            )
-                        )
-                )
-            }.filterNotNull()
+            .findAll(CustomUserDsl) { getActiveUser(userId, generation) }
+            .filterNotNull()
 
         if (result.size > 1) {
             throw BusinessException(UserError.DUPLICATE_ATTENDEE_ACTIVITY)
@@ -216,26 +143,8 @@ class UserFindService(
         generation: Int
     ): UserWithActivityUnit =
         userRepository
-            .findAll {
-                selectNew<UserWithActivityUnit>(
-                    path(UserEntity::getId),
-                    path(UserEntity::email),
-                    path(UserEntity::name),
-                    path(UserEntity::role),
-                    path(ActivityUnitEntity::generation),
-                    path(ActivityUnitEntity::position)
-                ).from(
-                    entity(UserEntity::class),
-                    innerJoin(entity(ActivityUnitEntity::class))
-                        .on(
-                            and(
-                                path(UserEntity::getId).equal(path(ActivityUnitEntity::userId)),
-                                path(UserEntity::getId).equal(userId),
-                                path(ActivityUnitEntity::generation).equal(generation)
-                            )
-                        )
-                )
-            }.singleOrNull()
+            .findAll(CustomUserDsl) { getActiveUser(userId, generation) }
+            .singleOrNull()
             ?: throw BusinessException(UserError.USER_NOT_FOUND_WITH_GENERATION_ACTIVITY)
 
     private fun Jpql.getUserWithLastActivityUnit(

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/model/UserWithActivityUnit.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/model/UserWithActivityUnit.kt
@@ -10,6 +10,7 @@ data class UserWithActivityUnit(
     val email: String,
     val name: String,
     val role: UserRole,
+    val activityUnitId: UUID,
     val generation: Int,
     val position: Position
 ) {

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -24,8 +24,8 @@ spring:
     sql:
         init:
             schema-locations: classpath:schema.sql
-            data-locations: classpath:data.sql
-            mode: always
+#            data-locations: classpath:data.sql
+#            mode: always
 
     jpa:
         open-in-view: false

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -24,8 +24,8 @@ spring:
     sql:
         init:
             schema-locations: classpath:schema.sql
-#            data-locations: classpath:data.sql
-#            mode: always
+            data-locations: classpath:data.sql
+            mode: always
 
     jpa:
         open-in-view: false

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceServiceTest.kt
@@ -13,9 +13,8 @@ import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixtu
 import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.UserCommandService
 import co.yappuworld.user.infrastructure.entity.UserEntity
-import io.kotest.inspectors.shouldForAll
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 
 class AdminAttendanceServiceTest @Autowired constructor(
@@ -40,7 +39,7 @@ class AdminAttendanceServiceTest @Autowired constructor(
                 session = scheduleRepository.save(getSessionEntityFixture(generation = activeGeneration))
             }
 
-            scenario("출석 데이터가 아무것도 없다면, 모두 새로 생성한다.") {
+            scenario("출석 데이터가 아무것도 없다면 변경 사항이 존재하지 않는다.") {
                 adminAttendanceService.updateSessionAttendances(
                     AdminSessionAttendanceUpdateRequest(
                         sessionId = session.id,
@@ -48,10 +47,10 @@ class AdminAttendanceServiceTest @Autowired constructor(
                     )
                 )
 
-                attendanceRepository.findAllByScheduleId(session.id) shouldHaveSize 2
+                attendanceRepository.findAllByScheduleId(session.id) shouldHaveSize 0
             }
 
-            scenario("출석 데이터 중 일부 유저의 데이터가 없다면 새로 생성한다.") {
+            scenario("출석 데이터 중 일부 유저의 데이터가 없다면, 존재하는 출석 데이터만 변경된다.") {
                 val attendance = getAttendanceEntityFixture(
                     status = ABSENT,
                     scheduleId = session.id,
@@ -67,28 +66,8 @@ class AdminAttendanceServiceTest @Autowired constructor(
                 )
 
                 val attendances = attendanceRepository.findAllByScheduleId(session.id)
-                attendances shouldHaveSize 2
-                attendances.filterNot { it.userId == users[0].id }.shouldNotBeEmpty()
-            }
-
-            scenario("존재하는 출석 데이터는 상태가 업데이트 된다.") {
-                val attendance = getAttendanceEntityFixture(
-                    status = ABSENT,
-                    scheduleId = session.id,
-                    userId = users[0].id
-                )
-                attendanceRepository.save(attendance)
-
-                adminAttendanceService.updateSessionAttendances(
-                    AdminSessionAttendanceUpdateRequest(
-                        sessionId = session.id,
-                        attendanceStatus = ABSENT
-                    )
-                )
-
-                val attendances = attendanceRepository.findAllByScheduleId(session.id)
-                attendances shouldHaveSize 2
-                attendances.shouldForAll { it.status == ABSENT }
+                attendances shouldHaveSize 1
+                attendances.single().status shouldBe ABSENT
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AdminScheduleServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AdminScheduleServiceTest.kt
@@ -1,0 +1,52 @@
+package co.yappuworld.schedule.client.application
+
+import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
+import co.yappuworld.schedule.infrastructure.AttendanceRepository
+import co.yappuworld.schedule.infrastructure.ScheduleRepository
+import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
+import co.yappuworld.support.environment.SpringBootTestFeatureSpec
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
+
+class AdminScheduleServiceTest @Autowired constructor(
+    private val adminScheduleService: AdminScheduleService,
+    private val scheduleRepository: ScheduleRepository,
+    private val attendanceRepository: AttendanceRepository
+) : SpringBootTestFeatureSpec({
+
+        feature("세션을 수정할 때") {
+
+            scenario("참가자 요청에 따라, attendance의 추가, 삭제가 발생한다.") {
+                val session = scheduleRepository.save(getSessionEntityFixture())
+                val userId1 = UUID.randomUUID()
+                val userId2 = UUID.randomUUID()
+                val userId3 = UUID.randomUUID()
+                attendanceRepository.saveAllAndFlush(
+                    listOf(userId1, userId2).map { AttendanceEntity(it, session.id) }
+                )
+
+                val request = AdminSessionUpdateRequest(
+                    id = session.id,
+                    name = "수정된 세션",
+                    generation = 25,
+                    place = "마루 180",
+                    date = session.date,
+                    endDate = session.endDate,
+                    time = session.time,
+                    endTime = session.endTime,
+                    sessionType = session.sessionType,
+                    sessionAttendeeIds = listOf(userId2, userId3)
+                )
+                adminScheduleService.updateSession(request)
+
+                val result = attendanceRepository.findAll()
+                result.shouldHaveSize(2)
+                listOf(userId2, userId3).forEach { userId ->
+                    result.any { it.userId == userId } shouldBe true
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminServiceTest.kt
@@ -1,0 +1,39 @@
+package co.yappuworld.schedule.client.application
+
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.infrastructure.AttendanceRepository
+import co.yappuworld.support.environment.SpringBootTestFeatureSpec
+import co.yappuworld.support.fixture.ScheduleDtoFixture.getAdminSessionCreateRequestFixture
+import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
+import co.yappuworld.user.infrastructure.jpa.UserRepository
+import io.kotest.inspectors.shouldForAll
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+
+class ScheduleAdminServiceTest @Autowired constructor(
+    private val scheduleAdminService: ScheduleAdminService,
+    private val userRepository: UserRepository,
+    private val attendanceRepository: AttendanceRepository
+) : SpringBootTestFeatureSpec({
+
+        feature("세션 생성") {
+
+            scenario("세션을 생성하면 해당 세션에 참석하는 유저들의 출석 정보가 생성된다") {
+                // given
+                val users = userRepository.saveAll(listOf(getUserEntityFixture(), getUserEntityFixture()))
+                val request = getAdminSessionCreateRequestFixture(attendeeIds = users.map { it.id })
+
+                // when
+                val scheduleId = scheduleAdminService.createSchedule(request)
+
+                val userIds = users.map { user -> user.id }
+                val result = attendanceRepository.findAllByScheduleId(scheduleId)
+                result.shouldHaveSize(2)
+                result.shouldForAll {
+                    it.userId in userIds
+                    it.status shouldBe AttendanceStatus.PENDING
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminServiceTest.kt
@@ -8,9 +8,13 @@ import co.yappuworld.schedule.infrastructure.AttendanceRepository
 import co.yappuworld.schedule.infrastructure.ScheduleRepository
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.support.environment.SpringBootTestFeatureSpec
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.ScheduleDtoFixture.getAdminSessionCreateRequestFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getActivityUnitEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
 import co.yappuworld.user.infrastructure.jpa.UserRepository
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.inspectors.shouldForAll
@@ -22,6 +26,7 @@ import java.util.UUID
 class ScheduleAdminServiceTest @Autowired constructor(
     private val scheduleAdminService: ScheduleAdminService,
     private val userRepository: UserRepository,
+    private val activityUnitRepository: ActivityUnitRepository,
     private val scheduleRepository: ScheduleRepository,
     private val attendanceRepository: AttendanceRepository
 ) : SpringBootTestFeatureSpec({
@@ -63,7 +68,7 @@ class ScheduleAdminServiceTest @Autowired constructor(
                 val sessions = listOf(getSessionEntityFixture(), getSessionEntityFixture())
                     .also { scheduleRepository.saveAll(it) }
                 val users = userRepository.saveAll(listOf(getUserEntityFixture(), getUserEntityFixture()))
-                val attendances = listOf(
+                listOf(
                     AttendanceEntity(userId = users[0].id, scheduleId = sessions[0].id),
                     AttendanceEntity(userId = users[0].id, scheduleId = sessions[1].id),
                     AttendanceEntity(userId = users[1].id, scheduleId = sessions[1].id)
@@ -75,6 +80,43 @@ class ScheduleAdminServiceTest @Autowired constructor(
                 // then
                 attendanceRepository.findAllByScheduleId(sessions[0].id).shouldHaveSize(0)
                 attendanceRepository.findAllByScheduleId(sessions[1].id).shouldHaveSize(0)
+            }
+        }
+
+        feature("세션 상세 조회") {
+
+            scenario("참석자 정보가 포함된다") {
+                val user1 = getUserEntityFixture(name = "김개똥")
+                val user1ActivityUnits = listOf(
+                    getActivityUnitEntityFixture(generation = 25, position = Position.PM, userId = user1.id),
+                    getActivityUnitEntityFixture(generation = 25, position = Position.STAFF, userId = user1.id),
+                    getActivityUnitEntityFixture(generation = 24, position = Position.SERVER, userId = user1.id)
+                )
+                val user2 = getUserEntityFixture(name = "홍길동")
+                val user2ActivityUnits = listOf(
+                    getActivityUnitEntityFixture(generation = 25, position = Position.ANDROID, userId = user2.id)
+                )
+                val session = getSessionEntityFixture()
+                val attendances = listOf(
+                    getAttendanceEntityFixture(userId = user1.id, scheduleId = session.id),
+                    getAttendanceEntityFixture(userId = user2.id, scheduleId = session.id)
+                )
+
+                userRepository.saveAll(listOf(user1, user2))
+                activityUnitRepository.saveAll(user1ActivityUnits.union(user2ActivityUnits))
+                scheduleRepository.save(session)
+                attendanceRepository.saveAllAndFlush(attendances)
+
+                val result = scheduleAdminService.getSession(session.id)
+
+                result.attendees.single { it.position == Position.PM }.let {
+                    it.attendees.shouldHaveSize(1)
+                    it.attendees[0].name shouldBe user1.name
+                }
+                result.attendees.single { it.position == Position.ANDROID }.let {
+                    it.attendees.shouldHaveSize(1)
+                    it.attendees[0].name shouldBe user2.name
+                }
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminServiceTest.kt
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.util.UUID
 
 class ScheduleAdminServiceTest @Autowired constructor(
-    private val scheduleAdminService: ScheduleAdminService,
+    private val adminScheduleService: AdminScheduleService,
     private val userRepository: UserRepository,
     private val activityUnitRepository: ActivityUnitRepository,
     private val scheduleRepository: ScheduleRepository,
@@ -39,7 +39,7 @@ class ScheduleAdminServiceTest @Autowired constructor(
                 val request = getAdminSessionCreateRequestFixture(attendeeIds = users.map { it.id })
 
                 // when
-                val scheduleId = scheduleAdminService.createSchedule(request)
+                val scheduleId = adminScheduleService.createSchedule(request)
 
                 val userIds = users.map { user -> user.id }
                 val result = attendanceRepository.findAllByScheduleId(scheduleId)
@@ -59,7 +59,7 @@ class ScheduleAdminServiceTest @Autowired constructor(
 
                 // when, then
                 shouldThrowExactly<BusinessException> {
-                    scheduleAdminService.deleteSessions(request)
+                    adminScheduleService.deleteSessions(request)
                 }.error shouldBe ScheduleError.CONTAIN_IMPROPER_ID_FOR_DELETE_SESSION
             }
 
@@ -75,7 +75,7 @@ class ScheduleAdminServiceTest @Autowired constructor(
                 ).also { attendanceRepository.saveAll(it) }
 
                 // when
-                scheduleAdminService.deleteSessions(AdminSessionDeleteRequest(ids = sessions.map { it.id }))
+                adminScheduleService.deleteSessions(AdminSessionDeleteRequest(ids = sessions.map { it.id }))
 
                 // then
                 attendanceRepository.findAllByScheduleId(sessions[0].id).shouldHaveSize(0)
@@ -107,7 +107,7 @@ class ScheduleAdminServiceTest @Autowired constructor(
                 scheduleRepository.save(session)
                 attendanceRepository.saveAllAndFlush(attendances)
 
-                val result = scheduleAdminService.getSession(session.id)
+                val result = adminScheduleService.getSession(session.id)
 
                 result.attendees.single { it.position == Position.PM }.let {
                     it.attendees.shouldHaveSize(1)

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/ScheduleAdminServiceTest.kt
@@ -1,19 +1,28 @@
 package co.yappuworld.schedule.client.application
 
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.schedule.client.dto.request.AdminSessionDeleteRequest
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.AttendanceRepository
+import co.yappuworld.schedule.infrastructure.ScheduleRepository
+import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.support.environment.SpringBootTestFeatureSpec
 import co.yappuworld.support.fixture.ScheduleDtoFixture.getAdminSessionCreateRequestFixture
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
 import co.yappuworld.user.infrastructure.jpa.UserRepository
+import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.inspectors.shouldForAll
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
 
 class ScheduleAdminServiceTest @Autowired constructor(
     private val scheduleAdminService: ScheduleAdminService,
     private val userRepository: UserRepository,
+    private val scheduleRepository: ScheduleRepository,
     private val attendanceRepository: AttendanceRepository
 ) : SpringBootTestFeatureSpec({
 
@@ -34,6 +43,38 @@ class ScheduleAdminServiceTest @Autowired constructor(
                     it.userId in userIds
                     it.status shouldBe AttendanceStatus.PENDING
                 }
+            }
+        }
+
+        feature("세션 삭제") {
+
+            scenario("존재하지 않는 세션에 대한 삭제를 요청하면 예외가 발생한다.") {
+                // given
+                val request = AdminSessionDeleteRequest(ids = listOf(UUID.randomUUID()))
+
+                // when, then
+                shouldThrowExactly<BusinessException> {
+                    scheduleAdminService.deleteSessions(request)
+                }.error shouldBe ScheduleError.CONTAIN_IMPROPER_ID_FOR_DELETE_SESSION
+            }
+
+            scenario("세션 삭제 시, 출석 정보도 함께 삭제된다.") {
+                // given
+                val sessions = listOf(getSessionEntityFixture(), getSessionEntityFixture())
+                    .also { scheduleRepository.saveAll(it) }
+                val users = userRepository.saveAll(listOf(getUserEntityFixture(), getUserEntityFixture()))
+                val attendances = listOf(
+                    AttendanceEntity(userId = users[0].id, scheduleId = sessions[0].id),
+                    AttendanceEntity(userId = users[0].id, scheduleId = sessions[1].id),
+                    AttendanceEntity(userId = users[1].id, scheduleId = sessions[1].id)
+                ).also { attendanceRepository.saveAll(it) }
+
+                // when
+                scheduleAdminService.deleteSessions(AdminSessionDeleteRequest(ids = sessions.map { it.id }))
+
+                // then
+                attendanceRepository.findAllByScheduleId(sessions[0].id).shouldHaveSize(0)
+                attendanceRepository.findAllByScheduleId(sessions[1].id).shouldHaveSize(0)
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AdminAttendancesResponseTest.kt
@@ -40,6 +40,12 @@ class AdminAttendancesResponseTest :
                 getAttendanceEntityFixture(scheduleId = sessions[0].id, userId = users[2].userId, status = ON_TIME),
                 getAttendanceEntityFixture(scheduleId = sessions[1].id, userId = users[2].userId, status = ABSENT)
             )
+            /**
+             *         세션1    세션2    세션3
+             * 유저1   출석     초대X    초대X
+             * 유저2   지각     초대X    초대X
+             * 유저3   출석     결석     초대X
+             */
 
             scenario("세션, 유저, 출석 정보를 기반으로 AdminAttendancesResponse를 생성한다.") {
                 val response = AdminAttendancesResponse.from(
@@ -56,9 +62,9 @@ class AdminAttendancesResponseTest :
                 response.users shouldHaveSize 3
                 response.sessions shouldHaveSize 3
                 response.attendancesGroupedBySession.forEach { it.attendances.shouldHaveSize(3) }
-                response.attendancesGroupedBySession[0].attendances.count { it.status == ON_TIME.label } shouldBe 2
-                response.attendancesGroupedBySession[0].attendances.count { it.status == LATE.label } shouldBe 1
-                response.attendancesGroupedBySession[1].attendances.count { it.status == ABSENT.label } shouldBe 3
+                response.attendancesGroupedBySession[0].attendances.count { it.status == ON_TIME } shouldBe 2
+                response.attendancesGroupedBySession[0].attendances.count { it.status == LATE } shouldBe 1
+                response.attendancesGroupedBySession[1].attendances.count { it.status == ABSENT } shouldBe 1
                 response.attendancesGroupedBySession[2].attendances.forAll { it.status.shouldBeNull() }
             }
         }

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
@@ -1,7 +1,9 @@
 package co.yappuworld.schedule.client.dto.response
 
-import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.LATE
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ON_TIME
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.PENDING
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceBookFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
@@ -53,7 +55,7 @@ class AttendanceStatisticsResponseTest :
             )
 
             scenario("일자, 시간에 따른 잔여 세션 수와 진행률 검증") {
-                val attendances = sessions.subList(0, 1).map { getAttendanceEntityFixture(scheduleId = it.id) }
+                val attendances = sessions.map { getAttendanceEntityFixture(scheduleId = it.id, userId = user.userId) }
                 AttendanceStatisticsResponse
                     .from(
                         getAttendanceBookFixture(
@@ -71,8 +73,14 @@ class AttendanceStatisticsResponseTest :
             }
 
             scenario("datetime 기준으로 조회를 진행") {
-                val attendances =
-                    sessions.subList(0, 2).map { getAttendanceEntityFixture(userId = user.userId, scheduleId = it.id) }
+                val attendances = sessions.map {
+                    getAttendanceEntityFixture(
+                        userId = user.userId,
+                        scheduleId = it.id,
+                        status = PENDING
+                    )
+                }
+
                 AttendanceStatisticsResponse
                     .from(
                         getAttendanceBookFixture(
@@ -87,26 +95,35 @@ class AttendanceStatisticsResponseTest :
                         it.totalSessionCount shouldBe 5
                         it.remainingSessionCount shouldBe 3
                         it.sessionProgressRate shouldBe 40
-                        it.attendancePoint shouldBe 100
-                        it.attendanceCount shouldBe 2
-                        it.lateCount shouldBe 0
-                        it.absenceCount shouldBe 0
                     }
             }
 
             scenario("모두 출석이면 출석 점수가 100점이다.") {
+                val attendances = sessions
+                    .subList(0, 2)
+                    .map {
+                        getAttendanceEntityFixture(
+                            userId = user.userId,
+                            scheduleId = it.id,
+                            status = ON_TIME
+                        )
+                    }.union(
+                        sessions.subList(2, 5).map {
+                            getAttendanceEntityFixture(
+                                userId = user.userId,
+                                scheduleId = it.id,
+                                status = PENDING
+                            )
+                        }
+                    ).toList()
+
                 AttendanceStatisticsResponse
                     .from(
                         getAttendanceBookFixture(
                             generation = generation,
                             attendees = listOf(getAttendeeFixture(user, generation)),
                             sessions = sessions,
-                            attendances = sessions.subList(0, 2).map {
-                                getAttendanceEntityFixture(
-                                    userId = user.userId,
-                                    scheduleId = it.id
-                                )
-                            },
+                            attendances = attendances,
                             now = datetime
                         ).getUserAttendanceStatistics(user.userId)
                     ).let {
@@ -124,7 +141,7 @@ class AttendanceStatisticsResponseTest :
                 val attendances =
                     sessions.subList(0, 2).map { getAttendanceEntityFixture(userId = user.userId, scheduleId = it.id) }
                 repeat(2) { r ->
-                    attendances[r].updateStatus(AttendanceStatus.LATE)
+                    attendances[r].updateStatus(LATE)
                     AttendanceStatisticsResponse
                         .from(
                             getAttendanceBookFixture(

--- a/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
@@ -39,6 +39,12 @@ class AttendanceBookTest :
 
         feature("임의의 데이터로 AttendanceBook을 생성한다.") {
 
+            /**
+             *         세션1    세션2    세션3
+             * 유저1   출석     지각     초대X
+             * 유저2   결석    미출석    초대X
+             * 유저3   초대X    지각    미출석
+             */
             val attendances = listOf(
                 getAttendanceEntityFixture(
                     userId = users[0].userId,
@@ -56,9 +62,19 @@ class AttendanceBookTest :
                     status = AttendanceStatus.ABSENT
                 ),
                 getAttendanceEntityFixture(
+                    userId = users[1].userId,
+                    scheduleId = sessions[1].id,
+                    status = AttendanceStatus.PENDING
+                ),
+                getAttendanceEntityFixture(
                     userId = users[2].userId,
                     scheduleId = sessions[1].id,
                     status = AttendanceStatus.LATE
+                ),
+                getAttendanceEntityFixture(
+                    userId = users[2].userId,
+                    scheduleId = sessions[2].id,
+                    status = AttendanceStatus.PENDING
                 )
             )
             val latePassEntities = listOf(
@@ -92,7 +108,7 @@ class AttendanceBookTest :
                 )
 
                 attendanceBook.getUserAttendanceStatistics(users[0].userId).let {
-                    it.totalSessionCount shouldBe 3
+                    it.totalSessionCount shouldBe 2
                     it.onTimeCount shouldBe 1
                     it.lateCount shouldBe 1
                     it.absentCount shouldBe 0
@@ -105,7 +121,7 @@ class AttendanceBookTest :
                 }
 
                 attendanceBook.getUserAttendanceStatistics(users[1].userId).let {
-                    it.totalSessionCount shouldBe 3
+                    it.totalSessionCount shouldBe 2
                     it.onTimeCount shouldBe 0
                     it.lateCount shouldBe 0
                     it.absentCount shouldBe 2
@@ -118,15 +134,15 @@ class AttendanceBookTest :
                 }
 
                 attendanceBook.getUserAttendanceStatistics(users[2].userId).let {
-                    it.totalSessionCount shouldBe 3
+                    it.totalSessionCount shouldBe 2
                     it.onTimeCount shouldBe 0
                     it.lateCount shouldBe 1
-                    it.absentCount shouldBe 1
+                    it.absentCount shouldBe 0
                     it.earlyCheckOutCount shouldBe 0
                     it.excusedAbsenceCount shouldBe 0
                     it.latePassCount shouldBe 0
-                    it.totalPoint shouldBe 70
-                    it.penaltyPoint shouldBe 30
+                    it.totalPoint shouldBe 90
+                    it.penaltyPoint shouldBe 10
                     it.bonusPoint shouldBe 0
                 }
             }
@@ -142,10 +158,10 @@ class AttendanceBookTest :
                 )
 
                 attendanceBook.getSessionAttendanceStatistics(sessions[0].id).let {
-                    it.totalPersonCount shouldBe 3
+                    it.totalPersonCount shouldBe 2
                     it.totalOnTimeCount shouldBe 1
                     it.totalLateCount shouldBe 0
-                    it.totalAbsentCount shouldBe 2
+                    it.totalAbsentCount shouldBe 1
                     it.totalEarlyCheckOutCount shouldBe 0
                     it.totalExcusedAbsenceCount shouldBe 0
                 }
@@ -160,7 +176,7 @@ class AttendanceBookTest :
                 }
 
                 attendanceBook.getSessionAttendanceStatistics(sessions[2].id).let {
-                    it.totalPersonCount shouldBe 3
+                    it.totalPersonCount shouldBe 1
                     it.totalOnTimeCount shouldBe 0
                     it.totalLateCount shouldBe 0
                     it.totalAbsentCount shouldBe 0
@@ -204,10 +220,12 @@ class AttendanceBookTest :
                 for (user in users) {
                     for (session in sessions) {
                         val expected = attendanceBook.getStatus(session.id, user.userId)
-                        val actual = attendances
-                            .find { it.userId == user.userId && it.scheduleId == session.id }
-                            ?.status
-                            ?: if (session.isFinished(now)) AttendanceStatus.ABSENT else null
+                        val attendance = attendances.find { it.userId == user.userId && it.scheduleId == session.id }
+                        val actual = when (attendance?.status == AttendanceStatus.PENDING && session.isFinished(now)) {
+                            true -> AttendanceStatus.ABSENT
+                            false -> attendance?.status
+                        }
+
                         expected shouldBe actual
                     }
                 }

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandServiceTest.kt
@@ -7,9 +7,12 @@ import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixtur
 import co.yappuworld.support.fixture.AttendanceFixture.getSessionAttendanceFixture
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.inspectors.shouldForAll
+import io.kotest.matchers.collections.shouldNotBeIn
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
 
 class AttendanceCommandServiceTest @Autowired constructor(
     private val attendanceRepository: AttendanceRepository
@@ -39,6 +42,27 @@ class AttendanceCommandServiceTest @Autowired constructor(
                         userId = attendance.userId,
                         scheduleId = attendance.scheduleId
                     ).shouldNotBeNull()
+            }
+        }
+
+        feature("여러 세션 목록에 매칭되는 출석 정보들을 삭제한다.") {
+
+            scenario("삭제할 출석 정보가 없으면 예외가 발생한다.") {
+                shouldThrowExactly<IllegalArgumentException> {
+                    attendanceCommandService.deleteAllInSessions(emptyList())
+                }.message shouldBe "삭제를 위한 세션 ID는 적어도 하나 이상이어야 합니다."
+            }
+
+            scenario("세션이 여러개면, 해당 세션의 모든 출석 정보를 삭제한다.") {
+                val sessionIds = List(2) { UUID.randomUUID() }
+                attendanceRepository.saveAllAndFlush(
+                    sessionIds.map { getAttendanceEntityFixture(scheduleId = it) }
+                )
+
+                attendanceCommandService.deleteAllInSessions(sessionIds)
+
+                val result = attendanceRepository.findAll()
+                result.shouldForAll { it.id shouldNotBeIn sessionIds }
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindServiceTest.kt
@@ -5,13 +5,21 @@ import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getActivityUnitEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
+import co.yappuworld.user.infrastructure.jpa.UserRepository
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 
 class AttendanceFindServiceTest @Autowired constructor(
     private val sessionRepository: ScheduleRepository,
-    private val attendanceRepository: AttendanceRepository
+    private val attendanceRepository: AttendanceRepository,
+    private val userRepository: UserRepository,
+    private val activityUnitRepository: ActivityUnitRepository
 ) : CustomDataJpaTestFeatureSpec({
 
         val attendanceFindService = AttendanceFindService(attendanceRepository)
@@ -40,6 +48,39 @@ class AttendanceFindServiceTest @Autowired constructor(
 
                 val result = attendanceFindService.findAttendancesOfGeneration(generation)
                 result.shouldHaveSize(3)
+            }
+        }
+
+        feature("세션 참석자를 조회한다.") {
+
+            scenario("세션 참석자 조회 시, 해당 세션에 참석한 직군 자격으로 조회된다.") {
+                val user1 = getUserEntityFixture()
+                val user1ActivityUnits = listOf(
+                    getActivityUnitEntityFixture(generation = 25, position = Position.PM, userId = user1.id),
+                    getActivityUnitEntityFixture(generation = 25, position = Position.STAFF, userId = user1.id),
+                    getActivityUnitEntityFixture(generation = 24, position = Position.SERVER, userId = user1.id)
+                )
+                val user2 = getUserEntityFixture()
+                val user2ActivityUnits = listOf(
+                    getActivityUnitEntityFixture(generation = 25, position = Position.STAFF, userId = user2.id)
+                )
+                val session = getSessionEntityFixture()
+                val attendance = getAttendanceEntityFixture(userId = user1.id, scheduleId = session.id)
+
+                userRepository.saveAll(listOf(user1, user2))
+                activityUnitRepository.saveAll(user1ActivityUnits.union(user2ActivityUnits))
+                sessionRepository.save(session)
+                attendanceRepository.saveAndFlush(attendance)
+
+                val result = attendanceFindService.findAttendees(session.id)
+                result.shouldHaveSize(1)
+                result[0].let {
+                    it.userId shouldBe user1.id
+                    it.name shouldBe user1.name
+                    it.generation shouldBe session.generation
+                    it.position shouldBe Position.PM
+                    it.sessionId shouldBe session.id
+                }
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/support/fixture/ScheduleDtoFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/ScheduleDtoFixture.kt
@@ -1,0 +1,38 @@
+package co.yappuworld.support.fixture
+
+import co.yappuworld.schedule.client.dto.request.AdminSessionCreateRequest
+import co.yappuworld.schedule.domain.vo.ScheduleType
+import co.yappuworld.schedule.domain.vo.SessionType
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+
+object ScheduleDtoFixture {
+
+    fun getAdminSessionCreateRequestFixture(
+        name: String = "세션 이름",
+        description: String? = null,
+        place: String? = "세션 장소",
+        date: LocalDate = LocalDate.of(2024, 12, 12),
+        endDate: LocalDate = LocalDate.of(2024, 12, 12),
+        time: LocalTime = LocalTime.of(10, 0),
+        endTime: LocalTime = LocalTime.of(12, 0),
+        generation: Int = 25,
+        type: ScheduleType = ScheduleType.SESSION,
+        sessionType: SessionType = SessionType.OFFLINE,
+        attendeeIds: List<UUID> = listOf(UUID.randomUUID())
+    ): AdminSessionCreateRequest =
+        AdminSessionCreateRequest(
+            name = name,
+            description = description,
+            place = place,
+            date = date,
+            endDate = endDate,
+            time = time,
+            endTime = endTime,
+            generation = generation,
+            type = type,
+            sessionType = sessionType,
+            sessionAttendeeIds = attendeeIds
+        )
+}

--- a/src/test/kotlin/co/yappuworld/support/fixture/UserFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/UserFixture.kt
@@ -105,6 +105,7 @@ object UserFixture {
         email: String = "email@abc.com",
         name: String = "홍길동",
         role: UserRole = UserRole.ACTIVE,
+        activityUnitId: UUID = UUID.randomUUID(),
         generation: Int = 25,
         position: Position = Position.SERVER
     ): UserWithActivityUnit =
@@ -113,6 +114,7 @@ object UserFixture {
             email = email,
             name = name,
             role = role,
+            activityUnitId = activityUnitId,
             generation = generation,
             position = position
         )

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/UserFindServiceTest.kt
@@ -386,7 +386,7 @@ class UserFindServiceTest @Autowired constructor(
         feature("특정 기수에 활동한 모든 유저를 조회한다.") {
 
             scenario("해당 기수에 활동한 유저가 없다면 빈 리스트를 반환한다.") {
-                userFindService.findUsersActiveOfGeneration(99).shouldBeEmpty()
+                userFindService.findActiveUsersOfGeneration(99).shouldBeEmpty()
             }
 
             scenario("특정 기수에 활동한 기록이 있는 모든 유저를 조회한다.") {
@@ -411,7 +411,7 @@ class UserFindServiceTest @Autowired constructor(
 
                 val userIds = listOf(user1.id, user2.id).sorted()
                 val result = userFindService
-                    .findUsersActiveOfGeneration(99)
+                    .findActiveUsersOfGeneration(99)
                 val resultByUserId = result.associateBy { it.userId }
 
                 result.shouldHaveSize(2)


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 세션 참석자를 지정할 수 있어야 합니다.
- 참석자의 존재 -> 세션 미대상자의 존재


## ⭐️ 어떻게 해결했나요?

### AS-IS
- 기존에는 세션의 기수(generation)이 설정되면, 해당 기수의 모든 인원이 세션 참석 대상자였습니다.
	- 세션 생성 시 별도의 attendance 데이터를 설정하지 않고, 실제 출석을 진행하면 attendance 데이터를 생성하였습니다.

### TO-BE
- 세션 생성 시 참석자를 지정할 수 있도록 하고, 지정된 참석자를 기반으로 attendance 데이터를 미리 생성합니다.


- 이러한 로직 변경으로 인해, 출석 관련 처리를 하는 AttendanceBook을 기반으로 하는 도메인 전반의 수정이 진행되었습니다.
- AttendanceStatus에 PENDING 상태를 새로 추가하여, 미출석(출석 대상이나, 아직 출석 관련 액션을 하지 않은 상태) 상태를 추가하였습니다.
- 유저 통계, 세션 통계에 대한 수정도 진행되었습니다.
- 출석 정보 수정 시에도, 출석 대상자에 대한 상태 변경만 진행될 수 있도록 수정하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
