### PR TITLE
fix: 개인 세션 통계 조회 API v2

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
@@ -4,10 +4,10 @@ import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.operation.infrastructure.ConfigFindService
 import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
-import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponse
 import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponse
 import co.yappuworld.schedule.domain.AttendanceBook
 import co.yappuworld.schedule.domain.SessionAttendance
+import co.yappuworld.schedule.domain.UserAttendanceStatistics
 import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
@@ -52,7 +52,7 @@ class AttendanceService(
     fun getAttendanceStatistics(
         userId: UUID,
         now: LocalDateTime
-    ): AttendanceStatisticsResponse {
+    ): UserAttendanceStatistics {
         val activeGeneration = generationFindService.findActiveGeneration()
         val attendee = userFindService.findSessionAttendee(userId, activeGeneration)
         val activeGenerationSessions = sessionFindService.findSessionsInGeneration(activeGeneration)
@@ -71,7 +71,7 @@ class AttendanceService(
             now = now
         )
 
-        return AttendanceStatisticsResponse.from(attendanceBook.getUserAttendanceStatistics(userId))
+        return attendanceBook.getUserAttendanceStatistics(userId)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
@@ -44,8 +44,6 @@ class AttendanceService(
 
         checkAttendanceCode(request.attendanceCode)
         sessionAttendance.checkIn(now)
-
-        attendanceCommandService.checkIn(sessionAttendance)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -96,14 +96,15 @@ class ScheduleService(
         val activeGeneration = generationFindService.findActiveGenerationOrNull()
             ?: throw BusinessException(ScheduleError.NO_SESSION_WITHOUT_ACTIVE_GENERATION)
         val attendee = userFindService.findSessionAttendee(userId, activeGeneration)
-        val session = sessionFindService.findUpcomingSession(activeGeneration, now)
-        val attendanceOrNull = attendanceFindService.findSessionAttendance(userId, session.id)
+        // TODO: 내가 참여하는 가장 임박한 세션으로 변경해야 함
+        val session = sessionFindService.findUpcomingSession(userId, activeGeneration, now)
+        val attendance = attendanceFindService.findSessionAttendance(userId, session.id)
 
         return UpcomingSessionAttendanceResponse.of(
             sessionAttendance = SessionAttendance(
                 attendee = attendee,
                 session = session,
-                attendance = attendanceOrNull
+                attendance = attendance
             ),
             now = now
         )

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseV2.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseV2.kt
@@ -2,14 +2,15 @@ package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.schedule.domain.UserAttendanceStatistics
 import io.swagger.v3.oas.annotations.media.Schema
+import kotlin.math.roundToInt
 
-data class AttendanceStatisticsResponse(
+data class AttendanceStatisticsResponseV2(
     @Schema(description = "전체 세션 수")
     val totalSessionCount: Int,
     @Schema(description = "남은 세션 수")
     val remainingSessionCount: Int,
     @Schema(description = "세션 진행률 (소수 첫째자리까지 표현)")
-    val sessionProgressRate: Int,
+    val sessionProgressRate: Double,
     @Schema(description = "출석 점수")
     val attendancePoint: Int,
     @Schema(description = "출석한 세션 수")
@@ -23,12 +24,15 @@ data class AttendanceStatisticsResponse(
 ) {
 
     companion object {
-        fun from(userAttendanceStatistics: UserAttendanceStatistics): AttendanceStatisticsResponse =
+        fun from(userAttendanceStatistics: UserAttendanceStatistics): AttendanceStatisticsResponseV2 =
             userAttendanceStatistics.let {
-                AttendanceStatisticsResponse(
+                val sessionProgressRatio = 1.0 - it.leftSessionCount.toDouble() / it.totalSessionCount
+                val sessionProgressRate = (sessionProgressRatio * 100 * 10).roundToInt() / 10.0
+
+                AttendanceStatisticsResponseV2(
                     totalSessionCount = it.totalSessionCount,
                     remainingSessionCount = it.leftSessionCount,
-                    sessionProgressRate = ((1.0 - it.leftSessionCount.toDouble() / it.totalSessionCount) * 100).toInt(),
+                    sessionProgressRate = sessionProgressRate,
                     attendancePoint = it.totalPoint,
                     attendanceCount = it.onTimeCount,
                     lateCount = it.lateCount,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionAttendanceResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionAttendanceResponse.kt
@@ -39,7 +39,7 @@ data class UpcomingSessionAttendanceResponse(
         description = """
             현재 출석이 가능한지 여부
             출석이 가능한 조건
-            1. 유저의 기수가 활성화 기수와 동일 & 유저의 권한이 ACTIVE(활동 중)
+            1. 세션 참가자로 초대를 받았고
             2. 세션 시작 20분 전 ~ 세션 종료 시간
             3. 아직 출석하지 않은 경우
         """

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
@@ -5,6 +5,7 @@ import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.global.security.SecurityUser
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponse
+import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponseV2
 import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -174,7 +175,7 @@ interface AttendanceApi {
                                         "data": {
                                             "totalSessionCount": 17,
                                             "remainingSessionCount": 2,
-                                            "sessionProgressRate": 88.2,
+                                            "sessionProgressRate": 88,
                                             "attendancePoint": 40,
                                             "attendanceCount": 10,
                                             "lateCount": 3,
@@ -215,6 +216,64 @@ interface AttendanceApi {
     fun getAttendanceStatistics(
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<SuccessResponse<AttendanceStatisticsResponse>>
+
+    @Operation(summary = "나의 출석 통계")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                content = [
+                    Content(
+                        schema = Schema(implementation = AttendanceStatisticsResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "출석 통계 조회",
+                                value = """
+                                    {
+                                        "data": {
+                                            "totalSessionCount": 17,
+                                            "remainingSessionCount": 2,
+                                            "sessionProgressRate": 88.2,
+                                            "attendancePoint": 40,
+                                            "attendanceCount": 10,
+                                            "lateCount": 3,
+                                            "absenceCount": 2,
+                                            "latePassCount": 1
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "활성화 된 기수가 없어 출석 통계 조회 불가",
+                                value = """
+                                    {
+                                        "errorCode": "ATD_2002",
+                                        "message": "활성화 된 기수가 없어서 출석 통계 조회가 불가합니다.",
+                                        "isSuccess": false
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/v2/attendances/statistics")
+    fun getAttendanceStatisticsV2(
+        @AuthenticationPrincipal securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<AttendanceStatisticsResponseV2>>
 
     @Operation(summary = "출석 내역 조회")
     @ApiResponses(

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
@@ -56,6 +56,16 @@ interface AttendanceApi {
                                         "isSuccess": false
                                     }
                                 """
+                            ),
+                            ExampleObject(
+                                name = "초대받지 않은 유저여서 출석이 불가",
+                                value = """
+                                    {
+                                        "errorCode": "ATD_1005",
+                                        "message": "초대받지 못한 유저입니다.",
+                                        "isSuccess": false
+                                    }
+                                """
                             )
                         ]
                     )

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceController.kt
@@ -6,6 +6,7 @@ import co.yappuworld.global.util.DatetimeUtils
 import co.yappuworld.schedule.client.application.AttendanceService
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponse
+import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponseV2
 import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -30,7 +31,20 @@ class AttendanceController(
     ): ResponseEntity<SuccessResponse<AttendanceStatisticsResponse>> =
         ResponseEntity.ok(
             SuccessResponse(
-                attendanceService.getAttendanceStatistics(securityUser.userId, LocalDateTime.now())
+                AttendanceStatisticsResponse.from(
+                    attendanceService.getAttendanceStatistics(securityUser.userId, LocalDateTime.now())
+                )
+            )
+        )
+
+    override fun getAttendanceStatisticsV2(
+        securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<AttendanceStatisticsResponseV2>> =
+        ResponseEntity.ok(
+            SuccessResponse(
+                AttendanceStatisticsResponseV2.from(
+                    attendanceService.getAttendanceStatistics(securityUser.userId, LocalDateTime.now())
+                )
             )
         )
 

--- a/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
@@ -5,7 +5,7 @@ import co.yappuworld.global.util.DatetimeUtils.dDayFrom
 import co.yappuworld.global.util.DatetimeUtils.isBeforeOrEqual
 import co.yappuworld.global.util.DatetimeUtils.korean
 import co.yappuworld.schedule.domain.vo.AttendanceError
-import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -20,7 +20,7 @@ private val logger = KotlinLogging.logger {}
 class SessionAttendance(
     private val attendee: Attendee,
     private val session: SessionEntity,
-    private var attendance: AttendanceEntity?
+    private val attendance: AttendanceEntity
 ) {
 
     val sessionId = session.id
@@ -33,24 +33,17 @@ class SessionAttendance(
     val sessionEndTime = session.endTime
     val sessionPlace = session.place
 
-    private val hasAttendance: Boolean
-        get() = attendance != null
-
     fun getRelativeDays(now: LocalDate): Int = sessionStartDate.dDayFrom(now).toInt()
 
-    fun canCheckIn(now: LocalDateTime): Boolean = now.isBetweenCheckInTime() && !hasAttendance
+    fun canCheckIn(now: LocalDateTime): Boolean = now.isBetweenCheckInTime() && attendance.canAttend()
 
     fun checkIn(now: LocalDateTime) {
         validateCheckInAvailability(now)
-        attendance = AttendanceEntity(
-            status = session.decideCheckInStatus(now),
-            userId = attendee.id,
-            scheduleId = session.id
-        )
+        attendance.updateStatus(session.decideCheckInStatus(now))
     }
 
     fun validateCheckInAvailability(now: LocalDateTime) {
-        if (hasAttendance) {
+        if (attendance.hasAttended()) {
             logger.warn { "이미 출석을 완료한 유저(${attendee.id})입니다." }
             throw BusinessException(AttendanceError.ALREADY_CHECKED_IN)
         }
@@ -61,23 +54,13 @@ class SessionAttendance(
         }
     }
 
-    fun getAttendanceStatus(now: LocalDateTime): String? {
-        val safeAttendance = attendance
-        return when {
-            safeAttendance != null -> safeAttendance.status.label
-            session.isFinished(now) -> AttendanceStatus.ABSENT.label
-            else -> null
-        }
-    }
-
-    fun getNewAttendance(): AttendanceEntity {
-        if (attendance == null) {
-            logger.error { "출석을 위한 데이터가 없습니다. 로직을 확인해주세요." }
-            throw BusinessException(AttendanceError.NO_ATTENDANCE_TO_CHECK_IN)
+    fun getAttendanceStatus(now: LocalDateTime): String? =
+        when {
+            attendance.canAttend() -> if (session.isFinished(now)) ABSENT.label else null
+            else -> attendance.status.label
         }
 
-        return checkNotNull(attendance)
-    }
+    fun getNewAttendance(): AttendanceEntity = attendance
 
     private fun LocalDateTime.isBetweenCheckInTime(): Boolean =
         session.checkInTimeFrom.isBeforeOrEqual(this) && this.isBefore(session.checkInTimeUntil)

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceError.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/AttendanceError.kt
@@ -26,15 +26,15 @@ enum class AttendanceError : Error {
         override val code: String = "ATD_1002"
         override val type: ErrorType = ErrorType.BAD_REQUEST
     },
-    NO_ATTENDANCE_TO_CHECK_IN {
-        override val message: String = "출석이 불가합니다. 개발자에게 문의해주세요."
-        override val code: String = "ATD_1003"
-        override val type: ErrorType = ErrorType.UNEXPECTED_ERROR
-    },
     UNREGISTERED_ATTENDANCE_CODE {
         override val message: String = "출석코드가 등록되지 않았습니다."
         override val code: String = "ATD_1004"
         override val type: ErrorType = ErrorType.WRONG_STATE
+    },
+    NOT_INVITED {
+        override val message: String = "초대받지 못한 유저입니다."
+        override val code: String = "ATD_1005"
+        override val type: ErrorType = ErrorType.BAD_REQUEST
     },
 
     // 외부 도메인 에러
@@ -62,11 +62,6 @@ enum class AttendanceError : Error {
         override val message: String = "유저의 출석 정보를 찾을 수 없습니다."
         override val code: String = "ATD_2005"
         override val type: ErrorType = ErrorType.NOT_FOUND
-    },
-    CANNOT_EXISTS_ATTENDANCE_FUTURE_SESSION {
-        override val message: String = "미래 세션에 출석할 수 없습니다."
-        override val code: String = "ATD_2006"
-        override val type: ErrorType = ErrorType.WRONG_STATE
     },
     NO_ATTENDEE_ACTIVITY_IN_GENERATION {
         override val message: String = "해당 기수에 활동이 없어서 출석 관련 처리가 불가합니다."

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/AttendanceFindService.kt
@@ -1,5 +1,7 @@
 package co.yappuworld.schedule.infrastructure
 
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.infrastructure.dto.SessionAttendeeDto
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
@@ -24,7 +26,9 @@ class AttendanceFindService(
     fun findSessionAttendance(
         userId: UUID,
         sessionId: UUID
-    ): AttendanceEntity? = attendanceRepository.findByUserIdAndScheduleId(userId, sessionId)
+    ): AttendanceEntity =
+        attendanceRepository.findByUserIdAndScheduleId(userId, sessionId)
+            ?: throw BusinessException(AttendanceError.NOT_INVITED)
 
     fun findAttendancesBySchedules(
         userId: UUID,

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
@@ -27,16 +27,21 @@ class SessionFindService(
             ?: throw BusinessException(ScheduleError.NOT_FOUND_SESSION)
 
     fun findUpcomingSession(
+        userId: UUID,
         activeGeneration: Int,
         now: LocalDateTime
     ): SessionEntity =
         scheduleRepository
             .findAll(limit = 1) {
                 select(entity(SessionEntity::class))
-                    .from(entity(SessionEntity::class))
-                    .where(
+                    .from(
+                        entity(SessionEntity::class),
+                        innerJoin(AttendanceEntity::class)
+                            .on(path(SessionEntity::getId).equal(path(AttendanceEntity::scheduleId)))
+                    ).where(
                         and(
                             path(SessionEntity::generation).equal(activeGeneration),
+                            path(AttendanceEntity::userId).equal(userId),
                             or(
                                 path(SessionEntity::endDate).greaterThan(now.toLocalDate()),
                                 and(

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
@@ -53,4 +53,8 @@ class AttendanceEntity(
     fun updateStatus(status: AttendanceStatus) {
         this.status = status
     }
+
+    fun hasAttended(): Boolean = status != AttendanceStatus.PENDING
+
+    fun canAttend(): Boolean = status == AttendanceStatus.PENDING
 }

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
@@ -5,6 +5,7 @@ import co.yappuworld.operation.infrastructure.ConfigFindService
 import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.domain.vo.AttendanceError
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.LatePassFindService
@@ -64,7 +65,7 @@ class AttendanceServiceTest :
             every { generationFindService.findActiveGeneration() } returns activeGeneration
             every { userFindService.findSessionAttendee(any(), any()) } returns attendee
             every { sessionFindService.findSession(any()) } returns session
-            every { attendanceFindService.findSessionAttendance(any(), any()) } returns null
+            every { attendanceFindService.findSessionAttendance(any(), any()) } returns getAttendanceEntityFixture()
             every { configFindService.findAttendanceCodeValue() } returns attendanceCode
             justRun { attendanceCommandService.checkIn(any()) }
         }
@@ -79,7 +80,7 @@ class AttendanceServiceTest :
                         successConditionMocking()
                         every {
                             attendanceFindService.findSessionAttendance(user.id, session.id)
-                        } returns getAttendanceEntityFixture()
+                        } returns getAttendanceEntityFixture(status = AttendanceStatus.ON_TIME)
 
                         shouldThrow<BusinessException> {
                             attendanceService.checkIn(request, user.id, LocalDateTime.now())

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/UpcomingSessionFindTest.kt
@@ -8,6 +8,7 @@ import co.yappuworld.schedule.infrastructure.AttendanceFindService
 import co.yappuworld.schedule.infrastructure.ScheduleFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.support.fixture.AttendanceFixture
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.ScheduleFixture
 import co.yappuworld.support.fixture.UserFixture.getActivityUnitFixture
@@ -69,8 +70,8 @@ class UpcomingSessionFindTest :
                     userWithActivityUnits = user,
                     generation = generation
                 )
-                every { sessionFindService.findUpcomingSession(any(), any()) } returns session
-                every { attendanceFindService.findSessionAttendance(any(), any()) } returns null
+                every { sessionFindService.findUpcomingSession(any(), any(), any()) } returns session
+                every { attendanceFindService.findSessionAttendance(any(), any()) } returns getAttendanceEntityFixture()
             }
 
             scenario("현재 테스트 조건에선 출석을 누를 수 있다.") {

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseTest.kt
@@ -138,8 +138,10 @@ class AttendanceStatisticsResponseTest :
             }
 
             scenario("지각 횟수당 10점씩 깎인다.") {
-                val attendances =
-                    sessions.subList(0, 2).map { getAttendanceEntityFixture(userId = user.userId, scheduleId = it.id) }
+                val attendances = sessions
+                    .subList(0, 2)
+                    .map { getAttendanceEntityFixture(status = ON_TIME, userId = user.userId, scheduleId = it.id) }
+
                 repeat(2) { r ->
                     attendances[r].updateStatus(LATE)
                     AttendanceStatisticsResponse
@@ -160,8 +162,10 @@ class AttendanceStatisticsResponseTest :
             }
 
             scenario("결석 횟수당 20점씩 깎인다.") {
-                val attendances =
-                    sessions.subList(0, 2).map { getAttendanceEntityFixture(userId = user.userId, scheduleId = it.id) }
+                val attendances = sessions
+                    .subList(0, 2)
+                    .map { getAttendanceEntityFixture(status = ON_TIME, userId = user.userId, scheduleId = it.id) }
+
                 repeat(2) { r ->
                     attendances[r].updateStatus(ABSENT)
                     AttendanceStatisticsResponse

--- a/src/test/kotlin/co/yappuworld/schedule/domain/SessionAttendanceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/SessionAttendanceTest.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.domain
 
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getSessionAttendanceFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
@@ -29,7 +30,9 @@ class SessionAttendanceTest :
 
             scenario("세션 시작 20분 전보다 더 이전이면 출석할 수 없다.") {
                 val now = LocalDateTime.of(2024, 12, 12, 13, 40).minusNanos(1)
-                getSessionAttendanceFixture(attendee, session, null).canCheckIn(now).shouldBeFalse()
+                getSessionAttendanceFixture(attendee, session, getAttendanceEntityFixture())
+                    .canCheckIn(now)
+                    .shouldBeFalse()
             }
 
             scenario("세션 시작 20분 전부터, 세션 종료 직전까지 출석할 수 있다.") {
@@ -37,13 +40,17 @@ class SessionAttendanceTest :
                     row(LocalDateTime.of(2024, 12, 12, 13, 40)),
                     row(LocalDateTime.of(2024, 12, 13, 10, 0).minusNanos(1))
                 ) { now ->
-                    getSessionAttendanceFixture(attendee, session, null).canCheckIn(now).shouldBeTrue()
+                    getSessionAttendanceFixture(attendee, session, getAttendanceEntityFixture())
+                        .canCheckIn(now)
+                        .shouldBeTrue()
                 }
             }
 
             scenario("종료 시간부터는 출석할 수 없다.") {
                 val now = LocalDateTime.of(session.endDate, session.endTime)
-                getSessionAttendanceFixture(attendee, session, null).canCheckIn(now).shouldBeFalse()
+                getSessionAttendanceFixture(attendee, session, getAttendanceEntityFixture())
+                    .canCheckIn(now)
+                    .shouldBeFalse()
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/AttendanceCommandServiceTest.kt
@@ -1,7 +1,5 @@
 package co.yappuworld.schedule.infrastructure
 
-import co.yappuworld.global.exception.BusinessException
-import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getSessionAttendanceFixture
@@ -21,12 +19,6 @@ class AttendanceCommandServiceTest @Autowired constructor(
         val attendanceCommandService = AttendanceCommandService(attendanceRepository)
 
         feature("도메인 모델로부터 새로운 출석 정보를 저장") {
-
-            scenario("출석 정보가 없으면 예외가 발생한다.") {
-                shouldThrowExactly<BusinessException> {
-                    attendanceCommandService.checkIn(getSessionAttendanceFixture())
-                }.error shouldBe AttendanceError.NO_ATTENDANCE_TO_CHECK_IN
-            }
 
             scenario("출석 정보가 있으면 정상적으로 저장된다.") {
                 val attendance = getAttendanceEntityFixture()

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
@@ -9,6 +9,7 @@ import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
@@ -205,66 +206,61 @@ class SessionFindServiceTest @Autowired constructor(
 
         feature("findUpcomingSession") {
 
-            scenario("예정된 세션이 없는 경우 NULL 반환") {
+            scenario("예정된 세션이 없는 경우 예외 발생") {
                 shouldThrowExactly<BusinessException> {
-                    sessionFindService.findUpcomingSession(25, LocalDateTime.of(2024, 12, 12, 0, 0))
+                    sessionFindService.findUpcomingSession(UUID.randomUUID(), 25, LocalDateTime.of(2024, 12, 12, 0, 0))
                 }.error shouldBe ScheduleError.NO_UPCOMING_SESSION
             }
 
-            scenario("당일 세션이 없다면, 다음 세션 중 가장 임박한 세션이 조회된다.") {
-                val generation = 25
-                val now = LocalDateTime.of(2024, 12, 12, 0, 0)
-                val sessions = listOf(
-                    getSessionEntityFixture(
-                        generation = generation,
-                        date = now.toLocalDate().minusDays(1),
-                        endDate = now.toLocalDate().minusDays(1)
-                    ),
-                    getSessionEntityFixture(
-                        generation = generation,
-                        date = now.toLocalDate().plusDays(1),
-                        endDate = now.toLocalDate().plusDays(1)
-                    ),
-                    getSessionEntityFixture(
-                        generation = generation,
-                        date = now.toLocalDate().plusDays(2),
-                        endDate = now.toLocalDate().plusDays(2)
+            scenario("세션 초대 현황에 따라 조회되는 세션이 다르다.") {
+                val today = LocalDate.of(2024, 12, 12)
+                val tomorrowSession = getSessionEntityFixture(
+                    generation = 25,
+                    date = today.plusDays(1),
+                    endDate = today.plusDays(1)
+                )
+                val nextWeekSession = getSessionEntityFixture(
+                    generation = 25,
+                    date = today.plusDays(7),
+                    endDate = today.plusDays(7)
+                )
+                scheduleRepository.saveAll(listOf(tomorrowSession, nextWeekSession))
+
+                val user1 = getUserEntityFixture()
+                val user2 = getUserEntityFixture()
+
+                attendanceRepository.saveAllAndFlush(
+                    listOf(
+                        getAttendanceEntityFixture(
+                            status = AttendanceStatus.PENDING,
+                            userId = user1.id,
+                            scheduleId = tomorrowSession.id
+                        ),
+                        getAttendanceEntityFixture(
+                            status = AttendanceStatus.PENDING,
+                            userId = user1.id,
+                            scheduleId = nextWeekSession.id
+                        ),
+                        getAttendanceEntityFixture(
+                            status = AttendanceStatus.PENDING,
+                            userId = user2.id,
+                            scheduleId = nextWeekSession.id
+                        )
                     )
                 )
 
-                scheduleRepository.saveAllAndFlush(sessions)
-
-                sessionFindService.findUpcomingSession(generation, now).id shouldBe
-                    sessions[1].id
-            }
-
-            scenario("당일 끝나지 않은 세션이 있다면, 해당 세션이 조회된다.") {
-                val generation = 25
-                val now = LocalDateTime.of(2024, 12, 12, 0, 0)
-                val sessions = listOf(
-                    getSessionEntityFixture(
-                        generation = generation,
-                        date = now.toLocalDate().minusDays(1),
-                        endDate = now.toLocalDate().minusDays(1)
-                    ),
-                    getSessionEntityFixture(
-                        generation = generation,
-                        date = now.toLocalDate(),
-                        endDate = now.toLocalDate(),
-                        time = now.toLocalTime().plusHours(1),
-                        endTime = now.toLocalTime().plusHours(1)
-                    ),
-                    getSessionEntityFixture(
-                        generation = generation,
-                        date = now.toLocalDate().plusDays(1),
-                        endDate = now.toLocalDate().plusDays(1)
-                    )
-                )
-
-                scheduleRepository.saveAllAndFlush(sessions)
-
-                sessionFindService.findUpcomingSession(generation, now).id shouldBe
-                    sessions[1].id
+                sessionFindService
+                    .findUpcomingSession(
+                        userId = user1.id,
+                        activeGeneration = 25,
+                        now = today.atStartOfDay()
+                    ).id shouldBe tomorrowSession.id
+                sessionFindService
+                    .findUpcomingSession(
+                        userId = user2.id,
+                        activeGeneration = 25,
+                        now = today.atStartOfDay()
+                    ).id shouldBe nextWeekSession.id
             }
         }
 

--- a/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
@@ -22,7 +22,7 @@ object AttendanceFixture {
     fun getSessionAttendanceFixture(
         attendee: Attendee = getAttendeeFixture(getUserWithActivityUnitFixture()),
         session: SessionEntity = getSessionEntityFixture(),
-        attendance: AttendanceEntity? = null
+        attendance: AttendanceEntity = getAttendanceEntityFixture(userId = attendee.id, scheduleId = session.id)
     ): SessionAttendance =
         SessionAttendance(
             attendee = attendee,
@@ -40,7 +40,7 @@ object AttendanceFixture {
         )
 
     fun getAttendanceEntityFixture(
-        status: AttendanceStatus = AttendanceStatus.ON_TIME,
+        status: AttendanceStatus = AttendanceStatus.PENDING,
         userId: UUID = UUID.randomUUID(),
         scheduleId: UUID = UUID.randomUUID()
     ) = AttendanceEntity(


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 세션 진행률을 표현하는 필드의 타입을 변경하였더니 에러가 발생했습니다. (개발환경 기준)
- 임박한 세션을 조회 했을 때, canCheckIn이 false로 반환되는 이슈가 있습니다.


## ⭐️ 어떻게 해결했나요?
- 세션 진행률을 제공하는 API를 원상복구하고, V2 API를 만들었습니다.
- attendance 관련 정책을 수정하며 체크하지 못한 부분이라, 변경된 로직을 반영할 수 있도록 하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
