### PR TITLE
feat: 내가 참여 대상인 세션의 출석 이력만 보이도록 변경

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
@@ -78,7 +78,7 @@ class AttendanceService(
         now: LocalDateTime
     ): AttendancesHistoryResponse {
         val activeGeneration = generationFindService.findActiveGeneration()
-        val sessionsWithAttendance = sessionFindService.findAttendancesHistory(
+        val sessionsWithAttendance = sessionFindService.findAttendancesHistories(
             generation = activeGeneration,
             userId = userId,
             now = now

--- a/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/SessionAttendance.kt
@@ -39,7 +39,7 @@ class SessionAttendance(
 
     fun checkIn(now: LocalDateTime) {
         validateCheckInAvailability(now)
-        attendance.updateStatus(session.decideCheckInStatus(now))
+        attendance.checkIn(session.decideCheckInStatus(now), now)
     }
 
     fun validateCheckInAvailability(now: LocalDateTime) {

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/CustomAttendanceDsl.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/CustomAttendanceDsl.kt
@@ -1,0 +1,32 @@
+package co.yappuworld.schedule.infrastructure
+
+import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
+import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
+import com.linecorp.kotlinjdsl.dsl.jpql.JpqlDsl
+import com.linecorp.kotlinjdsl.dsl.jpql.select.SelectQueryFromStep
+import org.springframework.stereotype.Component
+
+@Component
+class CustomAttendanceDsl : Jpql() {
+    companion object Constructor : JpqlDsl.Constructor<CustomAttendanceDsl> {
+        override fun newInstance(): CustomAttendanceDsl = CustomAttendanceDsl()
+    }
+
+    fun selectSessionWithAttendance(): SelectQueryFromStep<SessionWithAttendanceDto> =
+        selectNew<SessionWithAttendanceDto>(
+            path(SessionEntity::getId),
+            path(SessionEntity::name),
+            path(SessionEntity::description),
+            path(SessionEntity::place),
+            path(SessionEntity::date),
+            path(SessionEntity::endDate),
+            path(SessionEntity::time),
+            path(SessionEntity::endTime),
+            path(SessionEntity::generation),
+            path(SessionEntity::sessionType),
+            path(AttendanceEntity::createdAt),
+            path(AttendanceEntity::status)
+        )
+}

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
@@ -94,7 +94,7 @@ class SessionFindService(
             }.filterNotNull()
             .apply { forEach { it.resolveAttendanceStatusOfPastSessions(now) } }
 
-    fun findAttendancesHistory(
+    fun findAttendancesHistories(
         generation: Int,
         userId: UUID,
         now: LocalDateTime

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
@@ -2,6 +2,7 @@ package co.yappuworld.schedule.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.util.LocalDateRange
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
@@ -68,31 +69,19 @@ class SessionFindService(
         now: LocalDateTime
     ): List<SessionWithAttendanceDto> =
         scheduleRepository
-            .findAll {
-                selectNew<SessionWithAttendanceDto>(
-                    path(SessionEntity::getId),
-                    path(SessionEntity::name),
-                    path(SessionEntity::description),
-                    path(SessionEntity::place),
-                    path(SessionEntity::date),
-                    path(SessionEntity::endDate),
-                    path(SessionEntity::time),
-                    path(SessionEntity::endTime),
-                    path(SessionEntity::generation),
-                    path(SessionEntity::sessionType),
-                    path(AttendanceEntity::createdAt),
-                    path(AttendanceEntity::status)
-                ).from(
-                    entity(SessionEntity::class),
-                    leftJoin(AttendanceEntity::class).on(
-                        and(
-                            path(SessionEntity::getId).equal(path(AttendanceEntity::scheduleId)),
-                            path(AttendanceEntity::userId).equal(userId)
+            .findAll(CustomAttendanceDsl) {
+                selectSessionWithAttendance()
+                    .from(
+                        entity(SessionEntity::class),
+                        leftJoin(AttendanceEntity::class).on(
+                            and(
+                                path(SessionEntity::getId).equal(path(AttendanceEntity::scheduleId)),
+                                path(AttendanceEntity::userId).equal(userId)
+                            )
                         )
-                    )
-                ).where(path(SessionEntity::generation).equal(generation))
+                    ).where(path(SessionEntity::generation).equal(generation))
             }.filterNotNull()
-            .apply { forEach { it.resolveAttendanceStatusOfPastSessions(now) } }
+            .onEach { it.resolveAttendanceStatusOfPastSessions(now) }
 
     fun findAttendancesHistories(
         generation: Int,
@@ -100,38 +89,26 @@ class SessionFindService(
         now: LocalDateTime
     ): List<SessionWithAttendanceDto> =
         scheduleRepository
-            .findAll {
-                selectNew<SessionWithAttendanceDto>(
-                    path(SessionEntity::getId),
-                    path(SessionEntity::name),
-                    path(SessionEntity::description),
-                    path(SessionEntity::place),
-                    path(SessionEntity::date),
-                    path(SessionEntity::endDate),
-                    path(SessionEntity::time),
-                    path(SessionEntity::endTime),
-                    path(SessionEntity::generation),
-                    path(SessionEntity::sessionType),
-                    path(AttendanceEntity::createdAt),
-                    path(AttendanceEntity::status)
-                ).from(
-                    entity(SessionEntity::class),
-                    leftJoin(AttendanceEntity::class).on(
-                        and(
-                            path(SessionEntity::getId).equal(path(AttendanceEntity::scheduleId)),
-                            path(AttendanceEntity::userId).equal(userId)
+            .findAll(CustomAttendanceDsl) {
+                selectSessionWithAttendance()
+                    .from(
+                        entity(AttendanceEntity::class),
+                        innerJoin(SessionEntity::class)
+                            .on(path(SessionEntity::getId).equal(path(AttendanceEntity::scheduleId)))
+                    ).whereAnd(
+                        path(AttendanceEntity::userId).equal(userId),
+                        path(SessionEntity::generation).equal(generation),
+                        or(
+                            path(AttendanceEntity::status).notEqual(AttendanceStatus.PENDING),
+                            or(
+                                path(SessionEntity::endDate).lessThan(now.toLocalDate()),
+                                and(
+                                    path(SessionEntity::endDate).equal(now.toLocalDate()),
+                                    path(SessionEntity::endTime).lessThan(now.toLocalTime())
+                                )
+                            )
                         )
                     )
-                ).whereAnd(
-                    path(SessionEntity::generation).equal(generation),
-                    or(
-                        path(SessionEntity::endDate).lessThan(now.toLocalDate()),
-                        and(
-                            path(SessionEntity::endDate).equal(now.toLocalDate()),
-                            path(SessionEntity::endTime).lessThan(now.toLocalTime())
-                        )
-                    )
-                )
             }.filterNotNull()
             .onEach { it.resolveAttendanceStatusOfPastSessions(now) }
 

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/AttendanceEntity.kt
@@ -1,7 +1,6 @@
 package co.yappuworld.schedule.infrastructure.entity
 
 import co.yappuworld.global.persistence.BaseEntity
-import co.yappuworld.global.util.DatetimeUtils.isBeforeOrEqual
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -21,34 +20,22 @@ class AttendanceEntity(
     status: AttendanceStatus = AttendanceStatus.PENDING
 ) : BaseEntity() {
 
-    companion object {
-
-        fun checkInSession(
-            now: LocalDateTime,
-            userId: UUID,
-            session: SessionEntity
-        ): AttendanceEntity {
-            val isNowBetweenLateTimeRange =
-                session.lateTimeFrom.isBeforeOrEqual(now) && now.isBeforeOrEqual(session.lateTimeUntil)
-
-            val status = when {
-                now < session.lateTimeFrom -> AttendanceStatus.ON_TIME
-                isNowBetweenLateTimeRange -> AttendanceStatus.LATE
-                else -> AttendanceStatus.ABSENT
-            }
-
-            return AttendanceEntity(
-                status = status,
-                userId = userId,
-                scheduleId = session.id
-            )
-        }
-    }
-
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
     var status: AttendanceStatus = status
         private set
+
+    @Column(name = "user_checked_in_at")
+    var userCheckedInAt: LocalDateTime? = null
+        private set
+
+    fun checkIn(
+        status: AttendanceStatus,
+        now: LocalDateTime
+    ) {
+        this.status = status
+        this.userCheckedInAt = now
+    }
 
     fun updateStatus(status: AttendanceStatus) {
         this.status = status

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -116,12 +116,13 @@ CREATE TABLE generations
 drop table if exists attendances;
 create table attendances
 (
-    id          binary(16) PRIMARY KEY,
-    created_at  datetime(6),
-    updated_at  datetime(6),
-    user_id     binary(16) NOT NULL,
-    schedule_id binary(16) NOT NULL,
-    status      varchar(32) NOT NULL
+    id                 binary(16) PRIMARY KEY,
+    created_at         datetime(6),
+    updated_at         datetime(6),
+    user_id            binary(16) NOT NULL,
+    schedule_id        binary(16) NOT NULL,
+    status             varchar(32) NOT NULL,
+    user_checked_in_at datetime(6)
 );
 
 drop table if exists late_passes;

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
@@ -115,62 +115,65 @@ class SessionFindServiceTest @Autowired constructor(
                     .shouldBeEmpty()
             }
 
-            scenario("특정 기수의 세션이 존재하면 세션을 반환한다.") {
-                getSessionEntityFixture(generation = 4)
-                    .also { scheduleRepository.save(it) }
-
-                sessionFindService
-                    .findAttendancesHistories(4, UUID.randomUUID(), LocalDateTime.now())
-                    .shouldNotBeEmpty()
-            }
-
-            scenario("세션은 있는데 출석이 없으면 결석이다.") {
-                val session = getSessionEntityFixture(generation = 4)
-                    .also { scheduleRepository.save(it) }
-
-                val result = sessionFindService
-                    .findAttendancesHistories(
-                        4,
-                        UUID.randomUUID(),
-                        LocalDateTime.of(session.date.plusDays(1), session.time)
-                    ).first()
-
-                result.attendanceStatus shouldBe AttendanceStatus.ABSENT.label
-                result.checkedInAt.shouldBeNull()
-            }
-
-            scenario("현재 시간보다 뒷 세션은 조회되지 않는다.") {
-                val datetime = LocalDateTime.now()
-                listOf(
-                    getSessionEntityFixture(generation = 4, endDate = datetime.toLocalDate().minusDays(1)),
+            scenario("내가 참석자로 존재하는 세션만 조회된다.") {
+                val now = LocalDateTime.of(2024, 12, 14, 0, 0)
+                val user = getUserEntityFixture()
+                val sessions = listOf(
                     getSessionEntityFixture(
                         generation = 4,
-                        endDate = datetime.toLocalDate(),
-                        endTime = datetime.toLocalTime().minusSeconds(1)
+                        date = LocalDate.of(2024, 12, 12),
+                        endDate = LocalDate.of(2024, 12, 12)
                     ),
                     getSessionEntityFixture(
                         generation = 4,
-                        endDate = datetime.toLocalDate(),
-                        endTime = datetime.toLocalTime()
-                    ),
-                    getSessionEntityFixture(
-                        generation = 4,
-                        endDate = datetime.toLocalDate(),
-                        endTime = datetime.toLocalTime().plusSeconds(1)
-                    ),
-                    getSessionEntityFixture(generation = 4, endDate = datetime.toLocalDate().plusDays(1))
+                        date = LocalDate.of(2024, 12, 13),
+                        endDate = LocalDate.of(2024, 12, 13)
+                    )
                 ).also { scheduleRepository.saveAll(it) }
+                getAttendanceEntityFixture(
+                    userId = user.id,
+                    scheduleId = sessions[0].id,
+                    status = AttendanceStatus.PENDING
+                ).also { attendanceRepository.saveAndFlush(it) }
 
-                sessionFindService
-                    .findAttendancesHistories(
-                        4,
-                        UUID.randomUUID(),
-                        datetime
-                    ).shouldHaveSize(2)
-                    .forEach {
-                        it.checkedInAt.shouldBeNull()
-                        it.attendanceStatus shouldBe AttendanceStatus.ABSENT.label
+                sessionFindService.findAttendancesHistories(generation = 4, userId = user.id, now = now).let {
+                    it.shouldHaveSize(1)
+                    it[0].id shouldBe sessions[0].id
+                    it[0].attendanceStatus shouldBe AttendanceStatus.PENDING.label
+                }
+            }
+
+            scenario("종료 시간이 지나지 않은 세션에 대해, 출석을 한 경우만 노출이 된다.") {
+                val now = LocalDateTime.of(2024, 12, 12, 10, 40)
+                val user = getUserEntityFixture()
+                val sessions = listOf(
+                    getSessionEntityFixture(
+                        generation = 4,
+                        date = LocalDate.of(2024, 12, 12),
+                        time = LocalTime.of(10, 0),
+                        endDate = LocalDate.of(2024, 12, 12),
+                        endTime = LocalTime.of(11, 0)
+                    ),
+                    getSessionEntityFixture(
+                        generation = 4,
+                        date = LocalDate.of(2024, 12, 12),
+                        time = LocalTime.of(10, 0),
+                        endDate = LocalDate.of(2024, 12, 12),
+                        endTime = LocalTime.of(11, 0)
+                    )
+                ).also { scheduleRepository.saveAll(it) }
+                sessions
+                    .map { getAttendanceEntityFixture(userId = user.id, scheduleId = it.id) }
+                    .also {
+                        it[0].updateStatus(AttendanceStatus.ON_TIME)
+                        attendanceRepository.saveAllAndFlush(it)
                     }
+
+                sessionFindService.findAttendancesHistories(generation = 4, userId = user.id, now = now).let {
+                    it.shouldHaveSize(1)
+                    it[0].id shouldBe sessions[0].id
+                    it[0].attendanceStatus shouldBe AttendanceStatus.ON_TIME.label
+                }
             }
 
             scenario("출석 상태 검증") {

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
@@ -111,7 +111,7 @@ class SessionFindServiceTest @Autowired constructor(
 
             scenario("특정 기수의 세션이 존재하지 않으면 emptylist를 반환한다.") {
                 sessionFindService
-                    .findAttendancesHistory(4, UUID.randomUUID(), LocalDateTime.now())
+                    .findAttendancesHistories(4, UUID.randomUUID(), LocalDateTime.now())
                     .shouldBeEmpty()
             }
 
@@ -120,7 +120,7 @@ class SessionFindServiceTest @Autowired constructor(
                     .also { scheduleRepository.save(it) }
 
                 sessionFindService
-                    .findAttendancesHistory(4, UUID.randomUUID(), LocalDateTime.now())
+                    .findAttendancesHistories(4, UUID.randomUUID(), LocalDateTime.now())
                     .shouldNotBeEmpty()
             }
 
@@ -129,7 +129,7 @@ class SessionFindServiceTest @Autowired constructor(
                     .also { scheduleRepository.save(it) }
 
                 val result = sessionFindService
-                    .findAttendancesHistory(
+                    .findAttendancesHistories(
                         4,
                         UUID.randomUUID(),
                         LocalDateTime.of(session.date.plusDays(1), session.time)
@@ -162,7 +162,7 @@ class SessionFindServiceTest @Autowired constructor(
                 ).also { scheduleRepository.saveAll(it) }
 
                 sessionFindService
-                    .findAttendancesHistory(
+                    .findAttendancesHistories(
                         4,
                         UUID.randomUUID(),
                         datetime
@@ -197,7 +197,7 @@ class SessionFindServiceTest @Autowired constructor(
                 scheduleRepository.saveAll(sessions)
                 attendanceRepository.saveAll(attendances)
 
-                val result = sessionFindService.findAttendancesHistory(4, userId, now)
+                val result = sessionFindService.findAttendancesHistories(4, userId, now)
                 result.forEachIndexed { index, sessionWithAttendance ->
                     sessionWithAttendance.attendanceStatus shouldBe status[index].label
                 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 기존에는 해당 기수의 모든 세션을 기준으로 출석 이력을 노출하였습니다.


## ⭐️ 어떻게 해결했나요?
- 세션 참여자 기준이 생김에 따라, 세션 참여자로 지정된 세션에 대해서만 출석 기준이 노출되도록 변경하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
