### PR TITLE
feat: 공지사항의 대상 세션 설정

### DIFF
--- a/docker/docker-compose-local.yaml
+++ b/docker/docker-compose-local.yaml
@@ -8,6 +8,8 @@ services:
             MYSQL_USER: yapp
             MYSQL_PASSWORD: yapp
             MYSQL_ROOT_PASSWORD: yapp
+        volumes:
+            - yappu_mysql_data:/var/lib/mysql
         ports:
             - '3306:3306'
         restart: always
@@ -15,3 +17,6 @@ services:
             - --character-set-server=utf8mb4
             - --collation-server=utf8mb4_unicode_ci
             - --skip-character-set-client-handshake
+
+volumes:
+    yappu_mysql_data:

--- a/src/main/kotlin/co/yappuworld/post/client/application/AdminNoticeService.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/application/AdminNoticeService.kt
@@ -9,10 +9,12 @@ import co.yappuworld.post.client.dto.request.AdminNoticeUpdateRequest
 import co.yappuworld.post.client.dto.response.AdminNoticeDetailResponse
 import co.yappuworld.post.client.dto.response.AdminNoticeDetailWriterResponse
 import co.yappuworld.post.client.dto.response.AdminNoticeSummaryResponse
-import co.yappuworld.post.infrastructure.entity.NoticeEntity
+import co.yappuworld.post.client.dto.response.AdminNoticeTargetedSessionResponse
 import co.yappuworld.post.domain.PostError
 import co.yappuworld.post.infrastructure.PostCommandService
 import co.yappuworld.post.infrastructure.PostFindService
+import co.yappuworld.post.infrastructure.entity.NoticeEntity
+import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.user.infrastructure.UserFindService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,7 +24,8 @@ import java.util.UUID
 class AdminNoticeService(
     private val postFindService: PostFindService,
     private val postCommandService: PostCommandService,
-    private val userFindService: UserFindService
+    private val userFindService: UserFindService,
+    private val sessionFindService: SessionFindService
 ) {
 
     @Transactional(readOnly = true)
@@ -63,7 +66,8 @@ class AdminNoticeService(
             title = notice.title,
             content = notice.content,
             type = notice.noticeType,
-            writer = AdminNoticeDetailWriterResponse(writer)
+            writer = AdminNoticeDetailWriterResponse(writer),
+            targetSession = notice.targetSession?.let { AdminNoticeTargetedSessionResponse(it) }
         )
     }
 
@@ -78,7 +82,12 @@ class AdminNoticeService(
             contentSummary = request.plainContent.take(200),
             writerId = writerId,
             noticeType = request.type
-        ).run { postCommandService.save(this) }
+        ).also { postCommandService.save(it) }
+
+        if (request.sessionId != null) {
+            val session = sessionFindService.findSession(request.sessionId)
+            notice.targetSession(session)
+        }
 
         return notice.id
     }
@@ -94,6 +103,16 @@ class AdminNoticeService(
             contentSummary = request.plainContent.take(200),
             noticeType = request.type
         )
+
+        if (notice.targetSession?.id != request.sessionId) {
+            when (request.sessionId == null) {
+                true -> notice.detachSession()
+                false -> {
+                    val session = sessionFindService.findSession(request.sessionId)
+                    notice.targetSession(session)
+                }
+            }
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeCreateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeCreateRequest.kt
@@ -3,6 +3,7 @@ package co.yappuworld.post.client.dto.request
 import co.yappuworld.post.domain.NoticeType
 import io.swagger.v3.oas.annotations.media.Schema
 import org.hibernate.validator.constraints.Length
+import java.util.UUID
 
 data class AdminNoticeCreateRequest(
     @Schema(description = "공지 타입")
@@ -14,5 +15,7 @@ data class AdminNoticeCreateRequest(
     @field:Length(max = 5000, message = "내용은 5000자 이하여야 합니다.")
     val content: String,
     @Schema(description = "평문 형태 내용")
-    val plainContent: String
+    val plainContent: String,
+    @Schema(description = "공지사항이 대상으로 하는 세션", nullable = true)
+    val sessionId: UUID? = null
 )

--- a/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/request/AdminNoticeUpdateRequest.kt
@@ -17,5 +17,7 @@ data class AdminNoticeUpdateRequest(
     @field:Length(max = 5000, message = "내용은 5000자 이하여야 합니다.")
     val content: String,
     @Schema(description = "평문 형태 내용")
-    val plainContent: String
+    val plainContent: String,
+    @Schema(description = "공지사항이 대상으로 하는 세션", nullable = true)
+    val sessionId: UUID? = null
 )

--- a/src/main/kotlin/co/yappuworld/post/client/dto/response/AdminNoticeDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/dto/response/AdminNoticeDetailResponse.kt
@@ -1,8 +1,11 @@
 package co.yappuworld.post.client.dto.response
 
 import co.yappuworld.post.domain.NoticeType
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.user.infrastructure.entity.UserEntity
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 
 data class AdminNoticeDetailResponse(
@@ -17,7 +20,9 @@ data class AdminNoticeDetailResponse(
     @Schema(description = "공지사항 타입")
     val type: NoticeType,
     @Schema(description = "공지사항 작성자")
-    val writer: AdminNoticeDetailWriterResponse
+    val writer: AdminNoticeDetailWriterResponse,
+    @Schema(description = "공지사항의 대상 세션", nullable = true)
+    val targetSession: AdminNoticeTargetedSessionResponse?
 )
 
 data class AdminNoticeDetailWriterResponse(
@@ -27,5 +32,26 @@ data class AdminNoticeDetailWriterResponse(
     constructor(writer: UserEntity) : this(
         id = writer.id,
         name = writer.name
+    )
+}
+
+data class AdminNoticeTargetedSessionResponse(
+    @Schema(description = "세션 ID")
+    val sessionId: UUID,
+    @Schema(description = "세션 제목")
+    val title: String,
+    @Schema(description = "기수")
+    val generation: Int,
+    @Schema(description = "시작일")
+    val date: LocalDate,
+    @Schema(description = "시작 시간", nullable = false, example = "18:00:00", type = "string")
+    val time: LocalTime
+) {
+    constructor(session: SessionEntity) : this(
+        sessionId = session.id,
+        title = session.name,
+        generation = session.generation,
+        date = session.date,
+        time = session.time
     )
 }

--- a/src/main/kotlin/co/yappuworld/post/client/presentation/AdminNoticeController.kt
+++ b/src/main/kotlin/co/yappuworld/post/client/presentation/AdminNoticeController.kt
@@ -10,6 +10,7 @@ import co.yappuworld.post.client.dto.request.AdminNoticePageRequest
 import co.yappuworld.post.client.dto.request.AdminNoticeUpdateRequest
 import co.yappuworld.post.client.dto.response.AdminNoticeDetailResponse
 import co.yappuworld.post.client.dto.response.AdminNoticeSummaryResponse
+import co.yappuworld.post.domain.NoticeType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
@@ -35,12 +36,21 @@ class AdminNoticeController(
     override fun createNotice(
         securityUser: SecurityUser,
         request: AdminNoticeCreateRequest
-    ): ResponseEntity<Unit> =
-        adminNoticeService.createNotice(securityUser.userId, request).let { noticeId ->
-            ResponseEntity.created(URI.create("/admin/v1/notices/$noticeId")).build()
+    ): ResponseEntity<Unit> {
+        if (request.sessionId != null) {
+            require(request.type == NoticeType.SESSION) { "세션 공지사항만 대상 세션이 존재할 수 있습니다." }
         }
 
+        return adminNoticeService.createNotice(securityUser.userId, request).let { noticeId ->
+            ResponseEntity.created(URI.create("/admin/v1/notices/$noticeId")).build()
+        }
+    }
+
     override fun updateNotice(request: AdminNoticeUpdateRequest): ResponseEntity<Unit> {
+        if (request.sessionId != null) {
+            require(request.type == NoticeType.SESSION) { "세션 공지사항만 대상 세션이 존재할 수 있습니다." }
+        }
+
         adminNoticeService.updateNotice(request)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/co/yappuworld/post/infrastructure/entity/NoticeEntity.kt
+++ b/src/main/kotlin/co/yappuworld/post/infrastructure/entity/NoticeEntity.kt
@@ -1,10 +1,13 @@
 package co.yappuworld.post.infrastructure.entity
 
 import co.yappuworld.post.domain.NoticeType
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import java.util.UUID
 
 @Entity
@@ -21,6 +24,10 @@ class NoticeEntity(
     var noticeType: NoticeType = noticeType
         private set
 
+    @ManyToOne
+    @JoinColumn(name = "session_id")
+    var targetSession: SessionEntity? = null
+
     fun update(
         title: String,
         content: String,
@@ -31,5 +38,14 @@ class NoticeEntity(
         this.content = content
         this.contentSummary = contentSummary
         this.noticeType = noticeType
+    }
+
+    fun targetSession(session: SessionEntity) {
+        require(noticeType == NoticeType.SESSION) { "세션 공지사항만 대상 세션이 존재할 수 있습니다." }
+        this.targetSession = session
+    }
+
+    fun detachSession() {
+        this.targetSession = null
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -8,7 +8,7 @@ spring:
         compose:
             service: yappu-world-server
             enabled: true
-            lifecycle-management: start_only
+            lifecycle-management: none
             #            stop:
             #                command: down
             #                timeout: 1m
@@ -23,9 +23,9 @@ spring:
 
     sql:
         init:
-            schema-locations: classpath:schema.sql
-            data-locations: classpath:data.sql
-            mode: always
+#            schema-locations: classpath:schema.sql
+#            data-locations: classpath:data.sql
+            mode: never
 
     jpa:
         open-in-view: false

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -101,7 +101,8 @@ CREATE TABLE posts
     content_summary varchar(255),
     display_target  varchar(255),
     writer_id       binary(16) NOT NULL,
-    is_active       tinyint(1)  NOT NULL
+    is_active       tinyint(1) NOT NULL,
+    session_id      binary(16)
 );
 
 DROP TABLE IF EXISTS generations;

--- a/src/test/kotlin/co/yappuworld/post/infrastructure/PostFindServiceJdslTest.kt
+++ b/src/test/kotlin/co/yappuworld/post/infrastructure/PostFindServiceJdslTest.kt
@@ -2,7 +2,7 @@ package co.yappuworld.post.infrastructure
 
 import co.yappuworld.post.domain.NoticeType
 import co.yappuworld.support.environment.CustomDataJpaTest
-import co.yappuworld.support.fixture.PostFixture.getNoticeFixture
+import co.yappuworld.support.fixture.PostFixture.getNoticeEntityFixture
 import jakarta.persistence.EntityManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
@@ -30,8 +30,8 @@ class PostFindServiceJdslTest {
     @Test
     @Transactional
     fun `predicate 조건이 모두 주어지면 잘 조회된다`() {
-        val first = getNoticeFixture(noticeType = NoticeType.SESSION)
-        val second = getNoticeFixture(noticeType = NoticeType.SESSION)
+        val first = getNoticeEntityFixture(noticeType = NoticeType.SESSION)
+        val second = getNoticeEntityFixture(noticeType = NoticeType.SESSION)
         postRepository.saveAll(listOf(first, second))
 
         val notices = postFindService.findAllNotices(
@@ -48,18 +48,18 @@ class PostFindServiceJdslTest {
     fun `predicate 조건에 따라 조회된다`() {
         val sessions = postRepository.saveAll(
             listOf(
-                getNoticeFixture(title = "1", noticeType = NoticeType.SESSION),
-                getNoticeFixture(title = "2", noticeType = NoticeType.SESSION)
+                getNoticeEntityFixture(title = "1", noticeType = NoticeType.SESSION),
+                getNoticeEntityFixture(title = "2", noticeType = NoticeType.SESSION)
             )
         )
         val operations = postRepository.saveAll(
             listOf(
-                postRepository.save(getNoticeFixture(title = "1", noticeType = NoticeType.OPERATION)),
-                postRepository.save(getNoticeFixture(title = "2", noticeType = NoticeType.OPERATION))
+                postRepository.save(getNoticeEntityFixture(title = "1", noticeType = NoticeType.OPERATION)),
+                postRepository.save(getNoticeEntityFixture(title = "2", noticeType = NoticeType.OPERATION))
             )
         )
-        val lastSession = postRepository.save(getNoticeFixture(title = "3", noticeType = NoticeType.SESSION))
-        val lastOperation = postRepository.save(getNoticeFixture(title = "3", noticeType = NoticeType.OPERATION))
+        val lastSession = postRepository.save(getNoticeEntityFixture(title = "3", noticeType = NoticeType.SESSION))
+        val lastOperation = postRepository.save(getNoticeEntityFixture(title = "3", noticeType = NoticeType.OPERATION))
 
         entityManager.flush()
         entityManager.clear()

--- a/src/test/kotlin/co/yappuworld/support/fixture/PostFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/PostFixture.kt
@@ -1,13 +1,13 @@
 package co.yappuworld.support.fixture
 
-import co.yappuworld.post.infrastructure.entity.NoticeEntity
 import co.yappuworld.post.domain.NoticeType
+import co.yappuworld.post.infrastructure.entity.NoticeEntity
 import com.github.f4b6a3.ulid.UlidCreator
 import java.util.UUID
 
 object PostFixture {
 
-    fun getNoticeFixture(
+    fun getNoticeEntityFixture(
         title: String = "title",
         content: String = "content",
         writerId: UUID = UlidCreator.getMonotonicUlid().toUuid(),


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 공지사항과 세션의 연결성이 떨어져, 세션의 공지사항을 확인하기가 어렵습니다.


## ⭐️ 어떻게 해결했나요?
- 공지사항에서 세션을 선택할 수 있습니다.
- 공지사항은 하나의 세션만 대상으로 선택할 수 있습니다.
- 생성과 수정 시에 대상 세션을 선택할 수 있으며, 공지사항의 타입이 세션일 때만 가능합니다.

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
