### PR TITLE
feat: 세션에서 선택할 수 있는 공지사항 목록

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/util/PageUtils.kt
+++ b/src/main/kotlin/co/yappuworld/global/util/PageUtils.kt
@@ -1,0 +1,14 @@
+package co.yappuworld.global.util
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+
+object PageUtils {
+
+    fun <T : Any> Page<T?>.filterNotNull(): Page<T> =
+        PageImpl(
+            this.content.filterNotNull(),
+            this.pageable,
+            this.totalElements
+        )
+}

--- a/src/main/kotlin/co/yappuworld/post/infrastructure/PostFindService.kt
+++ b/src/main/kotlin/co/yappuworld/post/infrastructure/PostFindService.kt
@@ -1,7 +1,8 @@
 package co.yappuworld.post.infrastructure
 
-import co.yappuworld.post.infrastructure.entity.NoticeEntity
+import co.yappuworld.global.util.PageUtils.filterNotNull
 import co.yappuworld.post.domain.NoticeType
+import co.yappuworld.post.infrastructure.entity.NoticeEntity
 import co.yappuworld.post.infrastructure.entity.PostEntity
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import org.springframework.data.domain.Page
@@ -69,5 +70,28 @@ class PostFindService(
                 query.orderBy(
                     path(NoticeEntity::getId).desc()
                 )
+            }.filterNotNull()
+
+    fun findSessionNotices(
+        pageable: Pageable,
+        searchTitle: String? = null
+    ): Page<NoticeEntity> =
+        postRepository
+            .findPage(pageable) {
+                val predicates = mutableListOf<Predicate>()
+
+                predicates.add(path(NoticeEntity::noticeType).equal(NoticeType.SESSION))
+                searchTitle?.let {
+                    predicates.add(path(NoticeEntity::title).like("%$searchTitle%"))
+                }
+
+                val query = select(entity(NoticeEntity::class))
+                    .from(entity(NoticeEntity::class))
+
+                if (predicates.isNotEmpty()) {
+                    query.where(and(*predicates.toTypedArray()))
+                }
+
+                query.orderBy(path(NoticeEntity::getId).desc())
             }.filterNotNull()
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
@@ -2,14 +2,17 @@ package co.yappuworld.schedule.client.application
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.response.OffsetPageResponse
+import co.yappuworld.post.infrastructure.PostFindService
 import co.yappuworld.schedule.client.dto.request.AdminSessionCreateRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionDeleteRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionEligibleUsersParamRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionPageRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
+import co.yappuworld.schedule.client.dto.request.AdminSimpleSessionNoticePageRequest
 import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionEligibleUsersResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
+import co.yappuworld.schedule.client.dto.response.AdminTargetableSessionNoticeResponse
 import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.infrastructure.AttendanceCommandService
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
@@ -28,7 +31,8 @@ class AdminScheduleService(
     private val scheduleCommandService: ScheduleCommandService,
     private val attendanceFindService: AttendanceFindService,
     private val attendanceCommandService: AttendanceCommandService,
-    private val userFindService: UserFindService
+    private val userFindService: UserFindService,
+    private val postFindService: PostFindService
 ) {
 
     @Transactional
@@ -82,6 +86,21 @@ class AdminScheduleService(
     @Transactional(readOnly = true)
     fun getSessionEligibleUsers(request: AdminSessionEligibleUsersParamRequest): AdminSessionEligibleUsersResponse =
         AdminSessionEligibleUsersResponse.from(userFindService.findActiveUsersOfGeneration(request.generation))
+
+    @Transactional(readOnly = true)
+    fun getTargetableSessionNotices(
+        request: AdminSimpleSessionNoticePageRequest
+    ): OffsetPageResponse<AdminTargetableSessionNoticeResponse> {
+        val response = postFindService.findSessionNotices(request.toPageRequest(), request.search)
+        return OffsetPageResponse.from(response) { notice ->
+            AdminTargetableSessionNoticeResponse(
+                id = notice.id,
+                title = notice.title,
+                createdAt = notice.createdAt,
+                isSelectedByOtherSession = notice.targetSession != null
+            )
+        }
+    }
 
     private fun handleAttendee(
         session: SessionEntity,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSimpleSessionNoticePageRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSimpleSessionNoticePageRequest.kt
@@ -1,0 +1,20 @@
+package co.yappuworld.schedule.client.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+
+data class AdminSimpleSessionNoticePageRequest(
+    @field:Schema(description = "페이지 번호", required = true)
+    @field:Min(value = 1L, message = "페이지 번호는 1 이상이어야 합니다.")
+    val page: Int,
+    @field:Schema(description = "페이지 당 데이터 개수", required = true)
+    @field:Min(value = 1L, message = "페이지 당 데이터 개수는 1 이상이어야 합니다.")
+    val size: Int,
+    @field:Schema(description = "검색어", required = false, nullable = true)
+    val search: String? = null
+) {
+
+    fun toPageRequest(): PageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"))
+}

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminTargetableSessionNoticeResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminTargetableSessionNoticeResponse.kt
@@ -1,0 +1,16 @@
+package co.yappuworld.schedule.client.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class AdminTargetableSessionNoticeResponse(
+    @Schema(description = "공지 ID")
+    val id: UUID,
+    @Schema(description = "공지 제목")
+    val title: String,
+    @Schema(description = "공지 작성일시")
+    val createdAt: LocalDateTime,
+    @Schema(description = "다른 세션에서 선택한 공지사항인지 여부")
+    val isSelectedByOtherSession: Boolean
+)

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminScheduleApi.kt
@@ -8,9 +8,11 @@ import co.yappuworld.schedule.client.dto.request.AdminSessionDeleteRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionEligibleUsersParamRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionPageRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
+import co.yappuworld.schedule.client.dto.request.AdminSimpleSessionNoticePageRequest
 import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionEligibleUsersResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
+import co.yappuworld.schedule.client.dto.response.AdminTargetableSessionNoticeResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -410,4 +412,10 @@ interface AdminScheduleApi {
     fun getSessionEligibleUsers(
         @Valid @ParameterObject request: AdminSessionEligibleUsersParamRequest
     ): ResponseEntity<SuccessResponse<AdminSessionEligibleUsersResponse>>
+
+    @Operation(summary = "세션 공지사항으로 선택할 수 있는 목록 조회")
+    @GetMapping("/admin/v1/sessions/targetable-notices")
+    fun getTargetNotices(
+        @Valid @ParameterObject request: AdminSimpleSessionNoticePageRequest
+    ): ResponseEntity<SuccessResponse<OffsetPageResponse<AdminTargetableSessionNoticeResponse>>>
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminScheduleController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AdminScheduleController.kt
@@ -8,9 +8,11 @@ import co.yappuworld.schedule.client.dto.request.AdminSessionDeleteRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionEligibleUsersParamRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionPageRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
+import co.yappuworld.schedule.client.dto.request.AdminSimpleSessionNoticePageRequest
 import co.yappuworld.schedule.client.dto.response.AdminSessionDetailResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionEligibleUsersResponse
 import co.yappuworld.schedule.client.dto.response.AdminSessionOverviewResponse
+import co.yappuworld.schedule.client.dto.response.AdminTargetableSessionNoticeResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
@@ -53,5 +55,12 @@ class AdminScheduleController(
     ): ResponseEntity<SuccessResponse<AdminSessionEligibleUsersResponse>> =
         ResponseEntity.ok(
             SuccessResponse(adminScheduleService.getSessionEligibleUsers(request))
+        )
+
+    override fun getTargetNotices(
+        request: AdminSimpleSessionNoticePageRequest
+    ): ResponseEntity<SuccessResponse<OffsetPageResponse<AdminTargetableSessionNoticeResponse>>> =
+        ResponseEntity.ok(
+            SuccessResponse(adminScheduleService.getTargetableSessionNotices(request))
         )
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
@@ -1,6 +1,7 @@
 package co.yappuworld.user.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.global.util.PageUtils.filterNotNull
 import co.yappuworld.schedule.domain.Attendee
 import co.yappuworld.user.domain.model.UserWithActivityUnits
 import co.yappuworld.user.domain.vo.UserError
@@ -21,7 +22,6 @@ import com.linecorp.kotlinjdsl.support.spring.data.jpa.extension.createQuery
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.persistence.EntityManager
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -86,13 +86,7 @@ class UserFindService(
             .findPage(pageable) {
                 selectUserWithLastActivityUnit()
                     .orderBy(path(UserEntity::getId).desc())
-            }.let {
-                PageImpl(
-                    it.content.filterNotNull(),
-                    it.pageable,
-                    it.totalElements
-                )
-            }
+            }.filterNotNull()
 
     fun findUserWithActivities(userId: UUID): UserWithActivityUnits {
         val result = userRepository

--- a/src/test/kotlin/co/yappuworld/post/infrastructure/PostFindServiceJdslTest.kt
+++ b/src/test/kotlin/co/yappuworld/post/infrastructure/PostFindServiceJdslTest.kt
@@ -2,97 +2,106 @@ package co.yappuworld.post.infrastructure
 
 import co.yappuworld.post.domain.NoticeType
 import co.yappuworld.support.environment.CustomDataJpaTest
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.PostFixture.getNoticeEntityFixture
 import jakarta.persistence.EntityManager
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.annotation.Transactional
-import kotlin.test.BeforeTest
-import kotlin.test.Test
+import org.springframework.data.domain.PageRequest
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 @CustomDataJpaTest
-class PostFindServiceJdslTest {
+class PostFindServiceJdslTest @Autowired constructor(
+    private val postRepository: PostRepository,
+    private val entityManager: EntityManager
+) : CustomDataJpaTestFeatureSpec({
 
-    @Autowired
-    lateinit var postRepository: PostRepository
+        lateinit var postFindService: PostFindService
 
-    lateinit var postFindService: PostFindService
-
-    @Autowired
-    lateinit var entityManager: EntityManager
-
-    @BeforeTest
-    fun beforeEach() {
-        postFindService = PostFindService(postRepository)
-    }
-
-    @Test
-    @Transactional
-    fun `predicate 조건이 모두 주어지면 잘 조회된다`() {
-        val first = getNoticeEntityFixture(noticeType = NoticeType.SESSION)
-        val second = getNoticeEntityFixture(noticeType = NoticeType.SESSION)
-        postRepository.saveAll(listOf(first, second))
-
-        val notices = postFindService.findAllNotices(
-            limit = 10,
-            noticeType = NoticeType.SESSION,
-            lastNoticeId = second.id
-        )
-
-        assert(notices.isNotEmpty())
-        assertEquals(notices.first(), first)
-    }
-
-    @Test
-    fun `predicate 조건에 따라 조회된다`() {
-        val sessions = postRepository.saveAll(
-            listOf(
-                getNoticeEntityFixture(title = "1", noticeType = NoticeType.SESSION),
-                getNoticeEntityFixture(title = "2", noticeType = NoticeType.SESSION)
-            )
-        )
-        val operations = postRepository.saveAll(
-            listOf(
-                postRepository.save(getNoticeEntityFixture(title = "1", noticeType = NoticeType.OPERATION)),
-                postRepository.save(getNoticeEntityFixture(title = "2", noticeType = NoticeType.OPERATION))
-            )
-        )
-        val lastSession = postRepository.save(getNoticeEntityFixture(title = "3", noticeType = NoticeType.SESSION))
-        val lastOperation = postRepository.save(getNoticeEntityFixture(title = "3", noticeType = NoticeType.OPERATION))
-
-        entityManager.flush()
-        entityManager.clear()
-
-        postFindService.findAllNotices(2, NoticeType.SESSION).let {
-            assert(it.size == 2)
-            assert(it.all { n -> n.noticeType == NoticeType.SESSION })
+        beforeEach {
+            postFindService = PostFindService(postRepository)
         }
 
-        postFindService.findAllNotices(2, NoticeType.OPERATION).let {
-            assert(it.size == 2)
-            assert(it.all { n -> n.noticeType == NoticeType.OPERATION })
-        }
+        feature("공지사항 목록 조회") {
+            scenario("predicate 조건이 모두 주어지면 잘 조회된다") {
+                val first = getNoticeEntityFixture(noticeType = NoticeType.SESSION)
+                val second = getNoticeEntityFixture(noticeType = NoticeType.SESSION)
+                postRepository.saveAll(listOf(first, second))
 
-        postFindService.findAllNotices(limit = 2, lastNoticeId = lastSession.id).let {
-            val operationIds = operations.map { s -> s.id }
-            it.forEach { n ->
-                assertContains(operationIds, n.id)
+                val notices = postFindService.findAllNotices(
+                    limit = 10,
+                    noticeType = NoticeType.SESSION,
+                    lastNoticeId = second.id
+                )
+
+                assert(notices.isNotEmpty())
+                assertEquals(notices.first(), first)
+            }
+
+            scenario("predicate 조건에 따라 조회된다") {
+                val sessions = postRepository.saveAll(
+                    listOf(
+                        getNoticeEntityFixture(title = "1", noticeType = NoticeType.SESSION),
+                        getNoticeEntityFixture(title = "2", noticeType = NoticeType.SESSION)
+                    )
+                )
+                val operations = postRepository.saveAll(
+                    listOf(
+                        postRepository.save(getNoticeEntityFixture(title = "1", noticeType = NoticeType.OPERATION)),
+                        postRepository.save(getNoticeEntityFixture(title = "2", noticeType = NoticeType.OPERATION))
+                    )
+                )
+                val lastSession = postRepository.save(
+                    getNoticeEntityFixture(title = "3", noticeType = NoticeType.SESSION)
+                )
+                val lastOperation =
+                    postRepository.save(getNoticeEntityFixture(title = "3", noticeType = NoticeType.OPERATION))
+
+                entityManager.flush()
+                entityManager.clear()
+
+                postFindService.findAllNotices(2, NoticeType.SESSION).let {
+                    assert(it.size == 2)
+                    assert(it.all { n -> n.noticeType == NoticeType.SESSION })
+                }
+
+                postFindService.findAllNotices(2, NoticeType.OPERATION).let {
+                    assert(it.size == 2)
+                    assert(it.all { n -> n.noticeType == NoticeType.OPERATION })
+                }
+
+                postFindService.findAllNotices(limit = 2, lastNoticeId = lastSession.id).let {
+                    val operationIds = operations.map { s -> s.id }
+                    it.forEach { n ->
+                        assertContains(operationIds, n.id)
+                    }
+                }
+
+                postFindService.findAllNotices(2, NoticeType.SESSION, lastSession.id).let {
+                    val sessionIds = sessions.map { s -> s.id }
+                    it.forEach { n ->
+                        assertContains(sessionIds, n.id)
+                    }
+                }
+
+                postFindService.findAllNotices(2, NoticeType.OPERATION, lastOperation.id).let { notices ->
+                    val operationIds = operations.map { o -> o.id }
+                    notices.forEach { n ->
+                        assertContains(operationIds, n.id)
+                    }
+                }
             }
         }
 
-        postFindService.findAllNotices(2, NoticeType.SESSION, lastSession.id).let {
-            val sessionIds = sessions.map { s -> s.id }
-            it.forEach { n ->
-                assertContains(sessionIds, n.id)
-            }
-        }
+        feature("세션 공지사항 조회") {
+            scenario("검색어가 있는 경우 매칭되는 조건에 맞추어 검색된다.") {
+                postRepository.saveAndFlush(getNoticeEntityFixture(title = "우리 호빵맨~", noticeType = NoticeType.SESSION))
 
-        postFindService.findAllNotices(2, NoticeType.OPERATION, lastOperation.id).let { notices ->
-            val operationIds = operations.map { o -> o.id }
-            notices.forEach { n ->
-                assertContains(operationIds, n.id)
+                postFindService.findSessionNotices(PageRequest.of(0, 5), "호빵맨").let { page ->
+                    assert(page.content.isNotEmpty())
+                    assertEquals(1, page.content.size)
+                    assertEquals("우리 호빵맨~", page.content.first().title)
+                }
             }
         }
-    }
-}
+    })

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AdminScheduleServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AdminScheduleServiceTest.kt
@@ -1,10 +1,14 @@
 package co.yappuworld.schedule.client.application
 
+import co.yappuworld.post.domain.NoticeType
+import co.yappuworld.post.infrastructure.PostRepository
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
+import co.yappuworld.schedule.client.dto.request.AdminSimpleSessionNoticePageRequest
 import co.yappuworld.schedule.infrastructure.AttendanceRepository
 import co.yappuworld.schedule.infrastructure.ScheduleRepository
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.support.environment.SpringBootTestFeatureSpec
+import co.yappuworld.support.fixture.PostFixture.getNoticeEntityFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -14,6 +18,7 @@ import java.util.UUID
 class AdminScheduleServiceTest @Autowired constructor(
     private val adminScheduleService: AdminScheduleService,
     private val scheduleRepository: ScheduleRepository,
+    private val noticeRepository: PostRepository,
     private val attendanceRepository: AttendanceRepository
 ) : SpringBootTestFeatureSpec({
 
@@ -47,6 +52,21 @@ class AdminScheduleServiceTest @Autowired constructor(
                 listOf(userId2, userId3).forEach { userId ->
                     result.any { it.userId == userId } shouldBe true
                 }
+            }
+        }
+
+        feature("세션 공지사항으로 등록 가능한 공지사항 목록을 조회할 때") {
+            scenario("공지사항이 다른 세션에 등록되어 있는지 여부가 표현된다.") {
+                val otherSession = scheduleRepository.save(getSessionEntityFixture())
+                val notice = noticeRepository.saveAndFlush(
+                    getNoticeEntityFixture(noticeType = NoticeType.SESSION, targetSession = otherSession)
+                )
+
+                val result = adminScheduleService.getTargetableSessionNotices(
+                    AdminSimpleSessionNoticePageRequest(page = 1, size = 10)
+                )
+
+                result.data.single { it.id == notice.id }.isSelectedByOtherSession shouldBe true
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/support/fixture/PostFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/PostFixture.kt
@@ -2,6 +2,7 @@ package co.yappuworld.support.fixture
 
 import co.yappuworld.post.domain.NoticeType
 import co.yappuworld.post.infrastructure.entity.NoticeEntity
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import com.github.f4b6a3.ulid.UlidCreator
 import java.util.UUID
 
@@ -12,13 +13,19 @@ object PostFixture {
         content: String = "content",
         writerId: UUID = UlidCreator.getMonotonicUlid().toUuid(),
         contentSummary: String = "contentSummary",
-        noticeType: NoticeType = NoticeType.SESSION
-    ): NoticeEntity =
-        NoticeEntity(
+        noticeType: NoticeType = NoticeType.SESSION,
+        targetSession: SessionEntity? = null
+    ): NoticeEntity {
+        val notice = NoticeEntity(
             title = title,
             content = content,
             writerId = writerId,
             contentSummary = contentSummary,
             noticeType = noticeType
         )
+
+        targetSession?.let { session -> notice.targetSession(session) }
+
+        return notice
+    }
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 공지사항과 세션의 연결성이 떨어져, 세션의 공지사항을 확인하기가 어렵습니다.

## ⭐️ 어떻게 해결했나요?
- 세션에서 선택할 수 있는 공지사항 목록을 제공합니다.
- 이미 다른 세션에서 선택한 공지사항인지 노출합니다.

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
