### PR TITLE
feat: 세션에서 공지사항 연결

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/filter/PathRegistry.kt
+++ b/src/main/kotlin/co/yappuworld/global/filter/PathRegistry.kt
@@ -18,7 +18,7 @@ class PathRegistry(
         "/swagger-ui/**",
         "/health",
         "/v3/api-docs/**",
-        "/actuator/**"
+        "/actuator/prometheus"
     )
 
     @PostConstruct

--- a/src/main/kotlin/co/yappuworld/post/infrastructure/PostCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/post/infrastructure/PostCommandService.kt
@@ -12,6 +12,10 @@ class PostCommandService(
 
     fun save(post: PostEntity): PostEntity = postRepository.save(post)
 
+    fun saveAll(posts: List<PostEntity>) {
+        postRepository.saveAll(posts)
+    }
+
     fun deleteAll(posts: List<PostEntity>) {
         postRepository.deleteAll(posts)
     }

--- a/src/main/kotlin/co/yappuworld/post/infrastructure/PostFindService.kt
+++ b/src/main/kotlin/co/yappuworld/post/infrastructure/PostFindService.kt
@@ -4,6 +4,7 @@ import co.yappuworld.global.util.PageUtils.filterNotNull
 import co.yappuworld.post.domain.NoticeType
 import co.yappuworld.post.infrastructure.entity.NoticeEntity
 import co.yappuworld.post.infrastructure.entity.PostEntity
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -93,5 +94,19 @@ class PostFindService(
                 }
 
                 query.orderBy(path(NoticeEntity::getId).desc())
+            }.filterNotNull()
+
+    fun findNoticesTargetingSession(
+        noticeIds: List<UUID>,
+        sessionId: UUID
+    ): List<NoticeEntity> =
+        postRepository
+            .findAll {
+                select(entity(NoticeEntity::class))
+                    .from(entity(NoticeEntity::class))
+                    .whereOr(
+                        path(NoticeEntity::getId).`in`(noticeIds),
+                        path(NoticeEntity::targetSession)(SessionEntity::getId).equal(sessionId)
+                    )
             }.filterNotNull()
 }

--- a/src/main/kotlin/co/yappuworld/post/infrastructure/PostFindService.kt
+++ b/src/main/kotlin/co/yappuworld/post/infrastructure/PostFindService.kt
@@ -97,8 +97,8 @@ class PostFindService(
             }.filterNotNull()
 
     fun findNoticesTargetingSession(
-        noticeIds: List<UUID>,
-        sessionId: UUID
+        sessionId: UUID,
+        noticeIds: List<UUID> = emptyList()
     ): List<NoticeEntity> =
         postRepository
             .findAll {

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
@@ -2,7 +2,9 @@ package co.yappuworld.schedule.client.application
 
 import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.global.response.OffsetPageResponse
+import co.yappuworld.post.infrastructure.PostCommandService
 import co.yappuworld.post.infrastructure.PostFindService
+import co.yappuworld.post.infrastructure.entity.NoticeEntity
 import co.yappuworld.schedule.client.dto.request.AdminSessionCreateRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionDeleteRequest
 import co.yappuworld.schedule.client.dto.request.AdminSessionEligibleUsersParamRequest
@@ -32,7 +34,8 @@ class AdminScheduleService(
     private val attendanceFindService: AttendanceFindService,
     private val attendanceCommandService: AttendanceCommandService,
     private val userFindService: UserFindService,
-    private val postFindService: PostFindService
+    private val postFindService: PostFindService,
+    private val postCommandService: PostCommandService
 ) {
 
     @Transactional
@@ -40,10 +43,10 @@ class AdminScheduleService(
         val schedule = request.toDomain()
         scheduleCommandService.save(schedule)
 
-        request.sessionAttendeeIds
-            .takeIf { it.isNotEmpty() }
-            ?.map { attendeeId -> AttendanceEntity(userId = attendeeId, scheduleId = schedule.id) }
-            ?.also { attendanceCommandService.saveAll(it) }
+        createAttendance(request.sessionAttendeeIds, schedule.id)
+        if (schedule is SessionEntity) {
+            linkSessionAndNotice(request.noticeIds, schedule)
+        }
 
         return schedule.id
     }
@@ -81,6 +84,7 @@ class AdminScheduleService(
         val session = sessionFindService.findSession(request.id)
         request.applyTo(session)
         handleAttendee(session, request.sessionAttendeeIds)
+        adjustLinkBetweenSessionAndNotice(request.noticeIds, session)
     }
 
     @Transactional(readOnly = true)
@@ -102,6 +106,30 @@ class AdminScheduleService(
         }
     }
 
+    private fun createAttendance(
+        attendeeIds: List<UUID>,
+        scheduleId: UUID
+    ) {
+        attendeeIds
+            .takeIf { it.isNotEmpty() }
+            ?.map { attendeeId -> AttendanceEntity(userId = attendeeId, scheduleId = scheduleId) }
+            ?.also { attendanceCommandService.saveAll(it) }
+    }
+
+    private fun linkSessionAndNotice(
+        noticeIds: List<UUID>,
+        session: SessionEntity
+    ) {
+        val notices = postFindService.findAllByIdIn(noticeIds)
+
+        if (notices.any { it !is NoticeEntity }) {
+            throw BusinessException(ScheduleError.NOT_SESSION_NOTICE)
+        }
+
+        notices.filterIsInstance<NoticeEntity>().onEach { notice -> notice.targetSession(session) }
+        postCommandService.saveAll(notices)
+    }
+
     private fun handleAttendee(
         session: SessionEntity,
         requestSessionAttendeeIds: List<UUID>
@@ -119,5 +147,20 @@ class AdminScheduleService(
             .filterNot { attendance -> attendance.userId in requestSessionAttendeeIds }
 
         if (toDelete.isNotEmpty()) attendanceCommandService.deleteAll(toDelete)
+    }
+
+    private fun adjustLinkBetweenSessionAndNotice(
+        noticeIds: List<UUID>,
+        session: SessionEntity
+    ) {
+        val notices = postFindService.findNoticesTargetingSession(noticeIds, session.id)
+        notices.onEach { notice ->
+            when (notice.id in noticeIds) {
+                true -> notice.targetSession(session)
+                false -> notice.detachSession()
+            }
+        }
+
+        postCommandService.saveAll(notices)
     }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
@@ -60,9 +60,10 @@ class AdminScheduleService(
 
     @Transactional(readOnly = true)
     fun getSession(id: UUID): AdminSessionDetailResponse =
-        AdminSessionDetailResponse(
+        AdminSessionDetailResponse.from(
             session = sessionFindService.findSession(id),
-            attendees = attendanceFindService.findAttendees(id)
+            attendees = attendanceFindService.findAttendees(id),
+            notices = postFindService.findNoticesTargetingSession(id)
         )
 
     /**
@@ -153,7 +154,7 @@ class AdminScheduleService(
         noticeIds: List<UUID>,
         session: SessionEntity
     ) {
-        val notices = postFindService.findNoticesTargetingSession(noticeIds, session.id)
+        val notices = postFindService.findNoticesTargetingSession(session.id, noticeIds)
         notices.onEach { notice ->
             when (notice.id in noticeIds) {
                 true -> notice.targetSession(session)

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionCreateRequest.kt
@@ -35,7 +35,9 @@ data class AdminSessionCreateRequest(
     @Schema(description = "세션 종류", nullable = false, example = "OFFLINE")
     var sessionType: SessionType,
     @Schema(description = "세션 참석자 ID", nullable = false)
-    val sessionAttendeeIds: List<UUID>
+    val sessionAttendeeIds: List<UUID>,
+    @Schema(description = "세션 공지사항 ID", nullable = false)
+    val noticeIds: List<UUID>
 ) {
 
     fun toDomain(): ScheduleEntity =

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSessionUpdateRequest.kt
@@ -27,7 +27,9 @@ data class AdminSessionUpdateRequest(
     @Schema(description = "세션 종류", example = "OFFLINE")
     val sessionType: SessionType,
     @Schema(description = "세션 참석자 ID", nullable = false)
-    val sessionAttendeeIds: List<UUID>
+    val sessionAttendeeIds: List<UUID>,
+    @Schema(description = "세션 공지사항 ID", nullable = false)
+    val noticeIds: List<UUID>
 ) {
 
     fun applyTo(session: SessionEntity) {

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AdminSessionDetailResponse.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.schedule.client.dto.response
 
+import co.yappuworld.post.infrastructure.entity.NoticeEntity
 import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.dto.SessionAttendeeDto
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
@@ -28,41 +29,58 @@ data class AdminSessionDetailResponse(
     val endTime: LocalTime,
     @Schema(description = "세션 타입")
     val sessionType: SessionType,
-    val attendees: List<AdminSessionAttendeeByPositionResponse>
+    @Schema(description = "세션 참가자 목록")
+    val attendees: List<AdminSessionAttendeeByPositionResponse>,
+    @Schema(description = "세션 공지사항 목록")
+    val notices: List<AdminSessionNoticeResponse>
 ) {
 
-    constructor(session: SessionEntity, attendees: List<SessionAttendeeDto>) : this(
-        id = session.id,
-        name = session.name,
-        generation = session.generation,
-        place = session.place,
-        date = session.date,
-        endDate = session.endDate,
-        time = session.time,
-        endTime = session.endTime,
-        sessionType = session.sessionType,
-        attendees = attendees
-            .groupBy { it.position }
-            .let { attendeesGroupByPosition ->
-                Position.activeUserPositions.map { position ->
-                    AdminSessionAttendeeByPositionResponse(
-                        position = position,
-                        attendees = attendeesGroupByPosition[position]?.map { AdminSessionAttendeeResponse(it) }
-                            ?: emptyList()
-                    )
-                }
-            }.sortedBy { it.position.ordinal }
-    )
+    companion object {
+
+        fun from(
+            session: SessionEntity,
+            attendees: List<SessionAttendeeDto>,
+            notices: List<NoticeEntity>
+        ): AdminSessionDetailResponse =
+            AdminSessionDetailResponse(
+                id = session.id,
+                name = session.name,
+                generation = session.generation,
+                place = session.place,
+                date = session.date,
+                endDate = session.endDate,
+                time = session.time,
+                endTime = session.endTime,
+                sessionType = session.sessionType,
+                attendees = attendees
+                    .groupBy { it.position }
+                    .let { attendeesGroupByPosition ->
+                        Position.activeUserPositions.map { position ->
+                            AdminSessionAttendeeByPositionResponse(
+                                position = position,
+                                attendees = attendeesGroupByPosition[position]?.map { AdminSessionAttendeeResponse(it) }
+                                    ?: emptyList()
+                            )
+                        }
+                    }.sortedBy { it.position.ordinal },
+                notices = notices.map { n -> AdminSessionNoticeResponse(n.id, n.title) }
+            )
+    }
 }
 
 data class AdminSessionAttendeeByPositionResponse(
+    @Schema(description = "참석자 직군")
     val position: Position,
+    @Schema(description = "직군 내 참석자 목록")
     val attendees: List<AdminSessionAttendeeResponse>
 )
 
 data class AdminSessionAttendeeResponse(
+    @Schema(description = "참석자 ID")
     val userId: UUID,
+    @Schema(description = "참석자 이름")
     val name: String,
+    @Schema(description = "참석자 직군")
     val position: Position
 ) {
 
@@ -72,3 +90,10 @@ data class AdminSessionAttendeeResponse(
         position = attendee.position
     )
 }
+
+data class AdminSessionNoticeResponse(
+    @Schema(description = "공지사항 ID")
+    val noticeId: UUID,
+    @Schema(description = "공지사항 제목")
+    val title: String
+)

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionOverviewResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionOverviewResponse.kt
@@ -8,6 +8,7 @@ import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.user.domain.model.UserWithActivityUnits
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -102,6 +103,7 @@ data class SessionOverviewItemResponse(
     val attendanceStatus: String?
 ) {
 
+    @JsonIgnore
     val scheduleProgressPhase = ScheduleProgressPhase.entries.single { it.label == progressPhase }
 
     companion object {

--- a/src/main/kotlin/co/yappuworld/schedule/domain/Attendee.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/Attendee.kt
@@ -7,7 +7,10 @@ import co.yappuworld.user.domain.model.UserWithActivityUnits
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.model.UserWithActivityUnit
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.UUID
+
+private val logger = KotlinLogging.logger { }
 
 class Attendee(
     val id: UUID,
@@ -22,7 +25,7 @@ class Attendee(
             userWithActivityUnit: UserWithActivityUnit,
             generation: Int
         ): Attendee {
-            checkRole(userWithActivityUnit.role)
+            checkRole(userWithActivityUnit.userId, userWithActivityUnit.role)
             checkActivityUnit(userWithActivityUnit.getActivityUnit(), generation)
 
             return Attendee(
@@ -37,7 +40,7 @@ class Attendee(
             userWithActivityUnits: UserWithActivityUnits,
             generation: Int
         ): Attendee {
-            checkRole(userWithActivityUnits.role)
+            checkRole(userWithActivityUnits.id, userWithActivityUnits.role)
 
             val sessionGenerationActivityUnits = userWithActivityUnits.activityUnits
                 .filter { it.generation == generation }
@@ -60,8 +63,12 @@ class Attendee(
             )
         }
 
-        private fun checkRole(role: UserRole) {
+        private fun checkRole(
+            id: UUID,
+            role: UserRole
+        ) {
             if (role !in listOf(UserRole.ACTIVE, UserRole.STAFF)) {
+                logger.warn { "Role $role is not in a valid user with id $id" }
                 throw BusinessException(AttendanceError.UNAUTHORIZED_CHECK_IN)
             }
         }

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/ScheduleError.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/ScheduleError.kt
@@ -42,5 +42,12 @@ enum class ScheduleError : Error {
         override val message: String = "시작 시간이 종료 시간보다 늦을 수 없습니다."
         override val code: String = "SCH_4000"
         override val type: ErrorType = ErrorType.WRONG_ARGUMENT
+    },
+
+    // 5000번대 - 세션 공지사항
+    NOT_SESSION_NOTICE {
+        override val message: String = "세션 공지사항이 아닙니다."
+        override val code: String = "SCH_5000"
+        override val type: ErrorType = ErrorType.BAD_REQUEST
     }
 }

--- a/src/test/kotlin/co/yappuworld/post/infrastructure/PostFindServiceJdslTest.kt
+++ b/src/test/kotlin/co/yappuworld/post/infrastructure/PostFindServiceJdslTest.kt
@@ -1,9 +1,13 @@
 package co.yappuworld.post.infrastructure
 
 import co.yappuworld.post.domain.NoticeType
+import co.yappuworld.schedule.infrastructure.ScheduleRepository
 import co.yappuworld.support.environment.CustomDataJpaTest
 import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.PostFixture.getNoticeEntityFixture
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldNotBe
 import jakarta.persistence.EntityManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageRequest
@@ -13,6 +17,7 @@ import kotlin.test.assertEquals
 @CustomDataJpaTest
 class PostFindServiceJdslTest @Autowired constructor(
     private val postRepository: PostRepository,
+    private val scheduleRepository: ScheduleRepository,
     private val entityManager: EntityManager
 ) : CustomDataJpaTestFeatureSpec({
 
@@ -102,6 +107,21 @@ class PostFindServiceJdslTest @Autowired constructor(
                     assertEquals(1, page.content.size)
                     assertEquals("우리 호빵맨~", page.content.first().title)
                 }
+            }
+
+            scenario("세션 ID만으로 조회 된다.") {
+                val session = scheduleRepository.save(getSessionEntityFixture())
+                val notice = postRepository.saveAndFlush(
+                    getNoticeEntityFixture(
+                        title = "우리 호빵맨~",
+                        noticeType = NoticeType.SESSION,
+                        targetSession = session
+                    )
+                )
+
+                val result = postFindService.findNoticesTargetingSession(sessionId = session.id)
+                result shouldHaveSize 1
+                result.first().id shouldNotBe session.id
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AdminScheduleServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AdminScheduleServiceTest.kt
@@ -2,6 +2,7 @@ package co.yappuworld.schedule.client.application
 
 import co.yappuworld.post.domain.NoticeType
 import co.yappuworld.post.infrastructure.PostRepository
+import co.yappuworld.post.infrastructure.entity.NoticeEntity
 import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
 import co.yappuworld.schedule.client.dto.request.AdminSimpleSessionNoticePageRequest
 import co.yappuworld.schedule.infrastructure.AttendanceRepository
@@ -9,7 +10,9 @@ import co.yappuworld.schedule.infrastructure.ScheduleRepository
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.support.environment.SpringBootTestFeatureSpec
 import co.yappuworld.support.fixture.PostFixture.getNoticeEntityFixture
+import co.yappuworld.support.fixture.ScheduleDtoFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import io.kotest.inspectors.shouldForAll
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
@@ -43,7 +46,8 @@ class AdminScheduleServiceTest @Autowired constructor(
                     time = session.time,
                     endTime = session.endTime,
                     sessionType = session.sessionType,
-                    sessionAttendeeIds = listOf(userId2, userId3)
+                    sessionAttendeeIds = listOf(userId2, userId3),
+                    noticeIds = emptyList()
                 )
                 adminScheduleService.updateSession(request)
 
@@ -52,6 +56,29 @@ class AdminScheduleServiceTest @Autowired constructor(
                 listOf(userId2, userId3).forEach { userId ->
                     result.any { it.userId == userId } shouldBe true
                 }
+            }
+
+            scenario("공지사항 연결이 변경된다.") {
+                val session = scheduleRepository.saveAndFlush(getSessionEntityFixture())
+                val linkedNotices = noticeRepository.saveAllAndFlush(
+                    listOf(
+                        getNoticeEntityFixture(noticeType = NoticeType.SESSION, targetSession = session),
+                        getNoticeEntityFixture(noticeType = NoticeType.SESSION, targetSession = session)
+                    )
+                )
+                val newNotice = noticeRepository.saveAndFlush(getNoticeEntityFixture(noticeType = NoticeType.SESSION))
+
+                val request = ScheduleDtoFixture.getAdminSessionUpdateRequestFixture(
+                    id = session.id,
+                    noticeIds = listOf(linkedNotices[0].id, newNotice.id)
+                )
+                adminScheduleService.updateSession(request)
+
+                val notices = noticeRepository.findAllByIdIn(linkedNotices.map { it.id } + newNotice.id)
+                (notices.single { it.id == linkedNotices[1].id } as NoticeEntity).targetSession shouldBe null
+                notices
+                    .filter { it.id != linkedNotices[1].id }
+                    .shouldForAll { (it as NoticeEntity).targetSession?.id shouldBe session.id }
             }
         }
 

--- a/src/test/kotlin/co/yappuworld/support/fixture/ScheduleDtoFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/ScheduleDtoFixture.kt
@@ -1,6 +1,7 @@
 package co.yappuworld.support.fixture
 
 import co.yappuworld.schedule.client.dto.request.AdminSessionCreateRequest
+import co.yappuworld.schedule.client.dto.request.AdminSessionUpdateRequest
 import co.yappuworld.schedule.domain.vo.ScheduleType
 import co.yappuworld.schedule.domain.vo.SessionType
 import java.time.LocalDate
@@ -20,7 +21,8 @@ object ScheduleDtoFixture {
         generation: Int = 25,
         type: ScheduleType = ScheduleType.SESSION,
         sessionType: SessionType = SessionType.OFFLINE,
-        attendeeIds: List<UUID> = listOf(UUID.randomUUID())
+        attendeeIds: List<UUID> = emptyList(),
+        noticeIds: List<UUID> = emptyList()
     ): AdminSessionCreateRequest =
         AdminSessionCreateRequest(
             name = name,
@@ -33,6 +35,33 @@ object ScheduleDtoFixture {
             generation = generation,
             type = type,
             sessionType = sessionType,
-            sessionAttendeeIds = attendeeIds
+            sessionAttendeeIds = attendeeIds,
+            noticeIds = noticeIds
         )
+
+    fun getAdminSessionUpdateRequestFixture(
+        id: UUID = UUID.randomUUID(),
+        name: String = "name",
+        generation: Int = 25,
+        place: String = "장소",
+        date: LocalDate = LocalDate.of(2024, 12, 12),
+        endDate: LocalDate = LocalDate.of(2024, 12, 12),
+        time: LocalTime = LocalTime.of(10, 0),
+        endTime: LocalTime = LocalTime.of(11, 0),
+        sessionType: SessionType = SessionType.ONLINE,
+        sessionAttendeeIds: List<UUID> = emptyList(),
+        noticeIds: List<UUID> = emptyList()
+    ) = AdminSessionUpdateRequest(
+        id = id,
+        name = name,
+        generation = generation,
+        place = place,
+        date = date,
+        endDate = endDate,
+        time = time,
+        endTime = endTime,
+        sessionType = sessionType,
+        sessionAttendeeIds = sessionAttendeeIds,
+        noticeIds = noticeIds
+    )
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 세션과 공지사항의 연결성을 추가합니다.


## ⭐️ 어떻게 해결했나요?
- 세션 생성 및 수정 시에 공지사항을 선택할 수 있습니다.
- 세션 하나에 공지사항은 여러개가 등록 될 수 있다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
