### PR TITLE
feat: 활동 기수 세션 목록 조회

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -5,6 +5,7 @@ import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
 import co.yappuworld.schedule.client.dto.request.SessionParamRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
+import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponseV2
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.SessionOverviewResponse
 import co.yappuworld.schedule.client.dto.response.UpcomingSessionAttendanceResponse
@@ -57,6 +58,20 @@ class ScheduleService(
             ?: return ActiveGenerationSessionsResponse.from(emptyList(), now)
         val sessions = sessionFindService.findSessionsWithAttendanceStatus(currentGeneration, userId, now)
         return ActiveGenerationSessionsResponse.from(
+            sessions = sessions,
+            now = now
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getActiveGenerationSessions(
+        userId: UUID,
+        now: LocalDateTime
+    ): ActiveGenerationSessionsResponseV2 {
+        val currentGeneration = generationFindService.findActiveGenerationOrNull()
+            ?: return ActiveGenerationSessionsResponseV2.from(emptyList(), now)
+        val sessions = sessionFindService.findSessionsWithAttendanceStatus(currentGeneration, userId, now)
+        return ActiveGenerationSessionsResponseV2.from(
             sessions = sessions,
             now = now
         )

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponseV2.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponseV2.kt
@@ -1,6 +1,7 @@
 package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.global.util.DatetimeUtils.korean
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase.DONE
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase.PENDING
@@ -14,9 +15,9 @@ import java.time.LocalTime
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
-data class ActiveGenerationSessionsResponse(
+data class ActiveGenerationSessionsResponseV2(
     @Schema(description = "활동 중인 기수의 세션 목록, 데이터가 없다면 빈 리스트 반환")
-    val sessions: List<ActiveGenerationSessionResponse>,
+    val sessions: List<ActiveGenerationSessionResponseV2>,
     @Schema(
         description = """
             가장 가까이 예정된 세션의 인덱스
@@ -32,22 +33,22 @@ data class ActiveGenerationSessionsResponse(
         fun from(
             sessions: List<SessionWithAttendanceDto>,
             now: LocalDateTime
-        ): ActiveGenerationSessionsResponse {
-            if (sessions.isEmpty()) return ActiveGenerationSessionsResponse(emptyList(), null)
+        ): ActiveGenerationSessionsResponseV2 {
+            if (sessions.isEmpty()) return ActiveGenerationSessionsResponseV2(emptyList(), null)
 
             val orderedSessions = sessions.sortedWith(compareBy({ it.date }, { it.time }))
             val (upcomingSessionIndex, upcomingSessionStatus) = getUpcomingSessionIndexAndStatus(orderedSessions, now)
-                ?: return ActiveGenerationSessionsResponse(
-                    orderedSessions.map { ActiveGenerationSessionResponse(it, DONE, now) },
+                ?: return ActiveGenerationSessionsResponseV2(
+                    orderedSessions.map { ActiveGenerationSessionResponseV2(it, DONE, now) },
                     orderedSessions.last().id
                 )
 
-            return ActiveGenerationSessionsResponse(
+            return ActiveGenerationSessionsResponseV2(
                 sessions = orderedSessions.mapIndexed { index, session ->
                     when {
-                        index < upcomingSessionIndex -> ActiveGenerationSessionResponse(session, DONE, now)
-                        index > upcomingSessionIndex -> ActiveGenerationSessionResponse(session, PENDING, now)
-                        else -> ActiveGenerationSessionResponse(session, upcomingSessionStatus, now)
+                        index < upcomingSessionIndex -> ActiveGenerationSessionResponseV2(session, DONE, now)
+                        index > upcomingSessionIndex -> ActiveGenerationSessionResponseV2(session, PENDING, now)
+                        else -> ActiveGenerationSessionResponseV2(session, upcomingSessionStatus, now)
                     }
                 },
                 upcomingSessionId = orderedSessions[upcomingSessionIndex].id
@@ -70,7 +71,7 @@ data class ActiveGenerationSessionsResponse(
     }
 }
 
-data class ActiveGenerationSessionResponse(
+data class ActiveGenerationSessionResponseV2(
     @Schema(description = "세션 식별자")
     val id: UUID,
     @Schema(description = "세션 이름")
@@ -102,8 +103,8 @@ data class ActiveGenerationSessionResponse(
     val type: SessionType,
     @Schema(description = "세션 진행 상태")
     val progressPhase: SessionProgressPhase,
-    @Schema(description = "출석 상태", nullable = true, allowableValues = ["출석", "지각", "결석", "조퇴", "공결"])
-    val attendanceStatus: String?
+    @Schema(description = "출석 상태", nullable = true)
+    val attendanceStatus: AttendanceStatus?
 ) {
 
     constructor(
@@ -123,6 +124,6 @@ data class ActiveGenerationSessionResponse(
         endTime = session.endTime,
         type = session.sessionType,
         progressPhase = status,
-        attendanceStatus = session.attendanceStatus
+        attendanceStatus = session.attendanceStatusType
     )
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ActiveGenerationSessionApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ActiveGenerationSessionApi.kt
@@ -1,0 +1,81 @@
+package co.yappuworld.schedule.client.presentation
+
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.global.security.SecurityUser
+import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponseV2
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+
+@Tag(name = "활동 기수 세션 API", description = "현재 활성화 된 기수의 세션 API")
+interface ActiveGenerationSessionApi {
+
+    @Operation(summary = "현재 활성화 된 기수의 세션 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "활동 중인 기수의 세션 목록 (25년 4월 29일 기준)",
+                                value = """
+                                    {
+                                        "data": {
+                                            "sessions": [
+                                                {
+                                                    "id": "c07aa77e-1b30-11f0-add0-0242ac140002",
+                                                    "name": "가짜 세션1",
+                                                    "place": "아몰랑",
+                                                    "date": "2025-04-18",
+                                                    "startDayOfWeek": "금",
+                                                    "endDate": "2025-04-18",
+                                                    "endDayOfWeek": "금",
+                                                    "relativeDays": 11,
+                                                    "time": "13:30:00",
+                                                    "endTime": "17:00:00",
+                                                    "type": "OFFLINE",
+                                                    "progressPhase": "DONE",
+                                                    "attendanceStatus": "결석"
+                                                },
+                                                {
+                                                    "id": "c07afa8b-1b30-11f0-add0-0242ac140002",
+                                                    "name": "가짜 세션2",
+                                                    "place": "아몰랑",
+                                                    "date": "2025-05-08",
+                                                    "startDayOfWeek": "목",
+                                                    "endDate": "2025-05-08",
+                                                    "endDayOfWeek": "목",
+                                                    "relativeDays": -9,
+                                                    "time": "13:30:00",
+                                                    "endTime": "17:00:00",
+                                                    "type": "OFFLINE",
+                                                    "progressPhase": "PENDING",
+                                                    "attendanceStatus": null
+                                                }
+                                            ],
+                                            "upcomingSessionId": "c07afa8b-1b30-11f0-add0-0242ac140002"
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/v1/active-generation/sessions")
+    fun getActiveGenerationSessions(
+        @AuthenticationPrincipal securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<ActiveGenerationSessionsResponseV2>>
+}

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ActiveGenerationSessionController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ActiveGenerationSessionController.kt
@@ -1,0 +1,27 @@
+package co.yappuworld.schedule.client.presentation
+
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.global.security.SecurityUser
+import co.yappuworld.global.util.DatetimeUtils
+import co.yappuworld.schedule.client.application.ScheduleService
+import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponseV2
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ActiveGenerationSessionController(
+    private val scheduleService: ScheduleService
+) : ActiveGenerationSessionApi {
+
+    override fun getActiveGenerationSessions(
+        securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<ActiveGenerationSessionsResponseV2>> =
+        ResponseEntity.ok(
+            SuccessResponse(
+                scheduleService.getActiveGenerationSessions(
+                    securityUser.userId,
+                    DatetimeUtils.getCurrentDateTimeInKST()
+                )
+            )
+        )
+}

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/SessionProgressPhase.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/SessionProgressPhase.kt
@@ -5,6 +5,5 @@ enum class SessionProgressPhase(
 ) {
     DONE("완료"),
     TODAY("당일"),
-    UPCOMING("임박"),
     PENDING("예정")
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
@@ -26,6 +26,8 @@ class SessionWithAttendanceDto(
     var attendanceStatus: String? = attendanceStatus?.label
         private set
 
+    val attendanceStatusType: AttendanceStatus? = attendanceStatus
+
     fun resolveAttendanceStatusOfPastSessions(now: LocalDateTime) {
         if (attendanceStatus == null && isFinished(now)) {
             attendanceStatus = AttendanceStatus.ABSENT.label


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
기존에 /v1/sessions에서 제공하던 기능에서 enum 관련 변경 사항이 생김
버전 호환성 보장 필요

## ⭐️ 어떻게 해결했나요?
/v1/sessions가 활동 기수를, /v2/sessions가 전체 세션에 대한 내용을 다루게 되면서
/v1/sessions에서 처리하던 내용을 /v1/active-generation/sessions로 변경

추후, 활동 기수 관련 API는 active-generation 하위로 변경

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
