### PR TITLE
feat: 공지사항의 대상 세션 설정 (#160)

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminScheduleService.kt
@@ -105,11 +105,12 @@ class AdminScheduleService(
     ): OffsetPageResponse<AdminTargetableSessionNoticeResponse> {
         val response = postFindService.findSessionNotices(request.toPageRequest(), request.search)
         return OffsetPageResponse.from(response) { notice ->
+            val isSelectedByOtherSession = notice.targetSession != null && notice.targetSession?.id != request.sessionId
             AdminTargetableSessionNoticeResponse(
                 id = notice.id,
                 title = notice.title,
                 createdAt = notice.createdAt,
-                isSelectedByOtherSession = notice.targetSession != null
+                isSelectedByOtherSession = isSelectedByOtherSession
             )
         }
     }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSimpleSessionNoticePageRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminSimpleSessionNoticePageRequest.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import java.util.UUID
 
 data class AdminSimpleSessionNoticePageRequest(
     @field:Schema(description = "페이지 번호", required = true)
@@ -12,6 +13,8 @@ data class AdminSimpleSessionNoticePageRequest(
     @field:Schema(description = "페이지 당 데이터 개수", required = true)
     @field:Min(value = 1L, message = "페이지 당 데이터 개수는 1 이상이어야 합니다.")
     val size: Int,
+    @field:Schema(description = "세션 ID", required = true)
+    val sessionId: UUID? = null,
     @field:Schema(description = "검색어", required = false, nullable = true)
     val search: String? = null
 ) {

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AdminScheduleServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AdminScheduleServiceTest.kt
@@ -95,5 +95,18 @@ class AdminScheduleServiceTest @Autowired constructor(
 
                 result.data.single { it.id == notice.id }.isSelectedByOtherSession shouldBe true
             }
+
+            scenario("본인 세션에 등록된 공지사항은 선택 불가로 표현되지 않는다.") {
+                val session = scheduleRepository.save(getSessionEntityFixture())
+                val notice = noticeRepository.saveAndFlush(
+                    getNoticeEntityFixture(noticeType = NoticeType.SESSION, targetSession = session)
+                )
+
+                val result = adminScheduleService.getTargetableSessionNotices(
+                    AdminSimpleSessionNoticePageRequest(page = 1, size = 10, sessionId = session.id)
+                )
+
+                result.data.single { it.id == notice.id }.isSelectedByOtherSession shouldBe false
+            }
         }
     })


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 세션에서 공지사항을 선택할 때, 작업하는 세션에서 기등록한 공지사항은 선택이 비활성화 되는 문제가 있습니다.
- 사진 상 체크된 두 공지사항 모두, 해당 세션에서 선택한 공지사항
<img width="668" height="641" alt="image" src="https://github.com/user-attachments/assets/e2a1ada8-bcff-4047-ad32-2d29269568ee" />


## ⭐️ 어떻게 해결했나요?
- 요청 시 세션 ID를 파라미터로 넘겨받아, 공지사항의 대상 세션 ID와 일치하는 경우 false를 반환하도록 처리하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료
<img width="325" height="396" alt="image" src="https://github.com/user-attachments/assets/2b0e7897-6c6e-41ee-a72f-4dd98ba1319a" />



## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
