### PR TITLE
refactor: 세션 상세 API 일시 필드 ISO 8601 표준으로 변경

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -10,6 +10,7 @@ import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsRespon
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.SessionDetailsNoticeResponse
 import co.yappuworld.schedule.client.dto.response.SessionDetailsResponse
+import co.yappuworld.schedule.client.dto.response.SessionDetailsResponseV2
 import co.yappuworld.schedule.client.dto.response.SessionOverviewResponse
 import co.yappuworld.schedule.client.dto.response.UpcomingSessionResponse
 import co.yappuworld.schedule.domain.vo.ScheduleError
@@ -140,6 +141,27 @@ class ScheduleService(
         }
 
         return SessionDetailsResponse.of(
+            session = session,
+            notices = notices,
+            writers = writers,
+            now = now
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun findSessionDetailsV2(
+        sessionId: UUID,
+        now: LocalDateTime
+    ): SessionDetailsResponseV2 {
+        val session = sessionFindService.findSession(sessionId)
+        val notices = postFindService.findNoticesTargetingSession(sessionId)
+        val writerIds = notices.map { it.writerId }.distinct()
+        val writers = when {
+            writerIds.isEmpty() -> emptyMap()
+            else -> userFindService.findAllUserWithLastActivityUnit(writerIds).associateBy { it.userId }
+        }
+
+        return SessionDetailsResponseV2.of(
             session = session,
             notices = notices,
             writers = writers,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionDetailsResponseV2.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionDetailsResponseV2.kt
@@ -17,11 +17,11 @@ data class SessionDetailsResponseV2(
     val progressPhase: SessionProgressPhase,
     @field:Schema(description = "세션 제목", example = "개발 세션")
     val title: String,
-    @field:Schema(description = "세션 시작 일시", example = "2024-01-01T09:00:00+09:00")
+    @field:Schema(description = "세션 시작 일시", example = "2024-01-01T09:00:00")
     val startDateTime: LocalDateTime,
     @field:Schema(description = "시작 요일", example = "월")
     val startDayOfWeek: String,
-    @field:Schema(description = "세션 종료 일시", example = "2024-12-31T18:00:00+09:00")
+    @field:Schema(description = "세션 종료 일시", example = "2024-12-31T18:00:00")
     val endDateTime: LocalDateTime,
     @field:Schema(description = "종료 요일", example = "토")
     val endDayOfWeek: String,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionDetailsResponseV2.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionDetailsResponseV2.kt
@@ -8,6 +8,8 @@ import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.user.infrastructure.model.UserWithLastActivityUnit
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.util.UUID
 
 data class SessionDetailsResponseV2(
@@ -18,11 +20,11 @@ data class SessionDetailsResponseV2(
     @field:Schema(description = "세션 제목", example = "개발 세션")
     val title: String,
     @field:Schema(description = "세션 시작 일시", example = "2024-01-01T09:00:00+09:00")
-    val startDateTime: LocalDateTime,
+    val startDateTime: ZonedDateTime,
     @field:Schema(description = "시작 요일", example = "월")
     val startDayOfWeek: String,
     @field:Schema(description = "세션 종료 일시", example = "2024-12-31T18:00:00+09:00")
-    val endDateTime: LocalDateTime,
+    val endDateTime: ZonedDateTime,
     @field:Schema(description = "종료 요일", example = "토")
     val endDayOfWeek: String,
     @field:Schema(description = "장소 이름", nullable = true)
@@ -47,9 +49,9 @@ data class SessionDetailsResponseV2(
                 id = session.id,
                 progressPhase = session.getSessionProgressPhase(now),
                 title = session.name,
-                startDateTime = LocalDateTime.of(session.date, session.time),
+                startDateTime = LocalDateTime.of(session.date, session.time).atZone(ZoneId.of("Asia/Seoul")),
                 startDayOfWeek = session.startDayOfWeek,
-                endDateTime = LocalDateTime.of(session.endDate, session.endTime),
+                endDateTime = LocalDateTime.of(session.endDate, session.endTime).atZone(ZoneId.of("Asia/Seoul")),
                 endDayOfWeek = session.endDayOfWeek,
                 place = session.place,
                 address = session.address,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionDetailsResponseV2.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionDetailsResponseV2.kt
@@ -1,0 +1,65 @@
+package co.yappuworld.schedule.client.dto.response
+
+import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.post.infrastructure.entity.NoticeEntity
+import co.yappuworld.schedule.domain.vo.ScheduleError
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import co.yappuworld.user.infrastructure.model.UserWithLastActivityUnit
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class SessionDetailsResponseV2(
+    @field:Schema(description = "세션 ID")
+    val id: UUID,
+    @field:Schema(description = "세션 진행 단계", example = "ONGOING")
+    val progressPhase: SessionProgressPhase,
+    @field:Schema(description = "세션 제목", example = "개발 세션")
+    val title: String,
+    @field:Schema(description = "세션 시작 일시", example = "2024-01-01T09:00:00+09:00")
+    val startDateTime: LocalDateTime,
+    @field:Schema(description = "시작 요일", example = "월")
+    val startDayOfWeek: String,
+    @field:Schema(description = "세션 종료 일시", example = "2024-12-31T18:00:00+09:00")
+    val endDateTime: LocalDateTime,
+    @field:Schema(description = "종료 요일", example = "토")
+    val endDayOfWeek: String,
+    @field:Schema(description = "장소 이름", nullable = true)
+    val place: String?,
+    @field:Schema(description = "주소", nullable = true)
+    val address: String?,
+    @field:Schema(description = "위도", nullable = true)
+    val latitude: Double?,
+    @field:Schema(description = "경도", nullable = true)
+    val longitude: Double?,
+    @field:Schema(description = "공지사항 목록")
+    val notices: List<SessionDetailsNoticeOverviewResponse>
+) {
+    companion object {
+        fun of(
+            session: SessionEntity,
+            notices: List<NoticeEntity>,
+            writers: Map<UUID, UserWithLastActivityUnit>,
+            now: LocalDateTime
+        ): SessionDetailsResponseV2 =
+            SessionDetailsResponseV2(
+                id = session.id,
+                progressPhase = session.getSessionProgressPhase(now),
+                title = session.name,
+                startDateTime = LocalDateTime.of(session.date, session.time),
+                startDayOfWeek = session.startDayOfWeek,
+                endDateTime = LocalDateTime.of(session.endDate, session.endTime),
+                endDayOfWeek = session.endDayOfWeek,
+                place = session.place,
+                address = session.address,
+                latitude = session.latitude,
+                longitude = session.longitude,
+                notices = notices.map { notice ->
+                    val writer = writers[notice.writerId]
+                        ?: throw BusinessException(ScheduleError.NO_WRITER_FOR_SCHEDULE)
+                    SessionDetailsNoticeOverviewResponse.of(notice, writer)
+                }
+            )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionDetailsResponseV2.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SessionDetailsResponseV2.kt
@@ -8,8 +8,6 @@ import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.user.infrastructure.model.UserWithLastActivityUnit
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.util.UUID
 
 data class SessionDetailsResponseV2(
@@ -20,11 +18,11 @@ data class SessionDetailsResponseV2(
     @field:Schema(description = "세션 제목", example = "개발 세션")
     val title: String,
     @field:Schema(description = "세션 시작 일시", example = "2024-01-01T09:00:00+09:00")
-    val startDateTime: ZonedDateTime,
+    val startDateTime: LocalDateTime,
     @field:Schema(description = "시작 요일", example = "월")
     val startDayOfWeek: String,
     @field:Schema(description = "세션 종료 일시", example = "2024-12-31T18:00:00+09:00")
-    val endDateTime: ZonedDateTime,
+    val endDateTime: LocalDateTime,
     @field:Schema(description = "종료 요일", example = "토")
     val endDayOfWeek: String,
     @field:Schema(description = "장소 이름", nullable = true)
@@ -49,9 +47,9 @@ data class SessionDetailsResponseV2(
                 id = session.id,
                 progressPhase = session.getSessionProgressPhase(now),
                 title = session.name,
-                startDateTime = LocalDateTime.of(session.date, session.time).atZone(ZoneId.of("Asia/Seoul")),
+                startDateTime = LocalDateTime.of(session.date, session.time),
                 startDayOfWeek = session.startDayOfWeek,
-                endDateTime = LocalDateTime.of(session.endDate, session.endTime).atZone(ZoneId.of("Asia/Seoul")),
+                endDateTime = LocalDateTime.of(session.endDate, session.endTime),
                 endDayOfWeek = session.endDayOfWeek,
                 place = session.place,
                 address = session.address,

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -404,8 +404,34 @@ interface ScheduleApi {
         @PathVariable sessionId: UUID
     ): ResponseEntity<SuccessResponse<SessionDetailsResponse>>
 
-    @Operation(summary = "세션 상세 조회 (ISO 8601)")
-    @ApiResponses()
+    @Operation(
+        summary = "세션 상세 조회",
+        description = "세션 일시 필드 ISO 8601 형식으로 제공"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "404",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "일정을 작성한 작성자가 존재하지 않는 경우",
+                                value = """
+                                    {
+                                        "message": "일정을 작성한 작성자가 존재하지 않습니다.",
+                                        "errorCode": "SCH_4001",
+                                        "isSuccess": false
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
     @GetMapping("/v2/sessions/{sessionId}")
     fun getSessionDetailsV2(
         @AuthenticationPrincipal securityUser: SecurityUser,

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -8,6 +8,7 @@ import co.yappuworld.schedule.client.dto.request.SessionParamRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.SessionDetailsResponse
+import co.yappuworld.schedule.client.dto.response.SessionDetailsResponseV2
 import co.yappuworld.schedule.client.dto.response.SessionOverviewResponse
 import co.yappuworld.schedule.client.dto.response.UpcomingSessionResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -402,4 +403,12 @@ interface ScheduleApi {
         @AuthenticationPrincipal securityUser: SecurityUser,
         @PathVariable sessionId: UUID
     ): ResponseEntity<SuccessResponse<SessionDetailsResponse>>
+
+    @Operation(summary = "세션 상세 조회 (ISO 8601)")
+    @ApiResponses()
+    @GetMapping("/v2/sessions/{sessionId}")
+    fun getSessionDetailsV2(
+        @AuthenticationPrincipal securityUser: SecurityUser,
+        @PathVariable sessionId: UUID
+    ): ResponseEntity<SuccessResponse<SessionDetailsResponseV2>>
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleController.kt
@@ -9,6 +9,7 @@ import co.yappuworld.schedule.client.dto.request.SessionParamRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
 import co.yappuworld.schedule.client.dto.response.SessionDetailsResponse
+import co.yappuworld.schedule.client.dto.response.SessionDetailsResponseV2
 import co.yappuworld.schedule.client.dto.response.SessionOverviewResponse
 import co.yappuworld.schedule.client.dto.response.UpcomingSessionResponse
 import jakarta.validation.Valid
@@ -72,6 +73,16 @@ class ScheduleController(
         ResponseEntity.ok(
             SuccessResponse(
                 scheduleService.findSessionDetails(sessionId, getCurrentDateTimeInKST())
+            )
+        )
+
+    override fun getSessionDetailsV2(
+        securityUser: SecurityUser,
+        sessionId: UUID
+    ): ResponseEntity<SuccessResponse<SessionDetailsResponseV2>> =
+        ResponseEntity.ok(
+            SuccessResponse(
+                scheduleService.findSessionDetailsV2(sessionId, getCurrentDateTimeInKST())
             )
         )
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 세션 시작/종료 날짜와 시간을 별도로 조합하지 않아도 되도록 API 응답을 개선합니다.

## ⭐️ 어떻게 해결했나요?
- `SessionDetailsResponseV2` DTO를 추가했습니다.
- `startDateTime`, `endDateTime` 필드를 `ZonedDateTime`으로 추가했습니다.
- `/v2/sessions/{sessionId}` 엔드포인트 추가했습니다.

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?
- `findSessionDetails()`와 `findSessionDetailsV2()`의 공통 로직을 별도 함수로 분리하는 것이 좋을까요?

## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
