### PR TITLE
fix: 세션 상세 조회 V2 API 정상 응답 문서화 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -411,6 +411,10 @@ interface ScheduleApi {
     @ApiResponses(
         value = [
             ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true
+            ),
+            ApiResponse(
                 responseCode = "404",
                 content = [
                     Content(


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 세션 상세 조회 V2 API의 정상 응답이 문서화가 빠져 있어 Swagger에 표시되지 않고 있습니다.

## ⭐️ 어떻게 해결했나요?
- `@ApiResponse(responseCode = "200", useReturnTypeSchema = true)`를 추가하여 정상 응답 문서화

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
