### PR TITLE
fix: 출석 대상자의 잘못된 역할을 예외 발생시키기 전에 필터링

### DIFF
--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
@@ -119,7 +119,9 @@ class UserFindService(
             .filterNotNull()
 
     fun findSessionAttendeesOfGeneration(generation: Int): List<Attendee> =
-        findActiveUsersOfGeneration(generation).map { Attendee.from(it, generation) }
+        findActiveUsersOfGeneration(generation)
+            .filter { it.canCheckIn() }
+            .map { Attendee.from(it, generation) }
 
     fun findSessionAttendee(
         userId: UUID,

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/model/UserWithActivityUnit.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/model/UserWithActivityUnit.kt
@@ -21,4 +21,6 @@ data class UserWithActivityUnit(
             position = position,
             userId = userId
         )
+
+    fun canCheckIn() = role in listOf(UserRole.ACTIVE, UserRole.STAFF)
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?

<img width="1706" height="772" alt="image" src="https://github.com/user-attachments/assets/475e0df8-eae5-461b-b6fb-da28ffef4ef8" />

활성된 기수 회원 중 일부의 역할이 잘못 설정되어 있는 경우, ATD_2004 에러가 발생하면서 출석부 전체가 노출되지 않는 문제가 있습니다.

## ⭐️ 어떻게 해결했나요?

### AS-IS
- 기존에는 조회한 활동 회원 정보를 Attendee로 변환하는 과정에서 유효성 검사를 진행하고, 역할이 잘못 설정되어 있으면 예외를 발생시켰습니다.

### TO-BE
- 조회한 활동 회원 정보에서, 잘못된 역할을 가지고 있는 유저를 필터링하였습니다.
- 문제가 없는 회원들이라도 보일 수 있도록 처리 하였습니다.

### TO-DO
- 애초에 잘못된 역할이 설정되지 않도록 하거나, 역할이 잘못 설정된 경우에 알아차릴 수 있도록 노티를 줄 수 있는 기능이 필요해 보입니다.

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)