### PR TITLE
feature: 어드민 지각 면제권 수정

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AdminAttendanceService.kt
@@ -8,10 +8,11 @@ import co.yappuworld.schedule.client.dto.request.AdminSessionAttendanceUpdateReq
 import co.yappuworld.schedule.client.dto.response.AdminAttendanceCodeResponse
 import co.yappuworld.schedule.client.dto.response.AdminAttendancesResponse
 import co.yappuworld.schedule.domain.AttendanceBook
-import co.yappuworld.schedule.infrastructure.AttendanceCommandService
 import co.yappuworld.schedule.infrastructure.AttendanceFindService
+import co.yappuworld.schedule.infrastructure.LatePassCommandService
 import co.yappuworld.schedule.infrastructure.LatePassFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService
+import co.yappuworld.schedule.infrastructure.entity.LatePassEntity
 import co.yappuworld.user.infrastructure.UserFindService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -20,11 +21,11 @@ import java.time.LocalDateTime
 @Service
 class AdminAttendanceService(
     private val attendanceFindService: AttendanceFindService,
-    private val attendanceCommandService: AttendanceCommandService,
     private val userFindService: UserFindService,
     private val sessionFindService: SessionFindService,
     private val generationFindService: GenerationFindService,
     private val latePassFindService: LatePassFindService,
+    private val latePassCommandService: LatePassCommandService,
     private val configFindService: ConfigFindService
 ) {
 
@@ -45,14 +46,8 @@ class AdminAttendanceService(
 
     @Transactional
     fun updateAttendance(request: AdminAttendanceUpdateRequest) {
-        val attendanceBySessionAndUserId = attendanceFindService
-            .findAttendances(request.getSessionAndUserIdPairs())
-            .associateBy { it.session.id to it.userId }
-
-        request.targets.forEach { target ->
-            attendanceBySessionAndUserId[target.sessionId to target.userId]
-                ?.apply { updateStatus(target.attendanceStatus) }
-        }
+        updateAttendanceStatus(request)
+        updateLatePasses(request)
     }
 
     @Transactional
@@ -78,5 +73,31 @@ class AdminAttendanceService(
     @Transactional
     fun deleteAttendanceCode() {
         configFindService.findAttendanceCode().reset()
+    }
+
+    private fun updateAttendanceStatus(request: AdminAttendanceUpdateRequest) {
+        val attendanceBySessionAndUserId = attendanceFindService
+            .findAttendances(request.getSessionAndUserIdPairs())
+            .associateBy { it.session.id to it.userId }
+
+        request.attendances.forEach { request ->
+            attendanceBySessionAndUserId[request.sessionId to request.userId]
+                ?.apply { updateStatus(request.attendanceStatus) }
+        }
+    }
+
+    private fun updateLatePasses(request: AdminAttendanceUpdateRequest) {
+        val existingLatePasses = latePassFindService
+            .findLatePasses(request.generation, request.latePasses.map { it.userId })
+            .associateBy { it.userId }
+
+        val latePasses = request.latePasses.map { updateRequest ->
+            val latePass = existingLatePasses[updateRequest.userId]
+                ?: LatePassEntity(userId = updateRequest.userId, generation = request.generation)
+
+            latePass.apply { updateCount(updateRequest.latePassCount) }
+        }
+
+        latePassCommandService.saveAll(latePasses)
     }
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminAttendanceUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/request/AdminAttendanceUpdateRequest.kt
@@ -6,22 +6,30 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 data class AdminAttendanceUpdateRequest(
-    @Schema(description = "업데이트 목록")
-    val targets: List<AdminAttendanceUpdateTargetRequest>
+    @param:Schema(description = "기수")
+    val generation: Int,
+    @param:Schema(description = "업데이트 목록")
+    val attendances: List<AdminAttendanceUpdateTargetRequest>,
+    @param:Schema(description = "지각 면제권 업데이트 목록")
+    val latePasses: List<AdminLatePassUpdateTargetRequest>
 ) {
 
     @JsonIgnore
-    val size = targets.size
-
-    @JsonIgnore
-    fun getSessionAndUserIdPairs(): List<Pair<UUID, UUID>> = targets.map { it.sessionId to it.userId }
+    fun getSessionAndUserIdPairs(): List<Pair<UUID, UUID>> = attendances.map { it.sessionId to it.userId }
 }
 
 data class AdminAttendanceUpdateTargetRequest(
-    @Schema(description = "유저 ID")
+    @param:Schema(description = "유저 ID")
     val userId: UUID,
-    @Schema(description = "세션 ID")
+    @param:Schema(description = "세션 ID")
     val sessionId: UUID,
-    @Schema(description = "업데이트 상태")
+    @param:Schema(description = "업데이트 상태")
     val attendanceStatus: AttendanceStatus
+)
+
+data class AdminLatePassUpdateTargetRequest(
+    @param:Schema(description = "유저 ID")
+    val userId: UUID,
+    @param:Schema(description = "지각 면제권 개수")
+    val latePassCount: Int
 )

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassCommandService.kt
@@ -1,0 +1,16 @@
+package co.yappuworld.schedule.infrastructure
+
+import co.yappuworld.schedule.infrastructure.entity.LatePassEntity
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class LatePassCommandService(
+    private val latePassRepository: LatePassRepository
+) {
+
+    fun saveAll(latePassEntities: List<LatePassEntity>) {
+        latePassRepository.saveAll(latePassEntities)
+    }
+}

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassFindService.kt
@@ -17,4 +17,9 @@ class LatePassFindService(
     ): Int = latePassRepository.countAllByGenerationAndUserId(generation, userId)
 
     fun findLatePasses(generation: Int): List<LatePassEntity> = latePassRepository.findAllByGeneration(generation)
+
+    fun findLatePasses(
+        generation: Int,
+        userIds: List<UUID>
+    ): List<LatePassEntity> = latePassRepository.findAllByGenerationAndUserIdIn(generation, userIds)
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassRepository.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassRepository.kt
@@ -12,4 +12,9 @@ interface LatePassRepository : JpaRepository<LatePassEntity, Long> {
     ): Int
 
     fun findAllByGeneration(generation: Int): List<LatePassEntity>
+
+    fun findAllByGenerationAndUserIdIn(
+        generation: Int,
+        userIds: Collection<UUID>
+    ): List<LatePassEntity>
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/LatePassEntity.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/entity/LatePassEntity.kt
@@ -10,10 +10,14 @@ import java.util.UUID
 @Table(name = "late_passes")
 class LatePassEntity(
     val userId: UUID,
-    val generation: Int,
-    reason: String? = null
+    val generation: Int
 ) : BaseEntity() {
 
-    @Column(name = "reason")
-    val reason: String? = reason
+    @Column(name = "count", nullable = false)
+    var count: Int = 0
+        private set
+
+    fun updateCount(latePassCount: Int) {
+        this.count = latePassCount
+    }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -137,5 +137,5 @@ create table late_passes
     updated_at datetime(6),
     user_id    binary(16) NOT NULL,
     generation int NOT NULL,
-    reason     varchar(128)
+    count      int NOT NULL DEFAULT 0
 );


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
<img width="1343" height="524" alt="image" src="https://github.com/user-attachments/assets/573a42c1-fb5d-4617-b686-f4899b642458" />

- 현재 출석관리에서 지각면제권 수정이 불가능합니다.


## ⭐️ 어떻게 해결했나요?

### Entity 변경
- 기존에는 지각 면제권을 하나의 쿠폰처럼 처리하여, 면제권 지급 사유를 기재하는 등 디테일한 관리를 하고자 하였습니다.
- 이 경우 화면 단에서 많은 개발 리소스가 필요하여, 단순하게 개수를 관리하는 방식으로 변경하였습니다.

### DTO 변경
- 기존 DTO 구조에서는 지각 면제권 수정에 관한 정보를 추가하기가 어렵습니다.
- 변경 사항 관련하여, 출석 정보와 지각 면제권 정보 필드를 분리하여 처리합니다.

### 테이블 변경 사항
- 기존에 지각 면제권 데이터가 없어서, drop 및 create 하였습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
