### PR TITLE
fix: 지각 면제권 조회 로직 수정

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/AttendanceBook.kt
@@ -67,9 +67,7 @@ class AttendanceBook(
         attendees = attendees,
         sessions = sessions,
         attendances = attendances,
-        latePassCountByUserId = latePasses
-            .groupBy { it.userId }
-            .mapValues { (_, latePasses) -> latePasses.size },
+        latePassCountByUserId = latePasses.associate { it.userId to it.count },
         now = now
     )
 

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassFindService.kt
@@ -14,7 +14,7 @@ class LatePassFindService(
     fun countLatePasses(
         generation: Int,
         userId: UUID
-    ): Int = latePassRepository.countAllByGenerationAndUserId(generation, userId)
+    ): Int = latePassRepository.findByGenerationAndUserId(generation, userId)?.count ?: 0
 
     fun findLatePasses(generation: Int): List<LatePassEntity> = latePassRepository.findAllByGeneration(generation)
 

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassRepository.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/LatePassRepository.kt
@@ -6,10 +6,10 @@ import java.util.UUID
 
 interface LatePassRepository : JpaRepository<LatePassEntity, Long> {
 
-    fun countAllByGenerationAndUserId(
+    fun findByGenerationAndUserId(
         generation: Int,
         userId: UUID
-    ): Int
+    ): LatePassEntity?
 
     fun findAllByGeneration(generation: Int): List<LatePassEntity>
 

--- a/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/domain/AttendanceBookTest.kt
@@ -77,12 +77,10 @@ class AttendanceBookTest :
                     status = AttendanceStatus.PENDING
                 )
             )
-            val latePassEntities = listOf(
-                LatePassEntity(
-                    userId = users[0].userId,
-                    generation = generation
-                )
-            )
+            val latePassEntity = LatePassEntity(
+                userId = users[0].userId,
+                generation = generation
+            ).apply { updateCount(1) }
 
             scenario("AttendanceBook을 생성한다.") {
                 shouldNotThrowAny {
@@ -91,7 +89,7 @@ class AttendanceBookTest :
                         attendees = users.map { getAttendeeFixture(it, generation) },
                         sessions = sessions,
                         attendances = attendances,
-                        latePasses = latePassEntities,
+                        latePasses = listOf(latePassEntity),
                         now = now
                     )
                 }
@@ -103,7 +101,7 @@ class AttendanceBookTest :
                     attendees = users.map { getAttendeeFixture(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
-                    latePasses = latePassEntities,
+                    latePasses = listOf(latePassEntity),
                     now = now
                 )
 
@@ -153,7 +151,7 @@ class AttendanceBookTest :
                     attendees = users.map { getAttendeeFixture(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
-                    latePasses = latePassEntities,
+                    latePasses = listOf(latePassEntity),
                     now = now
                 )
 
@@ -195,11 +193,7 @@ class AttendanceBookTest :
                         LatePassEntity(
                             userId = users[0].userId,
                             generation = generation
-                        ),
-                        LatePassEntity(
-                            userId = users[0].userId,
-                            generation = generation
-                        )
+                        ).apply { updateCount(2) }
                     ),
                     now = now
                 )
@@ -213,7 +207,7 @@ class AttendanceBookTest :
                     attendees = users.map { getAttendeeFixture(it, generation) },
                     sessions = sessions,
                     attendances = attendances,
-                    latePasses = latePassEntities,
+                    latePasses = listOf(latePassEntity),
                     now = now
                 )
 


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
<img width="575" height="315" alt="image" src="https://github.com/user-attachments/assets/077e10ab-7d2b-421d-9c25-cef7ace85375" />

- 지각 면제권의 수를 1이 아닌 다른 값으로 변경해도, 여전히 1로만 조회되는 오류가 있습니다.


## ⭐️ 어떻게 해결했나요?

<img width="1341" height="86" alt="image" src="https://github.com/user-attachments/assets/4aa5a5be-5cf2-4716-8228-3d6e6bd91cd5" />

- 실제 DB엔 4로 기록되어 있으나, 조회 로직이 초기 설계 그대로 유지되고 있었습니다.
	- 초기 설계에선 지각 면제권 하나가 하나의 row로 처리 되었으므로, count 쿼리로 조회했습니다.
	- 현재는 하나의 로우에서 count 컬럼 값을 확인해야 합니다.
- 어드민과 개인 프로필 쪽에서 사용하는 두 개의 조회 로직에 수정을 진행했습니다.

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
