### PR TITLE
fix: 미출석 시 결석 조건 변경

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/CustomAttendanceDsl.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/CustomAttendanceDsl.kt
@@ -29,7 +29,7 @@ class CustomAttendanceDsl : Jpql() {
             path(SessionEntity::endTime),
             path(SessionEntity::generation),
             path(SessionEntity::sessionType),
-            path(AttendanceEntity::createdAt),
+            path(AttendanceEntity::userCheckedInAt),
             path(AttendanceEntity::status)
         )
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
@@ -24,16 +24,16 @@ class SessionWithAttendanceDto(
     val generation: Int,
     val sessionType: SessionType,
     val checkedInAt: LocalDateTime?,
-    attendanceStatus: AttendanceStatus?
+    private val _attendanceStatus: AttendanceStatus?
 ) {
 
-    var attendanceStatus: String? = attendanceStatus?.label
+    var attendanceStatus: String? = _attendanceStatus?.label
         private set
 
-    val attendanceStatusType: AttendanceStatus? = attendanceStatus
+    val attendanceStatusType: AttendanceStatus? = _attendanceStatus
 
     fun resolveAttendanceStatusOfPastSessions(now: LocalDateTime) {
-        if (attendanceStatus == null && isFinished(now)) {
+        if (checkedInAt == null && isFinished(now)) {
             attendanceStatus = AttendanceStatus.ABSENT.label
         }
     }

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
@@ -99,7 +99,10 @@ class SessionFindServiceTest @Autowired constructor(
                         endDate = now.toLocalDate().minusDays(1)
                     )
                     sessions.add(session)
-                    attendances.add(getAttendanceEntityFixture(status[it], userId, session))
+                    attendances.add(
+                        getAttendanceEntityFixture(status[it], userId, session)
+                            .also { attendance -> attendance.checkIn(status[it], now) }
+                    )
                 }
                 scheduleRepository.saveAll(sessions)
                 attendanceRepository.saveAll(attendances)
@@ -143,7 +146,7 @@ class SessionFindServiceTest @Autowired constructor(
                 sessionFindService.findAttendancesHistories(generation = 4, userId = user.id, now = now).let {
                     it.shouldHaveSize(1)
                     it[0].id shouldBe sessions[0].id
-                    it[0].attendanceStatus shouldBe AttendanceStatus.PENDING.label
+                    it[0].attendanceStatus shouldBe AttendanceStatus.ABSENT.label
                 }
             }
 
@@ -199,7 +202,10 @@ class SessionFindServiceTest @Autowired constructor(
                         endDate = now.toLocalDate().minusDays(1)
                     )
                     sessions.add(session)
-                    attendances.add(getAttendanceEntityFixture(status[it], userId, session))
+                    attendances.add(
+                        getAttendanceEntityFixture(status[it], userId, session)
+                            .also { attendance -> attendance.checkIn(status[it], now) }
+                    )
                 }
                 scheduleRepository.saveAll(sessions)
                 attendanceRepository.saveAll(attendances)

--- a/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/AttendanceFixture.kt
@@ -43,9 +43,9 @@ object AttendanceFixture {
         userId: UUID = UUID.randomUUID(),
         session: SessionEntity = getSessionEntityFixture()
     ) = AttendanceEntity(
-        status = status,
         userId = userId,
-        session = session
+        session = session,
+        status = status
     )
 
     fun getAttendanceBookFixture(

--- a/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
@@ -85,7 +85,7 @@ object ScheduleFixture {
             endTime = endTime,
             generation = generation,
             sessionType = sessionType,
-            attendanceStatus = attendanceStatus,
+            _attendanceStatus = attendanceStatus,
             checkedInAt = checkedInAt
         )
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/17a95402-45c3-4e22-9897-6f1e63035a3b" />

- 미출석 상태 + 세션 종료이면 결석으로 보여야 합니다.
- 현재는 출석 시간이 표시되고, 별도의 칩이 노출되지 않습니다.


## ⭐️ 어떻게 해결했나요?
- 출석 상태 기본값을 PENDING으로 변경하면서, 기존에 null로 판단하던 로직이 정상 동작하지 않았습니다.
- checkedInAt 시간이 존재하지 않고, 세션이 종료됐다면 결석으로 변경합니다.
- resolveAttendanceStatusOfPastSessions 메서드로 판단합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)