### PR TITLE
fix: 일정 목록에서 출석 정보가 정상적으로 노출되도록 변경

### DIFF
--- a/src/main/kotlin/co/yappuworld/external/fcm/FcmTestController.kt
+++ b/src/main/kotlin/co/yappuworld/external/fcm/FcmTestController.kt
@@ -5,6 +5,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.context.annotation.Profile
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -15,7 +16,8 @@ private val logger = KotlinLogging.logger { }
 @Tag(name = "FCM 테스트용", description = "_")
 @RestController
 class FcmTestController(
-    private val fcmClient: FcmClient
+    private val fcmClient: FcmClient,
+    private val jdbcTemplate: JdbcTemplate
 ) {
 
     data class SingleFcm(

--- a/src/main/kotlin/co/yappuworld/external/fcm/FcmTestController.kt
+++ b/src/main/kotlin/co/yappuworld/external/fcm/FcmTestController.kt
@@ -5,7 +5,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.context.annotation.Profile
-import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -16,8 +15,7 @@ private val logger = KotlinLogging.logger { }
 @Tag(name = "FCM 테스트용", description = "_")
 @RestController
 class FcmTestController(
-    private val fcmClient: FcmClient,
-    private val jdbcTemplate: JdbcTemplate
+    private val fcmClient: FcmClient
 ) {
 
     data class SingleFcm(

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/ScheduleService.kt
@@ -8,7 +8,6 @@ import co.yappuworld.schedule.client.dto.request.SessionParamRequest
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponse
 import co.yappuworld.schedule.client.dto.response.ActiveGenerationSessionsResponseV2
 import co.yappuworld.schedule.client.dto.response.SchedulePageResponse
-import co.yappuworld.schedule.client.dto.response.SessionDetailsNoticeResponse
 import co.yappuworld.schedule.client.dto.response.SessionDetailsResponse
 import co.yappuworld.schedule.client.dto.response.SessionDetailsResponseV2
 import co.yappuworld.schedule.client.dto.response.SessionOverviewResponse
@@ -50,7 +49,7 @@ class ScheduleService(
                 .map { it.id }
         )
 
-        return SchedulePageResponse.from(userWithActivityUnits, schedules, attendances, request, now)
+        return SchedulePageResponse.from(schedules, attendances, request, now)
     }
 
     @Transactional(readOnly = true)
@@ -134,10 +133,6 @@ class ScheduleService(
         val writers = when {
             writerIds.isEmpty() -> emptyMap()
             else -> userFindService.findAllUserWithLastActivityUnit(writerIds).associateBy { it.userId }
-        }
-
-        val noticeResponses = notices.map { notice ->
-            SessionDetailsNoticeResponse.from(notice)
         }
 
         return SessionDetailsResponse.of(

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
@@ -3,8 +3,8 @@ package co.yappuworld.schedule.client.dto.response
 import co.yappuworld.global.util.DatetimeUtils.korean
 import co.yappuworld.global.util.LocalDateRange
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
+import co.yappuworld.schedule.domain.vo.ScheduleProgressPhase
 import co.yappuworld.schedule.domain.vo.ScheduleType
-import co.yappuworld.schedule.domain.vo.SessionProgressPhase
 import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
@@ -94,7 +94,7 @@ data class SimpleScheduleResponse(
     @field:Schema(description = "세션 종류", nullable = true)
     val sessionType: SessionType?,
     @field:Schema(description = "일정 진행 상태")
-    val scheduleProgressPhase: SessionProgressPhase,
+    val scheduleProgressPhase: ScheduleProgressPhase,
     @field:Schema(description = "출석 상태", nullable = true, allowableValues = ["출석", "지각", "결석", "조퇴", "공결"])
     val attendanceStatus: String?
 ) {
@@ -110,6 +110,7 @@ data class SimpleScheduleResponse(
             now: LocalDateTime
         ): SimpleScheduleResponse =
             sessionWithAttendance.let {
+                it.resolveAttendanceStatusOfPastSessions(now)
                 SimpleScheduleResponse(
                     id = it.id,
                     name = it.name,
@@ -122,7 +123,7 @@ data class SimpleScheduleResponse(
                     endTime = it.endTime,
                     scheduleType = ScheduleType.SESSION,
                     sessionType = it.sessionType,
-                    scheduleProgressPhase = it.getSessionProgressPhase(now),
+                    scheduleProgressPhase = it.getScheduleProgressPhase(now),
                     attendanceStatus = it.attendanceStatus
                 )
             }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
@@ -3,15 +3,13 @@ package co.yappuworld.schedule.client.dto.response
 import co.yappuworld.global.util.DatetimeUtils.korean
 import co.yappuworld.global.util.LocalDateRange
 import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
-import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
-import co.yappuworld.schedule.domain.vo.ScheduleProgressPhase
 import co.yappuworld.schedule.domain.vo.ScheduleType
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase
 import co.yappuworld.schedule.domain.vo.SessionType
+import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.ScheduleEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
-import co.yappuworld.schedule.infrastructure.entity.TaskEntity
-import co.yappuworld.user.domain.model.UserWithActivityUnits
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -25,21 +23,22 @@ data class SchedulePageResponse(
 
     companion object {
         fun from(
-            userWithActivityUnits: UserWithActivityUnits,
             schedules: List<ScheduleEntity>,
             attendances: List<AttendanceEntity>,
             request: SchedulePageRequest,
             now: LocalDateTime
         ): SchedulePageResponse {
             val attendanceBySessionId = attendances.associateBy { it.session.id }
-            val scheduleWithAttendance = schedules.map { Pair(it, attendanceBySessionId[it.id]) }
-            val scheduleByDate = scheduleWithAttendance.groupBy { (schedule, _) -> schedule.date }
+            // TODO: 일단 세션 뿐이니, 세션으로만 변환, 추후에 다른 Schedule도 처리하도록 변경 필요
+            val scheduleWithAttendance = schedules.map {
+                SessionWithAttendanceDto.from(it as SessionEntity, attendanceBySessionId[it.id])
+            }
+            val scheduleByDate = scheduleWithAttendance.groupBy { it.date }
 
             return LocalDateRange(request.from, request.toInclusive.plusDays(1))
                 .map { date ->
                     DateGroupedScheduleResponse(
                         date = date,
-                        userWithActivityUnits = userWithActivityUnits,
                         scheduleWithAttendance = scheduleByDate[date] ?: emptyList(),
                         now = now
                     )
@@ -61,14 +60,13 @@ data class DateGroupedScheduleResponse(
 
     constructor(
         date: LocalDate,
-        userWithActivityUnits: UserWithActivityUnits,
-        scheduleWithAttendance: List<Pair<ScheduleEntity, AttendanceEntity?>>,
+        scheduleWithAttendance: List<SessionWithAttendanceDto>,
         now: LocalDateTime
     ) : this(
         date = date,
         isToday = date.isEqual(now.toLocalDate()),
         dayOfTheWeek = date.dayOfWeek.korean(),
-        schedules = scheduleWithAttendance.map { SimpleScheduleResponse.from(it, userWithActivityUnits, now) }
+        schedules = scheduleWithAttendance.map { SimpleScheduleResponse.from(it, now) }
     )
 }
 
@@ -96,48 +94,36 @@ data class SimpleScheduleResponse(
     @field:Schema(description = "세션 종류", nullable = true)
     val sessionType: SessionType?,
     @field:Schema(description = "일정 진행 상태")
-    val scheduleProgressPhase: ScheduleProgressPhase,
+    val scheduleProgressPhase: SessionProgressPhase,
     @field:Schema(description = "출석 상태", nullable = true, allowableValues = ["출석", "지각", "결석", "조퇴", "공결"])
     val attendanceStatus: String?
 ) {
 
     companion object {
         fun from(
-            scheduleWithAttendance: Pair<ScheduleEntity, AttendanceEntity?>,
-            userWithActivityUnits: UserWithActivityUnits,
+            scheduleWithAttendance: SessionWithAttendanceDto,
             now: LocalDateTime
-        ): SimpleScheduleResponse =
-            when (scheduleWithAttendance.first) {
-                is SessionEntity -> convertSession(scheduleWithAttendance, userWithActivityUnits, now)
-                is TaskEntity -> TODO()
-                else -> TODO()
-            }
+        ): SimpleScheduleResponse = convertSession(scheduleWithAttendance, now)
 
         private fun convertSession(
-            sessionWithAttendance: Pair<ScheduleEntity, AttendanceEntity?>,
-            userWithActivityUnits: UserWithActivityUnits,
+            sessionWithAttendance: SessionWithAttendanceDto,
             now: LocalDateTime
         ): SimpleScheduleResponse =
-            sessionWithAttendance.let { (s, attendance) ->
-                val session = s as SessionEntity
+            sessionWithAttendance.let {
                 SimpleScheduleResponse(
-                    id = session.id,
-                    name = session.name,
-                    place = session.place,
-                    date = session.date,
-                    startDayOfTheWeek = session.date.dayOfWeek.korean(),
-                    endDate = session.endDate,
-                    endDayOfTheWeek = session.endDate.dayOfWeek.korean(),
-                    time = session.time,
-                    endTime = session.endTime,
+                    id = it.id,
+                    name = it.name,
+                    place = it.place,
+                    date = it.date,
+                    startDayOfTheWeek = it.date.dayOfWeek.korean(),
+                    endDate = it.endDate,
+                    endDayOfTheWeek = it.endDate.dayOfWeek.korean(),
+                    time = it.time,
+                    endTime = it.endTime,
                     scheduleType = ScheduleType.SESSION,
-                    sessionType = session.sessionType,
-                    scheduleProgressPhase = session.getProgressPhase(now),
-                    attendanceStatus = ABSENT.label.takeIf {
-                        attendance == null &&
-                            session.isFinished(now) &&
-                            session.generation in userWithActivityUnits.activityUnits.map { it.generation }
-                    }
+                    sessionType = it.sessionType,
+                    scheduleProgressPhase = it.getSessionProgressPhase(now),
+                    attendanceStatus = it.attendanceStatus
                 )
             }
     }

--- a/src/main/kotlin/co/yappuworld/schedule/domain/vo/SessionProgressPhase.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/domain/vo/SessionProgressPhase.kt
@@ -1,10 +1,11 @@
 package co.yappuworld.schedule.domain.vo
 
 enum class SessionProgressPhase(
-    val label: String
+    val label: String,
+    val order: Int
 ) {
-    DONE("완료"),
-    ONGOING("진행 중"),
-    TODAY("당일"),
-    PENDING("예정")
+    DONE("종료", 0),
+    ONGOING("진행 중", 1),
+    TODAY("당일", 2),
+    PENDING("예정", 3)
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
@@ -61,7 +61,7 @@ class SessionWithAttendanceDto(
     val attendanceStatusType: AttendanceStatus? = _attendanceStatus
 
     fun resolveAttendanceStatusOfPastSessions(now: LocalDateTime) {
-        if (checkedInAt == null && isFinished(now)) {
+        if (attendanceStatusType == AttendanceStatus.PENDING && checkedInAt == null && isFinished(now)) {
             attendanceStatus = AttendanceStatus.ABSENT.label
         }
     }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
@@ -4,6 +4,8 @@ import co.yappuworld.global.util.DatetimeUtils.isBeforeOrEqual
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase
 import co.yappuworld.schedule.domain.vo.SessionType
+import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -26,6 +28,31 @@ class SessionWithAttendanceDto(
     val checkedInAt: LocalDateTime?,
     private val _attendanceStatus: AttendanceStatus?
 ) {
+
+    companion object {
+
+        fun from(
+            session: SessionEntity,
+            attendance: AttendanceEntity?
+        ): SessionWithAttendanceDto =
+            SessionWithAttendanceDto(
+                id = session.id,
+                name = session.name,
+                description = session.description,
+                place = session.place,
+                address = session.address,
+                latitude = session.latitude,
+                longitude = session.longitude,
+                date = session.date,
+                endDate = session.endDate,
+                time = session.time,
+                endTime = session.endTime,
+                generation = session.generation,
+                sessionType = session.sessionType,
+                checkedInAt = attendance?.userCheckedInAt,
+                _attendanceStatus = attendance?.status
+            )
+    }
 
     var attendanceStatus: String? = _attendanceStatus?.label
         private set

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/SessionWithAttendanceDto.kt
@@ -2,6 +2,7 @@ package co.yappuworld.schedule.infrastructure.dto
 
 import co.yappuworld.global.util.DatetimeUtils.isBeforeOrEqual
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.ScheduleProgressPhase
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase
 import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
@@ -78,6 +79,14 @@ class SessionWithAttendanceDto(
 
     fun isToday(now: LocalDateTime): Boolean =
         date.isBeforeOrEqual(now.toLocalDate()) && now.toLocalDate().isBeforeOrEqual(endDate)
+
+    fun getScheduleProgressPhase(now: LocalDateTime): ScheduleProgressPhase =
+        when {
+            isFinished(now) -> ScheduleProgressPhase.DONE
+            isOnGoing(now) -> ScheduleProgressPhase.ONGOING
+            isToday(now) -> ScheduleProgressPhase.TODAY
+            else -> ScheduleProgressPhase.PENDING
+        }
 
     fun getSessionProgressPhase(now: LocalDateTime): SessionProgressPhase =
         when {

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/SignUpApplicationRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/SignUpApplicationRepository.kt
@@ -13,6 +13,8 @@ interface SignUpApplicationRepository :
 
     fun findAllByIdIn(ids: List<UUID>): List<SignUpApplicationEntity>
 
+    fun findAllByApplicantEmailIn(emails: List<String>): List<SignUpApplicationEntity>
+
     @Query(value = "select get_lock(:email, :timeoutSeconds)", nativeQuery = true)
     fun getLock(
         @Param("email") email: String,

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -16,10 +16,10 @@ spring:
                 in-tests: false
             file: docker/docker-compose-local.yaml
 
-#    datasource:
-#        url: jdbc:mysql://localhost:3306/yappu_world
-#        username: yapp
-#        password: yapp
+    datasource:
+        url: jdbc:mysql://localhost:3306/yappu_world
+        username: yapp
+        password: yapp
 
     sql:
         init:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -16,10 +16,10 @@ spring:
                 in-tests: false
             file: docker/docker-compose-local.yaml
 
-    datasource:
-        url: jdbc:mysql://localhost:3306/yappu_world
-        username: yapp
-        password: yapp
+#    datasource:
+#        url: jdbc:mysql://localhost:3306/yappu_world
+#        username: yapp
+#        password: yapp
 
     sql:
         init:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -6,8 +6,8 @@ spring:
 
     docker:
         compose:
+            enabled: false
             service: yappu-world-server
-            enabled: true
             lifecycle-management: none
             #            stop:
             #                command: down

--- a/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/infrastructure/SessionFindServiceTest.kt
@@ -50,16 +50,22 @@ class SessionFindServiceTest @Autowired constructor(
                     .shouldNotBeEmpty()
             }
 
-            scenario("세션은 있는데 출석이 없으면 결석이다.") {
+            scenario("참석자로 지정된 세션에서 출석 기록이 없다면 결석 처리가 된다.") {
+                val userId = UUID.randomUUID()
                 val session = getSessionEntityFixture(generation = 4)
                     .also { scheduleRepository.save(it) }
+                attendanceRepository.saveAndFlush(
+                    getAttendanceEntityFixture(
+                        userId = userId,
+                        session = session
+                    )
+                )
 
+                val now = LocalDateTime.of(session.date.plusDays(1), session.time)
                 val result = sessionFindService
-                    .findSessionsWithAttendanceStatus(
-                        4,
-                        UUID.randomUUID(),
-                        LocalDateTime.of(session.date.plusDays(1), session.time)
-                    ).first()
+                    .findSessionsWithAttendanceStatus(4, userId, now)
+                    .first()
+                    .also { it.resolveAttendanceStatusOfPastSessions(now) }
 
                 result.attendanceStatus shouldBe AttendanceStatus.ABSENT.label
                 result.checkedInAt.shouldBeNull()

--- a/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutorConcurrencyTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutorConcurrencyTest.kt
@@ -4,7 +4,10 @@ import co.yappuworld.global.util.DatetimeUtils.getCurrentDateTimeInKST
 import co.yappuworld.support.environment.SpringBootTestFeatureSpec
 import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
 import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
 import co.yappuworld.user.infrastructure.jpa.SignUpApplicationRepository
+import co.yappuworld.user.infrastructure.jpa.UserAlarmSettingRepository
+import co.yappuworld.user.infrastructure.jpa.UserDeviceRepository
 import co.yappuworld.user.infrastructure.jpa.UserRepository
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
@@ -14,8 +17,51 @@ import java.util.concurrent.Executors
 class SignUpExecutorConcurrencyTest @Autowired constructor(
     private val signUpExecutor: SignUpExecutor,
     private val userRepository: UserRepository,
-    private val signUpApplicationRepository: SignUpApplicationRepository
+    private val signUpApplicationRepository: SignUpApplicationRepository,
+    private val activityUnitRepository: ActivityUnitRepository,
+    private val userDeviceRepository: UserDeviceRepository,
+    private val userAlarmSettingRepository: UserAlarmSettingRepository
 ) : SpringBootTestFeatureSpec({
+
+        afterTest {
+            userRepository
+                .findUserOrNullByEmail("concurrency-test")
+                ?.let { user ->
+                    val activityUnits = activityUnitRepository.findAllByUserId(user.id)
+                    activityUnitRepository.deleteAll(activityUnits)
+
+                    userDeviceRepository
+                        .findUserDeviceOrNullByUserId(user.id)
+                        ?.let { userDeviceRepository.delete(it) }
+
+                    userAlarmSettingRepository
+                        .findUserAlarmSettingOrNullByUserId(user.id)
+                        ?.let { userAlarmSettingRepository.delete(it) }
+
+                    userRepository.delete(user)
+                }
+
+            userRepository
+                .findUserOrNullByEmail("abcde@gmail.com")
+                ?.let { user ->
+                    val activityUnits = activityUnitRepository.findAllByUserId(user.id)
+                    activityUnitRepository.deleteAll(activityUnits)
+
+                    userDeviceRepository
+                        .findUserDeviceOrNullByUserId(user.id)
+                        ?.let { userDeviceRepository.delete(it) }
+
+                    userAlarmSettingRepository
+                        .findUserAlarmSettingOrNullByUserId(user.id)
+                        ?.let { userAlarmSettingRepository.delete(it) }
+
+                    userRepository.delete(user)
+                }
+
+            val testEmails = listOf("concurrency-test", "abcde@gmail.com")
+            val applications = signUpApplicationRepository.findAllByApplicantEmailIn(testEmails)
+            signUpApplicationRepository.deleteAll(applications)
+        }
 
         feature("동시에 같은 이메일로") {
 
@@ -25,12 +71,13 @@ class SignUpExecutorConcurrencyTest @Autowired constructor(
                 val latch = CountDownLatch(threadCount)
 
                 repeat(threadCount) {
+                    val application = getSignUpApplicationEntityFixture(
+                        email = "concurrency-test"
+                    )
                     executorService.submit {
                         try {
                             signUpExecutor.signUp(
-                                application = getSignUpApplicationEntityFixture(
-                                    email = "abc@gmail.com"
-                                ),
+                                application = application,
                                 role = UserRole.ACTIVE,
                                 now = getCurrentDateTimeInKST()
                             )
@@ -50,13 +97,12 @@ class SignUpExecutorConcurrencyTest @Autowired constructor(
                 val latch = CountDownLatch(threadCount)
 
                 repeat(threadCount) {
+                    val application = getSignUpApplicationEntityFixture(
+                        email = "abcde@gmail.com"
+                    )
                     executorService.submit {
                         try {
-                            signUpExecutor.submit(
-                                application = getSignUpApplicationEntityFixture(
-                                    email = "abc@gmail.com"
-                                )
-                            )
+                            signUpExecutor.submit(application = application)
                         } finally {
                             latch.countDown()
                         }

--- a/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutorConcurrencyTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/client/application/usecase/SignUpExecutorConcurrencyTest.kt
@@ -1,28 +1,21 @@
 package co.yappuworld.user.client.application.usecase
 
 import co.yappuworld.global.util.DatetimeUtils.getCurrentDateTimeInKST
+import co.yappuworld.support.environment.SpringBootTestFeatureSpec
 import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
 import co.yappuworld.user.domain.vo.UserRole
 import co.yappuworld.user.infrastructure.jpa.SignUpApplicationRepository
 import co.yappuworld.user.infrastructure.jpa.UserRepository
-import io.kotest.core.spec.style.FeatureSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 
-@SpringBootTest
 class SignUpExecutorConcurrencyTest @Autowired constructor(
     private val signUpExecutor: SignUpExecutor,
     private val userRepository: UserRepository,
     private val signUpApplicationRepository: SignUpApplicationRepository
-) : FeatureSpec({
-
-        afterTest {
-            userRepository.deleteAll()
-            signUpApplicationRepository.deleteAll()
-        }
+) : SpringBootTestFeatureSpec({
 
         feature("동시에 같은 이메일로") {
 


### PR DESCRIPTION
## 🚨 해결하려는 문제가 무엇인가요?

`/v1/schedules`와 `/v1/active-generation/sessions` API에서 출석 상태가 다르게 반환됩니다.

<img width="405" height="357" alt="image" src="https://github.com/user-attachments/assets/17a8b204-6307-4655-80c9-ef95e068a367" />


## ⭐️ 어떻게 해결했나요?

기존에 `/v1/schedules`에서는 결석 or null 두 상태 중 하나만을 반환하는 로직으로 되어 있었습니다.
- 히스토리는 모르겠네요... 왜 저렇게 짜놨지....
```kotlin
attendanceStatus = ABSENT.label.takeIf {
                        attendance == null &&
                            session.isFinished(now) &&
                            session.generation in userWithActivityUnits.activityUnits.map { it.generation }
                    }
```

응답 객체를 생성해줄 때, Pair<Session, Atttendance>가 아닌, SessionWIthAttendanceDto를 만들어 사용했습니다. 해당 객체에 작성된 로직을 재활용했습니다.

### 향후 개선

- 현재 세션과 출석의 상태 등을 처리하는 모델, 로직들이 혼재하여 정리가 필요한 상황입니다.
- 해당 부분은 문서로 정리해서 공유한 뒤 진행할게요!


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 일정 완료 상태 레이블을 "완료"에서 "종료"로 변경

* **New Features**
  * 세션 기반 진행 상태 계산 및 정렬(phase order) 추가
  * 회원 가입 조회용 이메일 리스트 검색 기능 추가

* **Chores**
  * 로컬 환경 Docker Compose 비활성화
  * 일정 데이터 조회/표현 로직 간소화 및 DTO 기반 처리로 개선

* **Tests**
  * 세션 출결 및 동시성 관련 테스트 보강 및 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->