### PR TITLE
fix: 다가오는 세션 조회 시 진행 단계도 함께 반환

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionResponse.kt
@@ -2,6 +2,8 @@ package co.yappuworld.schedule.client.dto.response
 
 import co.yappuworld.post.infrastructure.entity.NoticeEntity
 import co.yappuworld.schedule.domain.SessionAttendance
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase
+import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -48,6 +50,9 @@ data class UpcomingSessionResponse(
     val canCheckIn: Boolean,
     @field:Schema(description = "현재 출석 상태", allowableValues = ["출석", "지각", "결석", "조퇴", "공결"], nullable = true)
     val status: String?,
+    @field:Schema(description = "세션 진행 상태")
+    val progressPhase: SessionProgressPhase,
+    @field:Schema(description = "공지 사항 목록")
     val notices: List<UpcomingSessionNoticeResponse>
 ) {
 
@@ -72,6 +77,11 @@ data class UpcomingSessionResponse(
                     relativeDays = it.getRelativeDays(now.toLocalDate()),
                     canCheckIn = it.canCheckIn(now),
                     status = it.getAttendanceStatus(now),
+                    progressPhase = SessionWithAttendanceDto
+                        .from(
+                            sessionAttendance.session,
+                            sessionAttendance.attendance
+                        ).getSessionProgressPhase(now),
                     notices = notices.map { notice -> UpcomingSessionNoticeResponse(notice.id, notice.title) }
                 )
             }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/ScheduleApi.kt
@@ -278,6 +278,7 @@ interface ScheduleApi {
                                             "relativeDays": -1,
                                             "canCheckIn": false,
                                             "status": null,
+                                            "progressPhase": "PENDING",
                                             "notices": [
                                                 {
                                                     "id": "5523a1f4-ff12-11ef-ad31-0242ac120002",
@@ -306,6 +307,7 @@ interface ScheduleApi {
                                             "relativeDays": 0,
                                             "canCheckIn": true,
                                             "status": null,
+                                            "progressPhase": "TODAY",
                                             "notices": [
                                                 {
                                                     "id": "5523a1f4-ff12-11ef-ad31-0242ac120002",
@@ -334,6 +336,7 @@ interface ScheduleApi {
                                             "relativeDays": 0,
                                             "canCheckIn": false,
                                             "status": "출석",
+                                            "progressPhase": "ONGOING",
                                             "notices": [
                                                 {
                                                     "id": "5523a1f4-ff12-11ef-ad31-0242ac120002",


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?

https://discord.com/channels/1017275030180212916/1437658839762866348/1437658839762866348

동현님의 제보로, 다가오는 세션에서는 세션 진행 단계(progressPhase)가 API로 반환되지 않는다는 것을 알게 됨.
이로 인해, 화면에서 데이터를 노출함에 있어서, 여러 API를 혼재해서 사용 중임.

## ⭐️ 어떻게 해결했나요?

progressPhase를 응답으로 추가하여, 프론트에서 여러 API를 호출하지 않도록 처리.
다만, 이 과정에서 불필요하게 SessionWIthAttendanceDto를 생성하는데, getSessionProgressPhase 로직을 빠르게 재활용하기 위함.

- 조만간 전체 리팩토링 할 예정이니... 우선 빠르게 + 로직 안정성을 고려하여 개발


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예정된 세션 응답에 세션 진행 상태 정보 추가. 세션의 현재 진행 단계(PENDING, TODAY, ONGOING)를 조회 시 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->