### PR TITLE
fix: AdminUserDetailResponse activityUnits의 팀 정보 null 문제 해결

### DIFF
--- a/src/main/kotlin/co/yappuworld/team/client/application/AdminTeamService.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/application/AdminTeamService.kt
@@ -18,7 +18,6 @@ import co.yappuworld.team.infrastructure.entity.TeamEntity
 import co.yappuworld.team.infrastructure.entity.TeamServiceEntity
 import co.yappuworld.team.infrastructure.entity.ServiceLinks
 import co.yappuworld.team.infrastructure.entity.TeamMemberEntity
-import co.yappuworld.user.client.dto.response.AdminUserDetailTeamResponse
 import co.yappuworld.user.infrastructure.ActivityUnitFindService
 import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
 import org.springframework.stereotype.Service
@@ -60,12 +59,6 @@ class AdminTeamService(
 
         return AdminTeamDetailResponse.of(teamWithService, members)
     }
-
-    @Transactional(readOnly = true)
-    fun getActivityUnitTeams(activityUnits: List<ActivityUnitEntity>): Map<UUID, AdminUserDetailTeamResponse> =
-        teamMemberFindService
-            .findMembers(activityUnits)
-            .associate { it.activityUnit.id to AdminUserDetailTeamResponse.from(it) }
 
     @Transactional
     fun createTeam(request: AdminTeamCreateRequest): UUID {
@@ -118,17 +111,15 @@ class AdminTeamService(
         activityUnit: ActivityUnitEntity,
         teamId: UUID?
     ) {
-        teamMemberFindService.findMemberOrNull(activityUnit)?.let { existingMember ->
+        activityUnit.teamMember?.let { existingMember ->
             teamMemberCommandService.delete(existingMember)
         }
 
         if (teamId != null) {
             val team = teamFindService.findTeam(teamId)
-            val teamMember = TeamMemberEntity(
-                team = team,
-                activityUnit = activityUnit
-            )
-            teamMemberCommandService.save(teamMember)
+            TeamMemberEntity(team = team, activityUnit = activityUnit).also {
+                teamMemberCommandService.save(it)
+            }
         }
     }
 

--- a/src/main/kotlin/co/yappuworld/team/client/application/AdminTeamService.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/application/AdminTeamService.kt
@@ -219,7 +219,13 @@ class AdminTeamService(
         existingMembers
             .filterNot { it.activityUnit.id in activityUnitIds }
             .takeIf { it.isNotEmpty() }
-            ?.let { teamMemberCommandService.deleteAll(it) }
+            ?.let {
+                try {
+                    teamMemberCommandService.deleteAll(it)
+                } catch (e: IllegalArgumentException) {
+                    throw BusinessException(TeamError.INVALID_DELETE_REQUEST)
+                }
+            }
     }
 
     private fun deleteTeamMembers(team: TeamEntity) {

--- a/src/main/kotlin/co/yappuworld/team/client/application/AdminTeamService.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/application/AdminTeamService.kt
@@ -18,6 +18,7 @@ import co.yappuworld.team.infrastructure.entity.TeamEntity
 import co.yappuworld.team.infrastructure.entity.TeamServiceEntity
 import co.yappuworld.team.infrastructure.entity.ServiceLinks
 import co.yappuworld.team.infrastructure.entity.TeamMemberEntity
+import co.yappuworld.user.client.dto.response.AdminUserDetailTeamResponse
 import co.yappuworld.user.infrastructure.ActivityUnitFindService
 import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
 import org.springframework.stereotype.Service
@@ -59,6 +60,12 @@ class AdminTeamService(
 
         return AdminTeamDetailResponse.of(teamWithService, members)
     }
+
+    @Transactional(readOnly = true)
+    fun getActivityUnitTeams(activityUnits: List<ActivityUnitEntity>): Map<UUID, AdminUserDetailTeamResponse> =
+        teamMemberFindService
+            .findMembers(activityUnits)
+            .associate { it.activityUnit.id to AdminUserDetailTeamResponse.from(it) }
 
     @Transactional
     fun createTeam(request: AdminTeamCreateRequest): UUID {

--- a/src/main/kotlin/co/yappuworld/team/client/dto/response/AdminTeamDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/dto/response/AdminTeamDetailResponse.kt
@@ -77,7 +77,7 @@ data class AdminTeamMemberResponse(
             AdminTeamMemberResponse(
                 activityUnitId = dto.activityUnitId,
                 name = dto.userName,
-                position = dto.position
+                position = dto.position.label
             )
     }
 }

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/TeamMemberCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/TeamMemberCommandService.kt
@@ -20,15 +20,18 @@ class TeamMemberCommandService(
     }
 
     fun delete(teamMember: TeamMemberEntity) {
+        teamMember.removeActivityUnit()
         teamMemberRepository.delete(teamMember)
     }
 
     fun deleteAll(teamMembers: List<TeamMemberEntity>) {
         require(teamMembers.isNotEmpty()) { "최소 하나 이상의 삭제 대상이 필요합니다." }
+        teamMembers.forEach { it.removeActivityUnit() }
         teamMemberRepository.deleteAll(teamMembers)
     }
 
     fun deleteAll(team: TeamEntity) {
+        teamMemberRepository.findByTeam(team).forEach { it.removeActivityUnit() }
         teamMemberRepository.deleteAllByTeam(team)
     }
 }

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/TeamMemberFindService.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/TeamMemberFindService.kt
@@ -39,4 +39,9 @@ class TeamMemberFindService(
 
     fun findMemberOrNull(activityUnit: ActivityUnitEntity): TeamMemberEntity? =
         teamMemberRepository.findByActivityUnit(activityUnit)
+
+    fun findMembers(activityUnits: List<ActivityUnitEntity>): List<TeamMemberEntity> {
+        if (activityUnits.isEmpty()) return emptyList()
+        return teamMemberRepository.findAllByActivityUnitIn(activityUnits)
+    }
 }

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/TeamMemberFindService.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/TeamMemberFindService.kt
@@ -23,25 +23,13 @@ class TeamMemberFindService(
             selectTeamMemberDetail()
                 .from(
                     entity(TeamMemberEntity::class),
-                    join(ActivityUnitEntity::class).on(
-                        path(TeamMemberEntity::activityUnit)
-                            .path(ActivityUnitEntity::getId)
-                            .equal(path(ActivityUnitEntity::getId))
-                    ),
                     join(UserEntity::class).on(
-                        path(ActivityUnitEntity::userId)
+                        path(TeamMemberEntity::activityUnit)
+                            .path(ActivityUnitEntity::userId)
                             .equal(path(UserEntity::getId))
                     )
                 ).where(
                     path(TeamMemberEntity::team).path(TeamEntity::getId).equal(teamId)
                 )
         }
-
-    fun findMemberOrNull(activityUnit: ActivityUnitEntity): TeamMemberEntity? =
-        teamMemberRepository.findByActivityUnit(activityUnit)
-
-    fun findMembers(activityUnits: List<ActivityUnitEntity>): List<TeamMemberEntity> {
-        if (activityUnits.isEmpty()) return emptyList()
-        return teamMemberRepository.findAllByActivityUnitIn(activityUnits)
-    }
 }

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/dto/TeamMemberDetailDto.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/dto/TeamMemberDetailDto.kt
@@ -1,10 +1,11 @@
 package co.yappuworld.team.infrastructure.dto
 
+import co.yappuworld.user.domain.vo.Position
 import java.util.UUID
 
 data class TeamMemberDetailDto(
     val activityUnitId: UUID,
     val generation: Int,
-    val position: String,
+    val position: Position,
     val userName: String
 )

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/entity/TeamMemberEntity.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/entity/TeamMemberEntity.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.Table
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
 import jakarta.persistence.JoinColumn
 
 @Entity
@@ -20,8 +21,17 @@ class TeamMemberEntity(
     var team: TeamEntity = team
         private set
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "activity_unit_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_unit_id", unique = true)
     var activityUnit: ActivityUnitEntity = activityUnit
         private set
+
+    init {
+        this.activityUnit = activityUnit
+        activityUnit.teamMember = this
+    }
+
+    fun removeActivityUnit() {
+        this.activityUnit.teamMember = null
+    }
 }

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/jpa/TeamMemberRepository.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/jpa/TeamMemberRepository.kt
@@ -15,4 +15,6 @@ interface TeamMemberRepository :
     fun findByActivityUnit(activityUnit: ActivityUnitEntity): TeamMemberEntity?
 
     fun deleteAllByTeam(team: TeamEntity)
+
+    fun findAllByActivityUnitIn(activityUnits: List<ActivityUnitEntity>): List<TeamMemberEntity>
 }

--- a/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
@@ -84,12 +84,15 @@ class AdminUserService(
     }
 
     @Transactional(readOnly = true)
-    fun getUserDetail(userId: UUID): AdminUserDetailResponse =
-        AdminUserDetailResponse(
+    fun getUserDetail(userId: UUID): AdminUserDetailResponse {
+        val activityUnits = activityUnitFindService.findActivityUnits(userId)
+        return AdminUserDetailResponse(
             user = userFindService.findUser(userId),
-            activityUnits = activityUnitFindService.findActivityUnits(userId),
-            activeGeneration = generationActiveStateManager.getActiveGenerationOrNull()
+            activityUnits = activityUnits,
+            activeGeneration = generationActiveStateManager.getActiveGenerationOrNull(),
+            teams = adminTeamService.getActivityUnitTeams(activityUnits)
         )
+    }
 
     @Transactional(readOnly = true)
     fun getUserOverviews(request: AdminUserPageRequest): OffsetPageResponse<AdminUserOverviewResponse> =

--- a/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
@@ -84,15 +84,12 @@ class AdminUserService(
     }
 
     @Transactional(readOnly = true)
-    fun getUserDetail(userId: UUID): AdminUserDetailResponse {
-        val activityUnits = activityUnitFindService.findActivityUnits(userId)
-        return AdminUserDetailResponse(
+    fun getUserDetail(userId: UUID): AdminUserDetailResponse =
+        AdminUserDetailResponse(
             user = userFindService.findUser(userId),
-            activityUnits = activityUnits,
-            activeGeneration = generationActiveStateManager.getActiveGenerationOrNull(),
-            teams = adminTeamService.getActivityUnitTeams(activityUnits)
+            activityUnits = activityUnitFindService.findActivityUnits(userId),
+            activeGeneration = generationActiveStateManager.getActiveGenerationOrNull()
         )
-    }
 
     @Transactional(readOnly = true)
     fun getUserOverviews(request: AdminUserPageRequest): OffsetPageResponse<AdminUserOverviewResponse> =

--- a/src/main/kotlin/co/yappuworld/user/client/dto/response/AdminUserDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/dto/response/AdminUserDetailResponse.kt
@@ -1,6 +1,5 @@
 package co.yappuworld.user.client.dto.response
 
-import co.yappuworld.team.infrastructure.entity.TeamMemberEntity
 import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
 import co.yappuworld.user.infrastructure.entity.UserEntity
 import io.swagger.v3.oas.annotations.media.Schema
@@ -31,8 +30,7 @@ data class AdminUserDetailResponse(
     constructor(
         user: UserEntity,
         activityUnits: List<ActivityUnitEntity>,
-        activeGeneration: Int?,
-        teams: Map<UUID, AdminUserDetailTeamResponse> = emptyMap()
+        activeGeneration: Int?
     ) : this(
         id = user.id,
         name = user.name,
@@ -43,7 +41,7 @@ data class AdminUserDetailResponse(
         isActive = user.isActive,
         registrationDate = user.createdAt.toLocalDate(),
         activityUnits = activityUnits
-            .map { AdminUserDetailActivityUnitResponse(it, activeGeneration, team = teams[it.id]) }
+            .map { AdminUserDetailActivityUnitResponse(it, activeGeneration) }
             .sortedByDescending { it.generation }
     )
 }
@@ -63,14 +61,13 @@ data class AdminUserDetailActivityUnitResponse(
 
     constructor(
         activityUnit: ActivityUnitEntity,
-        activeGeneration: Int?,
-        team: AdminUserDetailTeamResponse? = null
+        activeGeneration: Int?
     ) : this(
         id = activityUnit.id,
         generation = activityUnit.generation,
         position = activityUnit.position.label,
         isActive = activityUnit.generation == activeGeneration,
-        team = team
+        team = AdminUserDetailTeamResponse.from(activityUnit)
     )
 }
 
@@ -81,10 +78,13 @@ data class AdminUserDetailTeamResponse(
     val name: String
 ) {
     companion object {
-        fun from(teamMember: TeamMemberEntity): AdminUserDetailTeamResponse =
-            AdminUserDetailTeamResponse(
-                id = teamMember.team.id,
-                name = teamMember.team.name
+        fun from(activityUnit: ActivityUnitEntity): AdminUserDetailTeamResponse? {
+            val team = activityUnit.teamMember?.team ?: return null
+
+            return AdminUserDetailTeamResponse(
+                id = team.id,
+                name = team.name
             )
+        }
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/client/dto/response/AdminUserDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/dto/response/AdminUserDetailResponse.kt
@@ -1,5 +1,6 @@
 package co.yappuworld.user.client.dto.response
 
+import co.yappuworld.team.infrastructure.entity.TeamMemberEntity
 import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
 import co.yappuworld.user.infrastructure.entity.UserEntity
 import io.swagger.v3.oas.annotations.media.Schema
@@ -30,7 +31,8 @@ data class AdminUserDetailResponse(
     constructor(
         user: UserEntity,
         activityUnits: List<ActivityUnitEntity>,
-        activeGeneration: Int?
+        activeGeneration: Int?,
+        teams: Map<UUID, AdminUserDetailTeamResponse> = emptyMap()
     ) : this(
         id = user.id,
         name = user.name,
@@ -41,7 +43,7 @@ data class AdminUserDetailResponse(
         isActive = user.isActive,
         registrationDate = user.createdAt.toLocalDate(),
         activityUnits = activityUnits
-            .map { AdminUserDetailActivityUnitResponse(it, activeGeneration) }
+            .map { AdminUserDetailActivityUnitResponse(it, activeGeneration, team = teams[it.id]) }
             .sortedByDescending { it.generation }
     )
 }
@@ -77,4 +79,12 @@ data class AdminUserDetailTeamResponse(
     val id: UUID,
     @Schema(description = "팀 이름")
     val name: String
-)
+) {
+    companion object {
+        fun from(teamMember: TeamMemberEntity): AdminUserDetailTeamResponse =
+            AdminUserDetailTeamResponse(
+                id = teamMember.team.id,
+                name = teamMember.team.name
+            )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/entity/ActivityUnitEntity.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/entity/ActivityUnitEntity.kt
@@ -1,11 +1,14 @@
 package co.yappuworld.user.infrastructure.entity
 
 import co.yappuworld.global.persistence.BaseEntity
+import co.yappuworld.team.infrastructure.entity.TeamMemberEntity
 import co.yappuworld.user.domain.vo.Position
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.Table
+import jakarta.persistence.OneToOne
 import java.util.UUID
 
 @Entity
@@ -22,6 +25,9 @@ class ActivityUnitEntity(
     @Enumerated(EnumType.STRING)
     var position: Position = position
         private set
+
+    @OneToOne(mappedBy = "activityUnit", fetch = FetchType.LAZY)
+    var teamMember: TeamMemberEntity? = null
 
     fun updateActivityUnit(
         generation: Int,

--- a/src/test/kotlin/co/yappuworld/team/client/application/AdminTeamServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/team/client/application/AdminTeamServiceTest.kt
@@ -66,7 +66,7 @@ class AdminTeamServiceTest @Autowired constructor(
         }
 
         fun getTeamByActivityUnit(activityUnit: ActivityUnitEntity): UserTeamResponse? {
-            val teamMember = teamMemberRepository.findByActivityUnit(activityUnit) ?: return null
+            val teamMember = activityUnit.teamMember ?: return null
 
             return UserTeamResponse(
                 id = teamMember.team.id,

--- a/src/test/kotlin/co/yappuworld/team/infrastructure/TeamMemberFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/team/infrastructure/TeamMemberFindServiceTest.kt
@@ -1,0 +1,47 @@
+package co.yappuworld.team.infrastructure
+
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
+import co.yappuworld.support.fixture.TeamFixture.getTeamEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getActivityUnitEntityFixture
+import co.yappuworld.team.infrastructure.entity.TeamMemberEntity
+import co.yappuworld.team.infrastructure.jpa.TeamMemberRepository
+import co.yappuworld.team.infrastructure.jpa.TeamRepository
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.infrastructure.jpa.UserRepository
+import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+
+class TeamMemberFindServiceTest @Autowired constructor(
+    private val teamMemberRepository: TeamMemberRepository,
+    private val teamRepository: TeamRepository,
+    private val userRepository: UserRepository,
+    private val activityUnitRepository: ActivityUnitRepository
+) : CustomDataJpaTestFeatureSpec({
+        val teamMemberFindService = TeamMemberFindService(teamMemberRepository)
+
+        feature("팀 멤버 상세 정보 조회") {
+
+            scenario("팀 ID로 멤버 상세 정보 조회") {
+                val team = teamRepository.save(getTeamEntityFixture(generation = 36, name = "팀"))
+                val user = userRepository.save(getUserEntityFixture(name = "홍길동"))
+                val activityUnit = activityUnitRepository.save(
+                    getActivityUnitEntityFixture(userId = user.id, generation = 36, position = Position.IOS)
+                )
+
+                teamMemberRepository.save(TeamMemberEntity(team = team, activityUnit = activityUnit))
+
+                val result = teamMemberFindService.findTeamMembersDetail(team.id)
+
+                result shouldHaveSize 1
+                result.filterNotNull() shouldHaveSize 1
+
+                val member1 = result.find { it?.userName == "홍길동" }
+                member1?.generation shouldBe 36
+                member1?.position shouldBe Position.IOS
+                member1?.activityUnitId shouldBe activityUnit.id
+            }
+        }
+    })


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- AdminUserDetailResponse의 activityUnits에 포함된 팀 정보가 항상 null로 조회되고 있었습니다.

## ⭐️ 어떻게 해결했나요?
- AdminTeamService에 ActivityUnit 목록으로 팀 정보를 조회하는 getActivityUnitTeams() 메서드 추가
- AdminUserDetailResponse 생성 시 조회한 팀 정보를 Map으로 전달하여 각 ActivityUnit과 매핑

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 팀 멤버와 활동 단위 간의 관계를 일대일로 정비하고 연관성 관리를 개선했습니다.
  * 팀 멤버 조회·저장 흐름을 정리해 안정성을 높였습니다.

* **Bug Fixes**
  * 팀 멤버 삭제 시 연관 활동 단위 사전 정리와 예외 처리 개선으로 삭제 오류를 명확히 처리합니다.

* **Tests**
  * 팀 멤버 상세 조회에 대한 통합 테스트를 추가/확장했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->