### PR TITLE
feat: 어드민 회원 탈퇴 처리

### DIFF
--- a/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
@@ -17,6 +17,7 @@ import co.yappuworld.user.client.application.usecase.UserLoginPermissionChecker
 import co.yappuworld.user.client.dto.request.AdminActivityUnitUpdateRequest
 import co.yappuworld.user.client.dto.request.AdminReissueTokenRequest
 import co.yappuworld.user.client.dto.request.AdminSignUpCodeUpdateRequest
+import co.yappuworld.user.client.dto.request.AdminUserDeactivateRequest
 import co.yappuworld.user.client.dto.request.AdminUserPageRequest
 import co.yappuworld.user.client.dto.request.AdminUserUpdateRequest
 import co.yappuworld.user.client.dto.request.LoginRequest
@@ -27,6 +28,7 @@ import co.yappuworld.user.client.dto.response.AdminUserProfileResponse
 import co.yappuworld.user.domain.vo.UserError
 import co.yappuworld.user.infrastructure.ActivityUnitCommandService
 import co.yappuworld.user.infrastructure.ActivityUnitFindService
+import co.yappuworld.user.infrastructure.UserCommandService
 import co.yappuworld.user.infrastructure.UserFindService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -45,7 +47,8 @@ class AdminUserService(
     private val userLoginPermissionChecker: UserLoginPermissionChecker,
     private val generationActiveStateManager: GenerationActiveStateManager,
     private val configFindService: ConfigFindService,
-    private val configCommandService: ConfigCommandService
+    private val configCommandService: ConfigCommandService,
+    private val userCommandService: UserCommandService
 ) {
 
     @Transactional
@@ -125,6 +128,12 @@ class AdminUserService(
     @Transactional(readOnly = true)
     fun getUserProfile(userId: UUID): AdminUserProfileResponse =
         AdminUserProfileResponse(userFindService.findUserWithLastActivityUnit(userId))
+
+    @Transactional
+    fun deactivate(request: AdminUserDeactivateRequest) {
+        val user = userFindService.findUser(request.userId)
+        userCommandService.deactivate(user)
+    }
 
     private fun handleActivityUnitRequest(
         userId: UUID,

--- a/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/AdminUserService.kt
@@ -17,7 +17,6 @@ import co.yappuworld.user.client.application.usecase.UserLoginPermissionChecker
 import co.yappuworld.user.client.dto.request.AdminActivityUnitUpdateRequest
 import co.yappuworld.user.client.dto.request.AdminReissueTokenRequest
 import co.yappuworld.user.client.dto.request.AdminSignUpCodeUpdateRequest
-import co.yappuworld.user.client.dto.request.AdminUserDeactivateRequest
 import co.yappuworld.user.client.dto.request.AdminUserPageRequest
 import co.yappuworld.user.client.dto.request.AdminUserUpdateRequest
 import co.yappuworld.user.client.dto.request.LoginRequest
@@ -130,8 +129,8 @@ class AdminUserService(
         AdminUserProfileResponse(userFindService.findUserWithLastActivityUnit(userId))
 
     @Transactional
-    fun deactivate(request: AdminUserDeactivateRequest) {
-        val user = userFindService.findUser(request.userId)
+    fun deactivate(userId: UUID) {
+        val user = userFindService.findUser(userId)
         userCommandService.deactivate(user)
     }
 

--- a/src/main/kotlin/co/yappuworld/user/client/dto/request/AdminUserDeactivateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/dto/request/AdminUserDeactivateRequest.kt
@@ -1,0 +1,9 @@
+package co.yappuworld.user.client.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+data class AdminUserDeactivateRequest(
+    @param:Schema(description = "탈퇴 시킬 유저 ID")
+    val userId: UUID
+)

--- a/src/main/kotlin/co/yappuworld/user/client/dto/request/AdminUserUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/dto/request/AdminUserUpdateRequest.kt
@@ -7,7 +7,6 @@ import co.yappuworld.user.domain.vo.UserRole
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.NotNull
 import java.util.UUID
 
 data class AdminUserUpdateRequest(

--- a/src/main/kotlin/co/yappuworld/user/client/dto/request/AdminUserUpdateRequest.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/dto/request/AdminUserUpdateRequest.kt
@@ -11,23 +11,22 @@ import jakarta.validation.constraints.NotNull
 import java.util.UUID
 
 data class AdminUserUpdateRequest(
-    @Schema(description = "변경 대상 유저 ID")
-    @field:NotNull(message = "유저 ID는 필수 입력 값입니다.")
+    @param:Schema(description = "변경 대상 유저 ID")
     val userId: UUID,
-    @Schema(description = "이름")
-    @field:NotBlank(message = "유저 이름은 필수 입력 값입니다.")
+    @param:Schema(description = "이름")
+    @param:NotBlank(message = "유저 이름은 필수 입력 값입니다.")
     val name: String,
-    @Schema(description = "이메일")
-    @field:NotBlank(message = "유저 이메일은 필수 입력 값입니다.")
+    @param:Schema(description = "이메일")
+    @param:NotBlank(message = "유저 이메일은 필수 입력 값입니다.")
     val email: String,
-    @Schema(description = "역할")
+    @param:Schema(description = "역할")
     val role: UserRole,
-    @Schema(description = "활동내역")
-    @field:NotEmpty(message = "유저 활동내역은 필수 입력 값입니다.")
+    @param:Schema(description = "활동내역")
+    @param:NotEmpty(message = "유저 활동내역은 필수 입력 값입니다.")
     val activityUnits: List<AdminActivityUnitUpdateRequest>,
-    @Schema(description = "전화번호, 요청 시에는 하이픈을 제외한 형태로", nullable = true)
+    @param:Schema(description = "전화번호, 요청 시에는 하이픈을 제외한 형태로", nullable = true)
     val phoneNumber: String? = null,
-    @Schema(description = "성별", nullable = true, allowableValues = ["남", "여"])
+    @param:Schema(description = "성별", nullable = true, allowableValues = ["남", "여"])
     val gender: String? = null
 ) {
 

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
@@ -5,6 +5,7 @@ import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.user.client.dto.request.AdminUserPageRequest
 import co.yappuworld.user.client.dto.request.AdminUserUpdateRequest
+import co.yappuworld.user.client.dto.request.AdminUserDeactivateRequest
 import co.yappuworld.user.client.dto.response.AdminUserDetailResponse
 import co.yappuworld.user.client.dto.response.AdminUserOverviewResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import java.util.UUID
+import org.springframework.web.bind.annotation.DeleteMapping
 
 @Tag(name = "회원 관리 API", description = "_")
 interface AdminUserManageApi {
@@ -197,5 +199,43 @@ interface AdminUserManageApi {
     @PutMapping("/admin/v1/users")
     fun updateUserDetails(
         @Valid @RequestBody request: AdminUserUpdateRequest
+    ): ResponseEntity<Unit>
+
+    @Operation(
+        summary = "회원 탈퇴 처리",
+        description = "_"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                content = [Content()]
+            ),
+            ApiResponse(
+                description = "리소스를 찾을 수 없습니다.",
+                responseCode = "404",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "유저가 존재하지 않습니다.",
+                                value = """
+                                    {
+                                        "isSuccess": false,
+                                        "message": "유저가 존재하지 않습니다.",
+                                        "errorCode": "USR_0001"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @DeleteMapping("/admin/v1/users")
+    fun deactivateUser(
+        @Valid @RequestBody request: AdminUserDeactivateRequest
     ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageApi.kt
@@ -5,7 +5,6 @@ import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.user.client.dto.request.AdminUserPageRequest
 import co.yappuworld.user.client.dto.request.AdminUserUpdateRequest
-import co.yappuworld.user.client.dto.request.AdminUserDeactivateRequest
 import co.yappuworld.user.client.dto.response.AdminUserDetailResponse
 import co.yappuworld.user.client.dto.response.AdminUserOverviewResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -18,12 +17,12 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import java.util.UUID
-import org.springframework.web.bind.annotation.DeleteMapping
 
 @Tag(name = "회원 관리 API", description = "_")
 interface AdminUserManageApi {
@@ -234,8 +233,8 @@ interface AdminUserManageApi {
             )
         ]
     )
-    @DeleteMapping("/admin/v1/users")
+    @DeleteMapping("/admin/v1/users/{userId}")
     fun deactivateUser(
-        @Valid @RequestBody request: AdminUserDeactivateRequest
+        @PathVariable("userId") userId: UUID
     ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageController.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageController.kt
@@ -3,14 +3,13 @@ package co.yappuworld.user.client.presentation
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.user.client.application.AdminUserService
-import co.yappuworld.user.client.dto.request.AdminUserDeactivateRequest
 import co.yappuworld.user.client.dto.request.AdminUserPageRequest
 import co.yappuworld.user.client.dto.request.AdminUserUpdateRequest
 import co.yappuworld.user.client.dto.response.AdminUserDetailResponse
 import co.yappuworld.user.client.dto.response.AdminUserOverviewResponse
-import java.util.UUID
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController
 class AdminUserManageController(
@@ -35,8 +34,8 @@ class AdminUserManageController(
         return ResponseEntity.noContent().build()
     }
 
-    override fun deactivateUser(request: AdminUserDeactivateRequest): ResponseEntity<Unit> {
-        adminUserService.deactivate(request)
+    override fun deactivateUser(userId: UUID): ResponseEntity<Unit> {
+        adminUserService.deactivate(userId)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageController.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/AdminUserManageController.kt
@@ -3,13 +3,14 @@ package co.yappuworld.user.client.presentation
 import co.yappuworld.global.response.OffsetPageResponse
 import co.yappuworld.global.response.SuccessResponse
 import co.yappuworld.user.client.application.AdminUserService
+import co.yappuworld.user.client.dto.request.AdminUserDeactivateRequest
 import co.yappuworld.user.client.dto.request.AdminUserPageRequest
 import co.yappuworld.user.client.dto.request.AdminUserUpdateRequest
 import co.yappuworld.user.client.dto.response.AdminUserDetailResponse
 import co.yappuworld.user.client.dto.response.AdminUserOverviewResponse
+import java.util.UUID
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 class AdminUserManageController(
@@ -31,6 +32,11 @@ class AdminUserManageController(
     override fun updateUserDetails(request: AdminUserUpdateRequest): ResponseEntity<Unit> {
         request.checkRequest()
         adminUserService.updateUserDetails(request)
+        return ResponseEntity.noContent().build()
+    }
+
+    override fun deactivateUser(request: AdminUserDeactivateRequest): ResponseEntity<Unit> {
+        adminUserService.deactivate(request)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserCommandService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserCommandService.kt
@@ -35,4 +35,10 @@ class UserCommandService(
     fun getLock(email: String): Int? = userRepository.getLock(email)
 
     fun releaseLock(email: String): Int? = userRepository.releaseLock(email)
+
+    fun deactivate(user: UserEntity) {
+        user.withdraw()
+        userDeviceRepository.deleteByUserId(user.id)
+        userAlarmSettingRepository.deleteByUserId(user.id)
+    }
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/UserAlarmSettingRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/UserAlarmSettingRepository.kt
@@ -7,4 +7,6 @@ import java.util.UUID
 interface UserAlarmSettingRepository : JpaRepository<UserAlarmSettingEntity, UUID> {
 
     fun findUserAlarmSettingOrNullByUserId(userId: UUID): UserAlarmSettingEntity?
+
+    fun deleteByUserId(userId: UUID)
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/UserDeviceRepository.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/jpa/UserDeviceRepository.kt
@@ -7,4 +7,6 @@ import java.util.UUID
 interface UserDeviceRepository : JpaRepository<UserDeviceEntity, UUID> {
 
     fun findUserDeviceOrNullByUserId(userId: UUID): UserDeviceEntity?
+
+    fun deleteByUserId(userId: UUID)
 }

--- a/src/test/kotlin/co/yappuworld/user/infrastructure/UserCommandServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/infrastructure/UserCommandServiceTest.kt
@@ -3,11 +3,14 @@ package co.yappuworld.user.infrastructure
 import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.UserFixture.getSignUpApplicationEntityFixture
 import co.yappuworld.user.domain.vo.UserRole
+import co.yappuworld.user.infrastructure.entity.SignUpApplicationEntity
+import co.yappuworld.user.infrastructure.entity.UserEntity
 import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
 import co.yappuworld.user.infrastructure.jpa.UserAlarmSettingRepository
 import co.yappuworld.user.infrastructure.jpa.UserDeviceRepository
 import co.yappuworld.user.infrastructure.jpa.UserRepository
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
@@ -43,6 +46,26 @@ class UserCommandServiceTest @Autowired constructor(
                 activityUnitRepository.findAllByUserId(user.id).shouldNotBeEmpty()
                 userAlarmSettingRepository.findUserAlarmSettingOrNullByUserId(user.id).shouldNotBeNull()
                 userDeviceRepository.findUserDeviceOrNullByUserId(user.id).shouldNotBeNull()
+            }
+        }
+
+        feature("회원 탈퇴") {
+            fun signUp(application: SignUpApplicationEntity): UserEntity =
+                userCommandService.signUp(application, UserRole.ACTIVE)
+
+            scenario("회원 탈퇴 시 isActive가 False로 변경된다.") {
+                val user = signUp(getSignUpApplicationEntityFixture())
+                userCommandService.deactivate(user)
+
+                user.isActive shouldBe false
+            }
+
+            scenario("회원 탈퇴 시 기기와 알림 정보는 삭제된다.") {
+                val user = signUp(getSignUpApplicationEntityFixture())
+                userCommandService.deactivate(user)
+
+                userDeviceRepository.findUserDeviceOrNullByUserId(user.id).shouldBeNull()
+                userAlarmSettingRepository.findUserAlarmSettingOrNullByUserId(user.id).shouldBeNull()
             }
         }
     })


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 어드민에서 회원을 탈퇴 시키는 기능을 만듭니다.


## ⭐️ 어떻게 해결했나요?
- 유저 데이터는 남겨두기 위해 User의 isActive 값을 변경합니다.
- 기기 정보(UserDevice), 알림 정보(UserAlarmSetting)는 삭제합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관리자가 사용자 계정을 비활성화(탈퇴 처리)할 수 있는 API(DELETE /admin/v1/users/{userId})가 추가되었습니다. 성공 시 204 응답을 반환합니다.
  * 사용자 비활성화 시 연관된 기기 정보와 알림 설정이 자동으로 삭제됩니다.

* **개선 사항**
  * API 요청 검증·스키마 주석이 파라미터 기반으로 조정되어 메타데이터와 검증 동작이 개선되었습니다.

* **테스트**
  * 사용자 탈퇴 흐름과 연관 데이터 삭제를 검증하는 테스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->