### PR TITLE
fix: 일정 조회 Oracle 호환성 개선

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/ScheduleFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/ScheduleFindService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
+// 이것만 수정하면 됨
 @Service
 @Transactional(readOnly = true)
 class ScheduleFindService(
@@ -14,5 +15,16 @@ class ScheduleFindService(
     fun findSchedulesBetween(
         from: LocalDate,
         toInclusive: LocalDate
-    ): List<ScheduleEntity> = scheduleRepository.findScheduleEntitiesByDateBetween(from, toInclusive)
+    ): List<ScheduleEntity> =
+        scheduleRepository
+            .findAll {
+                select(entity(ScheduleEntity::class))
+                    .from(entity(ScheduleEntity::class))
+                    .where(
+                        and(
+                            path(ScheduleEntity::date).greaterThanOrEqualTo(from),
+                            path(ScheduleEntity::date).lessThanOrEqualTo(toInclusive)
+                        )
+                    )
+            }.filterNotNull()
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/ScheduleFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/ScheduleFindService.kt
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
-// 이것만 수정하면 됨
 @Service
 @Transactional(readOnly = true)
 class ScheduleFindService(

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/ScheduleRepository.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/ScheduleRepository.kt
@@ -4,7 +4,6 @@ import co.yappuworld.schedule.infrastructure.entity.ScheduleEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import org.springframework.data.jpa.repository.JpaRepository
-import java.time.LocalDate
 import java.util.UUID
 
 interface ScheduleRepository :
@@ -13,13 +12,4 @@ interface ScheduleRepository :
     KotlinJdslJpqlExecutor {
 
     fun findAllByIdIn(ids: List<UUID>): List<SessionEntity>
-
-    /**
-     * @param from Inclusive
-     * @param to Inclusive
-     */
-    fun findScheduleEntitiesByDateBetween(
-        from: LocalDate,
-        to: LocalDate
-    ): List<ScheduleEntity>
 }


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- Oracle 이관 후 일정 조회 API에서 500 에러가 발생했습니다.

## ⭐️ 어떻게 해결했나요?
`ScheduleFindService.findSchedulesBetween()` 메서드를 JDSL을 사용하도록 변경했습니다.

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 일정 조회 로직을 내부적으로 재구성하여 성능과 유지보수성을 개선했습니다.
  * 날짜 범위 기반 일정 검색 구현을 변경하여 동일한 범위 결과를 보다 안정적으로 반환합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->