### PR TITLE
feat: 출석 내역 개선용 v2 API 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
@@ -93,6 +93,7 @@ class AttendanceService(
         now: LocalDateTime
     ): AttendancesHistoryResponseV2 {
         val activeGeneration = generationFindService.findActiveGeneration()
+        userFindService.findSessionAttendee(userId, activeGeneration)
         val sessionsWithAttendance = sessionFindService.findSessionsWithAttendanceStatus(
             generation = activeGeneration,
             userId = userId,

--- a/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/application/AttendanceService.kt
@@ -5,6 +5,7 @@ import co.yappuworld.operation.infrastructure.ConfigFindService
 import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponse
+import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponseV2
 import co.yappuworld.schedule.domain.AttendanceBook
 import co.yappuworld.schedule.domain.UserAttendanceStatistics
 import co.yappuworld.schedule.domain.vo.AttendanceError
@@ -84,6 +85,21 @@ class AttendanceService(
         )
 
         return AttendancesHistoryResponse.of(sessionsWithAttendance)
+    }
+
+    @Transactional(readOnly = true)
+    fun getAttendancesHistoryV2(
+        userId: UUID,
+        now: LocalDateTime
+    ): AttendancesHistoryResponseV2 {
+        val activeGeneration = generationFindService.findActiveGeneration()
+        val sessionsWithAttendance = sessionFindService.findSessionsWithAttendanceStatus(
+            generation = activeGeneration,
+            userId = userId,
+            now = now
+        )
+
+        return AttendancesHistoryResponseV2.of(sessionsWithAttendance, now)
     }
 
     private fun checkAttendanceCode(attendanceCode: String) {

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponse.kt
@@ -6,7 +6,7 @@ import co.yappuworld.schedule.domain.vo.SessionProgressPhase.DONE
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase.PENDING
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase.TODAY
 import co.yappuworld.schedule.domain.vo.SessionType
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
+import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -30,7 +30,7 @@ data class ActiveGenerationSessionsResponse(
 
     companion object {
         fun from(
-            sessions: List<SessionWithAttendanceDto>,
+            sessions: List<UserSessionAttendance>,
             now: LocalDateTime
         ): ActiveGenerationSessionsResponse {
             if (sessions.isEmpty()) return ActiveGenerationSessionsResponse(emptyList(), null)
@@ -55,7 +55,7 @@ data class ActiveGenerationSessionsResponse(
         }
 
         private fun getUpcomingSessionIndexAndStatus(
-            orderedSessions: List<SessionWithAttendanceDto>,
+            orderedSessions: List<UserSessionAttendance>,
             now: LocalDateTime
         ): Pair<Int, SessionProgressPhase>? {
             val upcomingSession = orderedSessions.firstOrNull { !it.isFinished(now) }
@@ -113,7 +113,7 @@ data class ActiveGenerationSessionResponse(
 ) {
 
     constructor(
-        session: SessionWithAttendanceDto,
+        session: UserSessionAttendance,
         status: SessionProgressPhase,
         now: LocalDateTime
     ) : this(

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponseV2.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/ActiveGenerationSessionsResponseV2.kt
@@ -5,7 +5,7 @@ import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase.DONE
 import co.yappuworld.schedule.domain.vo.SessionType
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
+import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -29,7 +29,7 @@ data class ActiveGenerationSessionsResponseV2(
 
     companion object {
         fun from(
-            sessions: List<SessionWithAttendanceDto>,
+            sessions: List<UserSessionAttendance>,
             now: LocalDateTime
         ): ActiveGenerationSessionsResponseV2 {
             if (sessions.isEmpty()) return ActiveGenerationSessionsResponseV2(emptyList(), null)
@@ -51,7 +51,7 @@ data class ActiveGenerationSessionsResponseV2(
         }
 
         private fun getUpcomingSessionIndexAndStatus(
-            orderedSessions: List<SessionWithAttendanceDto>,
+            orderedSessions: List<UserSessionAttendance>,
             now: LocalDateTime
         ): Int? {
             val upcomingSession = orderedSessions.firstOrNull { !it.isFinished(now) }
@@ -104,7 +104,7 @@ data class ActiveGenerationSessionResponseV2(
 ) {
 
     constructor(
-        session: SessionWithAttendanceDto,
+        session: UserSessionAttendance,
         status: SessionProgressPhase,
         now: LocalDateTime
     ) : this(

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseV2.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseV2.kt
@@ -20,7 +20,9 @@ data class AttendanceStatisticsResponseV2(
     @field:Schema(description = "결석한 세션 수")
     val absenceCount: Int,
     @field:Schema(description = "지각 면제권 수")
-    val latePassCount: Int
+    val latePassCount: Int,
+    @field:Schema(description = "출석 현황 상태", allowableValues = ["GOOD", "CAUTION", "INCOMPLETE"])
+    val summaryStatus: AttendanceSummaryStatus
 ) {
 
     companion object {
@@ -37,7 +39,8 @@ data class AttendanceStatisticsResponseV2(
                     attendanceCount = it.onTimeCount,
                     lateCount = it.lateCount,
                     absenceCount = it.absentCount,
-                    latePassCount = it.latePassCount
+                    latePassCount = it.latePassCount,
+                    summaryStatus = AttendanceSummaryStatus.from(it)
                 )
             }
     }

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceSummaryStatus.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceSummaryStatus.kt
@@ -1,0 +1,18 @@
+package co.yappuworld.schedule.client.dto.response
+
+import co.yappuworld.schedule.domain.UserAttendanceStatistics
+
+enum class AttendanceSummaryStatus {
+    GOOD,
+    CAUTION,
+    INCOMPLETE;
+
+    companion object {
+        fun from(statistics: UserAttendanceStatistics): AttendanceSummaryStatus =
+            when {
+                statistics.totalPoint < 70 -> INCOMPLETE
+                statistics.totalPoint < 80 -> CAUTION
+                else -> GOOD
+            }
+    }
+}

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendancesHistoryResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendancesHistoryResponse.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.schedule.client.dto.response
 
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
+import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 import java.util.UUID
@@ -11,7 +11,7 @@ data class AttendancesHistoryResponse(
 ) {
 
     companion object {
-        fun of(sessions: List<SessionWithAttendanceDto>): AttendancesHistoryResponse =
+        fun of(sessions: List<UserSessionAttendance>): AttendancesHistoryResponse =
             AttendancesHistoryResponse(sessions.map { AttendanceHistoryResponse(it) })
     }
 }
@@ -27,7 +27,7 @@ data class AttendanceHistoryResponse(
     val attendanceStatus: String?
 ) {
 
-    constructor(session: SessionWithAttendanceDto) : this(
+    constructor(session: UserSessionAttendance) : this(
         sessionId = session.id,
         name = session.name,
         checkedInAt = session.checkedInAt,

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendancesHistoryResponseV2.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/AttendancesHistoryResponseV2.kt
@@ -1,0 +1,62 @@
+package co.yappuworld.schedule.client.dto.response
+
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase
+import co.yappuworld.schedule.domain.vo.SessionType
+import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class AttendancesHistoryResponseV2(
+    @field:Schema(description = "세션 출석 이력 목록")
+    val histories: List<AttendanceHistoryResponseV2>
+) {
+
+    companion object {
+        fun of(
+            sessions: List<UserSessionAttendance>,
+            now: LocalDateTime
+        ): AttendancesHistoryResponseV2 =
+            AttendancesHistoryResponseV2(
+                histories = sessions
+                    .sortedWith(compareBy({ it.date }, { it.time }, { it.endDate }, { it.endTime }, { it.id }))
+                    .map { AttendanceHistoryResponseV2(it, now) }
+            )
+    }
+}
+
+data class AttendanceHistoryResponseV2(
+    @field:Schema(description = "세션 식별자")
+    val sessionId: UUID,
+    @field:Schema(description = "세션 제목")
+    val title: String,
+    @field:Schema(description = "세션 종류")
+    val sessionType: SessionType,
+    @field:Schema(description = "세션 시작 일시")
+    val startAt: LocalDateTime,
+    @field:Schema(description = "세션 종료 일시")
+    val endAt: LocalDateTime,
+    @field:Schema(description = "출석 시간", nullable = true)
+    val checkedInAt: LocalDateTime?,
+    @field:Schema(
+        description = "출석 상태",
+        nullable = true,
+        allowableValues = ["PENDING", "ON_TIME", "LATE", "ABSENT", "EARLY_CHECK_OUT", "EXCUSED_ABSENCE"]
+    )
+    val attendanceStatus: AttendanceStatus?,
+    @field:Schema(description = "세션 진행 상태")
+    val progressPhase: SessionProgressPhase
+) {
+
+    constructor(session: UserSessionAttendance, now: LocalDateTime) : this(
+        sessionId = session.id,
+        title = session.name,
+        sessionType = session.sessionType,
+        startAt = LocalDateTime.of(session.date, session.time),
+        endAt = LocalDateTime.of(session.endDate, session.endTime),
+        checkedInAt = session.checkedInAt,
+        attendanceStatus = session.resolveAttendanceStatus(now),
+        progressPhase = session.getSessionProgressPhase(now)
+    )
+}

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
@@ -29,9 +29,8 @@ data class SchedulePageResponse(
             now: LocalDateTime
         ): SchedulePageResponse {
             val attendanceBySessionId = attendances.associateBy { it.session.id }
-            // TODO: 일단 세션 뿐이니, 세션으로만 변환, 추후에 다른 Schedule도 처리하도록 변경 필요
-            val scheduleWithAttendance = schedules.map {
-                UserSessionAttendance.from(it as SessionEntity, attendanceBySessionId[it.id])
+            val scheduleWithAttendance = schedules.filterIsInstance<SessionEntity>().map {
+                UserSessionAttendance.from(it, attendanceBySessionId[it.id])
             }
             val scheduleByDate = scheduleWithAttendance.groupBy { it.date }
 

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponse.kt
@@ -6,7 +6,7 @@ import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
 import co.yappuworld.schedule.domain.vo.ScheduleProgressPhase
 import co.yappuworld.schedule.domain.vo.ScheduleType
 import co.yappuworld.schedule.domain.vo.SessionType
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
+import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.ScheduleEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
@@ -31,7 +31,7 @@ data class SchedulePageResponse(
             val attendanceBySessionId = attendances.associateBy { it.session.id }
             // TODO: 일단 세션 뿐이니, 세션으로만 변환, 추후에 다른 Schedule도 처리하도록 변경 필요
             val scheduleWithAttendance = schedules.map {
-                SessionWithAttendanceDto.from(it as SessionEntity, attendanceBySessionId[it.id])
+                UserSessionAttendance.from(it as SessionEntity, attendanceBySessionId[it.id])
             }
             val scheduleByDate = scheduleWithAttendance.groupBy { it.date }
 
@@ -60,7 +60,7 @@ data class DateGroupedScheduleResponse(
 
     constructor(
         date: LocalDate,
-        scheduleWithAttendance: List<SessionWithAttendanceDto>,
+        scheduleWithAttendance: List<UserSessionAttendance>,
         now: LocalDateTime
     ) : this(
         date = date,
@@ -101,12 +101,12 @@ data class SimpleScheduleResponse(
 
     companion object {
         fun from(
-            scheduleWithAttendance: SessionWithAttendanceDto,
+            scheduleWithAttendance: UserSessionAttendance,
             now: LocalDateTime
         ): SimpleScheduleResponse = convertSession(scheduleWithAttendance, now)
 
         private fun convertSession(
-            sessionWithAttendance: SessionWithAttendanceDto,
+            sessionWithAttendance: UserSessionAttendance,
             now: LocalDateTime
         ): SimpleScheduleResponse =
             sessionWithAttendance.let {

--- a/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionResponse.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/dto/response/UpcomingSessionResponse.kt
@@ -3,7 +3,7 @@ package co.yappuworld.schedule.client.dto.response
 import co.yappuworld.post.infrastructure.entity.NoticeEntity
 import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.domain.vo.SessionProgressPhase
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
+import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -77,7 +77,7 @@ data class UpcomingSessionResponse(
                     relativeDays = it.getRelativeDays(now.toLocalDate()),
                     canCheckIn = it.canCheckIn(now),
                     status = it.getAttendanceStatus(now),
-                    progressPhase = SessionWithAttendanceDto
+                    progressPhase = UserSessionAttendance
                         .from(
                             sessionAttendance.session,
                             sessionAttendance.attendance

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
@@ -7,6 +7,7 @@ import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponse
 import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponseV2
 import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponse
+import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponseV2
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -169,7 +170,7 @@ interface AttendanceApi {
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<Unit>
 
-    @Operation(summary = "나의 출석 통계")
+    @Operation(summary = "나의 출석 통계 (V2)")
     @ApiResponses(
         value = [
             ApiResponse(
@@ -190,7 +191,8 @@ interface AttendanceApi {
                                             "attendanceCount": 10,
                                             "lateCount": 3,
                                             "absenceCount": 2,
-                                            "latePassCount": 1
+                                            "latePassCount": 1,
+                                            "summaryStatus": "INCOMPLETE"
                                         },
                                         "isSuccess": true
                                     }
@@ -227,7 +229,7 @@ interface AttendanceApi {
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<SuccessResponse<AttendanceStatisticsResponse>>
 
-    @Operation(summary = "나의 출석 통계")
+    @Operation(summary = "나의 출석 통계 (V2)")
     @ApiResponses(
         value = [
             ApiResponse(
@@ -354,4 +356,76 @@ interface AttendanceApi {
     fun getAttendancesHistory(
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<SuccessResponse<AttendancesHistoryResponse>>
+
+    @Operation(summary = "출석 내역 조회 (V2)")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                content = [
+                    Content(
+                        schema = Schema(implementation = AttendancesHistoryResponseV2::class),
+                        examples = [
+                            ExampleObject(
+                                name = "세션 출석 이력 조회",
+                                value = """
+                                    {
+                                        "data": {
+                                            "histories": [
+                                                {
+                                                    "sessionId": "c076cadd-1b30-11f0-add0-0242ac140002",
+                                                    "title": "OT",
+                                                    "sessionType": "OFFLINE",
+                                                    "startAt": "2025-04-17T13:00:00",
+                                                    "endAt": "2025-04-17T18:00:00",
+                                                    "checkedInAt": "2025-04-17T13:18:17",
+                                                    "attendanceStatus": "ON_TIME",
+                                                    "progressPhase": "DONE"
+                                                },
+                                                {
+                                                    "sessionId": "c076ff63-1b30-11f0-add0-0242ac140002",
+                                                    "title": "팀 매칭",
+                                                    "sessionType": "TEAM",
+                                                    "startAt": "2025-04-24T13:00:00",
+                                                    "endAt": "2025-04-24T18:00:00",
+                                                    "checkedInAt": null,
+                                                    "attendanceStatus": null,
+                                                    "progressPhase": "PENDING"
+                                                }
+                                            ]
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "409",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "활성화 된 기수 없음",
+                                value = """
+                                    {
+                                        "errorCode": "ATD_2002",
+                                        "message": "활성화 된 기수가 없어서 출석 관련 처리가 불가합니다.",
+                                        "isSuccess": false
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/v2/attendances/history")
+    fun getAttendancesHistoryV2(
+        @AuthenticationPrincipal securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<AttendancesHistoryResponseV2>>
 }

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceApi.kt
@@ -170,7 +170,7 @@ interface AttendanceApi {
         @AuthenticationPrincipal securityUser: SecurityUser
     ): ResponseEntity<Unit>
 
-    @Operation(summary = "나의 출석 통계 (V2)")
+    @Operation(summary = "나의 출석 통계")
     @ApiResponses(
         value = [
             ApiResponse(
@@ -203,7 +203,7 @@ interface AttendanceApi {
                 ]
             ),
             ApiResponse(
-                responseCode = "404",
+                responseCode = "409",
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),
@@ -261,7 +261,7 @@ interface AttendanceApi {
                 ]
             ),
             ApiResponse(
-                responseCode = "404",
+                responseCode = "409",
                 content = [
                     Content(
                         schema = Schema(implementation = ErrorResponse::class),

--- a/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceController.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/client/presentation/AttendanceController.kt
@@ -8,6 +8,7 @@ import co.yappuworld.schedule.client.dto.request.AttendanceRequest
 import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponse
 import co.yappuworld.schedule.client.dto.response.AttendanceStatisticsResponseV2
 import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponse
+import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponseV2
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
@@ -54,6 +55,18 @@ class AttendanceController(
         ResponseEntity.ok(
             SuccessResponse(
                 attendanceService.getAttendancesHistory(securityUser.userId, DatetimeUtils.getCurrentDateTimeInKST())
+            )
+        )
+
+    override fun getAttendancesHistoryV2(
+        securityUser: SecurityUser
+    ): ResponseEntity<SuccessResponse<AttendancesHistoryResponseV2>> =
+        ResponseEntity.ok(
+            SuccessResponse(
+                attendanceService.getAttendancesHistoryV2(
+                    securityUser.userId,
+                    DatetimeUtils.getCurrentDateTimeInKST()
+                )
             )
         )
 }

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/CustomAttendanceDsl.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/CustomAttendanceDsl.kt
@@ -1,6 +1,6 @@
 package co.yappuworld.schedule.infrastructure
 
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
+import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
@@ -14,8 +14,8 @@ class CustomAttendanceDsl : Jpql() {
         override fun newInstance(): CustomAttendanceDsl = CustomAttendanceDsl()
     }
 
-    fun selectSessionWithAttendance(): SelectQueryFromStep<SessionWithAttendanceDto> =
-        selectNew<SessionWithAttendanceDto>(
+    fun selectSessionWithAttendance(): SelectQueryFromStep<UserSessionAttendance> =
+        selectNew<UserSessionAttendance>(
             path(SessionEntity::getId),
             path(SessionEntity::name),
             path(SessionEntity::description),

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/SessionFindService.kt
@@ -7,7 +7,7 @@ import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.ScheduleError
 import co.yappuworld.schedule.domain.vo.SessionType
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
+import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
 import co.yappuworld.schedule.infrastructure.entity.AttendanceEntity
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
@@ -76,7 +76,7 @@ class SessionFindService(
         generation: Int,
         userId: UUID,
         now: LocalDateTime
-    ): List<SessionWithAttendanceDto> =
+    ): List<UserSessionAttendance> =
         scheduleRepository
             .findAll(CustomAttendanceDsl) {
                 selectSessionWithAttendance()
@@ -96,7 +96,7 @@ class SessionFindService(
         generation: Int,
         userId: UUID,
         now: LocalDateTime
-    ): List<SessionWithAttendanceDto> =
+    ): List<UserSessionAttendance> =
         scheduleRepository
             .findAll(CustomAttendanceDsl) {
                 selectSessionWithAttendance()

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/UserSessionAttendance.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/UserSessionAttendance.kt
@@ -12,7 +12,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.UUID
 
-class SessionWithAttendanceDto(
+class UserSessionAttendance(
     val id: UUID,
     val name: String,
     val description: String?,
@@ -35,8 +35,8 @@ class SessionWithAttendanceDto(
         fun from(
             session: SessionEntity,
             attendance: AttendanceEntity?
-        ): SessionWithAttendanceDto =
-            SessionWithAttendanceDto(
+        ): UserSessionAttendance =
+            UserSessionAttendance(
                 id = session.id,
                 name = session.name,
                 description = session.description,
@@ -59,6 +59,14 @@ class SessionWithAttendanceDto(
         private set
 
     val attendanceStatusType: AttendanceStatus? = _attendanceStatus
+
+    fun resolveAttendanceStatus(now: LocalDateTime): AttendanceStatus? =
+        when {
+            attendanceStatusType == null -> null
+            attendanceStatusType == AttendanceStatus.PENDING && !isFinished(now) -> null
+            attendanceStatusType == AttendanceStatus.PENDING && isFinished(now) -> AttendanceStatus.ABSENT
+            else -> attendanceStatusType
+        }
 
     fun resolveAttendanceStatusOfPastSessions(now: LocalDateTime) {
         if (attendanceStatusType == AttendanceStatus.PENDING && checkedInAt == null && isFinished(now)) {

--- a/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/UserSessionAttendance.kt
+++ b/src/main/kotlin/co/yappuworld/schedule/infrastructure/dto/UserSessionAttendance.kt
@@ -64,7 +64,11 @@ class UserSessionAttendance(
         when {
             attendanceStatusType == null -> null
             attendanceStatusType == AttendanceStatus.PENDING && !isFinished(now) -> null
-            attendanceStatusType == AttendanceStatus.PENDING && isFinished(now) -> AttendanceStatus.ABSENT
+            attendanceStatusType == AttendanceStatus.PENDING &&
+                checkedInAt == null &&
+                isFinished(
+                    now
+                ) -> AttendanceStatus.ABSENT
             else -> attendanceStatusType
         }
 

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
@@ -4,6 +4,7 @@ import co.yappuworld.global.exception.BusinessException
 import co.yappuworld.operation.infrastructure.ConfigFindService
 import co.yappuworld.operation.infrastructure.GenerationFindService
 import co.yappuworld.schedule.client.dto.request.AttendanceRequest
+import co.yappuworld.schedule.client.dto.response.AttendancesHistoryResponseV2
 import co.yappuworld.schedule.domain.SessionAttendance
 import co.yappuworld.schedule.domain.vo.AttendanceError
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
@@ -14,6 +15,7 @@ import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.support.fixture.AttendanceFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionWithAttendanceFixture
 import co.yappuworld.support.fixture.UserFixture.getActivityUnitFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitsFixture
 import co.yappuworld.user.infrastructure.UserFindService
@@ -110,6 +112,33 @@ class AttendanceServiceTest :
                         }.error.shouldBe(AttendanceError.ATTENDANCE_CODE_NOT_MATCH)
                     }
                 }
+            }
+        }
+
+        feature("출석 내역 조회 v2") {
+
+            scenario("활성 기수의 전체 세션 출석 이력을 상태값과 함께 조회한다.") {
+                val now = LocalDateTime.of(2025, 2, 15, 15, 0)
+                val sessions = listOf(
+                    getSessionWithAttendanceFixture(attendanceStatus = AttendanceStatus.LATE),
+                    getSessionWithAttendanceFixture(
+                        attendanceStatus = AttendanceStatus.PENDING,
+                        checkedInAt = null,
+                        date = now.toLocalDate().plusDays(1),
+                        endDate = now.toLocalDate().plusDays(1)
+                    )
+                )
+                every { generationFindService.findActiveGeneration() } returns activeGeneration
+                every {
+                    sessionFindService.findSessionsWithAttendanceStatus(
+                        generation = activeGeneration,
+                        userId = user.id,
+                        now = now
+                    )
+                } returns sessions
+
+                attendanceService.getAttendancesHistoryV2(user.id, now) shouldBe
+                    AttendancesHistoryResponseV2.of(sessions, now)
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/application/AttendanceServiceTest.kt
@@ -14,9 +14,11 @@ import co.yappuworld.schedule.infrastructure.LatePassFindService
 import co.yappuworld.schedule.infrastructure.SessionFindService
 import co.yappuworld.support.fixture.AttendanceFixture
 import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
 import co.yappuworld.support.fixture.ScheduleFixture.getSessionWithAttendanceFixture
 import co.yappuworld.support.fixture.UserFixture.getActivityUnitFixture
+import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitFixture
 import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitsFixture
 import co.yappuworld.user.infrastructure.UserFindService
 import io.kotest.assertions.throwables.shouldThrow
@@ -136,9 +138,22 @@ class AttendanceServiceTest :
                         now = now
                     )
                 } returns sessions
+                every { userFindService.findSessionAttendee(user.id, activeGeneration) } returns
+                    getAttendeeFixture(getUserWithActivityUnitFixture(generation = activeGeneration), activeGeneration)
 
                 attendanceService.getAttendancesHistoryV2(user.id, now) shouldBe
                     AttendancesHistoryResponseV2.of(sessions, now)
+            }
+
+            scenario("활성 기수의 참가자가 아니면 예외가 발생한다.") {
+                val now = LocalDateTime.of(2025, 2, 15, 15, 0)
+                every { generationFindService.findActiveGeneration() } returns activeGeneration
+                every { userFindService.findSessionAttendee(user.id, activeGeneration) } throws
+                    BusinessException(AttendanceError.NO_ATTENDEE_POSITION_ACTIVITY_IN_GENERATION)
+
+                shouldThrow<BusinessException> {
+                    attendanceService.getAttendancesHistoryV2(user.id, now)
+                }.error shouldBe AttendanceError.NO_ATTENDEE_POSITION_ACTIVITY_IN_GENERATION
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseV2Test.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendanceStatisticsResponseV2Test.kt
@@ -1,0 +1,88 @@
+package co.yappuworld.schedule.client.dto.response
+
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ABSENT
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.LATE
+import co.yappuworld.schedule.domain.vo.AttendanceStatus.ON_TIME
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceBookFixture
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendanceEntityFixture
+import co.yappuworld.support.fixture.AttendanceFixture.getAttendeeFixture
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getUserWithActivityUnitFixture
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class AttendanceStatisticsResponseV2Test :
+    FeatureSpec({
+        feature("출석 현황 상태") {
+            val generation = 25
+            val user = getUserWithActivityUnitFixture(generation = generation)
+            val now = LocalDateTime.of(2025, 3, 4, 8, 0, 0)
+            val sessions = listOf(
+                getSessionEntityFixture(
+                    date = now.toLocalDate().minusDays(2),
+                    endDate = now.toLocalDate().minusDays(2),
+                    generation = generation
+                ),
+                getSessionEntityFixture(
+                    date = now.toLocalDate().minusDays(1),
+                    endDate = now.toLocalDate().minusDays(1),
+                    generation = generation
+                )
+            )
+
+            scenario("출석 점수가 80점 이상이면 GOOD 상태를 반환한다.") {
+                val attendances = listOf(
+                    getAttendanceEntityFixture(userId = user.userId, session = sessions[0], status = ON_TIME),
+                    getAttendanceEntityFixture(userId = user.userId, session = sessions[1], status = LATE)
+                )
+
+                AttendanceStatisticsResponseV2
+                    .from(
+                        getAttendanceBookFixture(
+                            generation = generation,
+                            attendees = listOf(getAttendeeFixture(user, generation)),
+                            sessions = sessions,
+                            attendances = attendances,
+                            now = now
+                        ).getUserAttendanceStatistics(user.userId)
+                    ).summaryStatus shouldBe AttendanceSummaryStatus.GOOD
+            }
+
+            scenario("출석 점수가 70점 이상 80점 미만이면 CAUTION 상태를 반환한다.") {
+                val attendances = listOf(
+                    getAttendanceEntityFixture(userId = user.userId, session = sessions[0], status = ABSENT),
+                    getAttendanceEntityFixture(userId = user.userId, session = sessions[1], status = LATE)
+                )
+
+                AttendanceStatisticsResponseV2
+                    .from(
+                        getAttendanceBookFixture(
+                            generation = generation,
+                            attendees = listOf(getAttendeeFixture(user, generation)),
+                            sessions = sessions,
+                            attendances = attendances,
+                            now = now
+                        ).getUserAttendanceStatistics(user.userId)
+                    ).summaryStatus shouldBe AttendanceSummaryStatus.CAUTION
+            }
+
+            scenario("출석 점수가 70점 미만이면 INCOMPLETE 상태를 반환한다.") {
+                val attendances = listOf(
+                    getAttendanceEntityFixture(userId = user.userId, session = sessions[0], status = ABSENT),
+                    getAttendanceEntityFixture(userId = user.userId, session = sessions[1], status = ABSENT)
+                )
+
+                AttendanceStatisticsResponseV2
+                    .from(
+                        getAttendanceBookFixture(
+                            generation = generation,
+                            attendees = listOf(getAttendeeFixture(user, generation)),
+                            sessions = sessions,
+                            attendances = attendances,
+                            now = now
+                        ).getUserAttendanceStatistics(user.userId)
+                    ).summaryStatus shouldBe AttendanceSummaryStatus.INCOMPLETE
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendancesHistoryResponseV2Test.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/AttendancesHistoryResponseV2Test.kt
@@ -1,0 +1,50 @@
+package co.yappuworld.schedule.client.dto.response
+
+import co.yappuworld.schedule.domain.vo.AttendanceStatus
+import co.yappuworld.schedule.domain.vo.SessionProgressPhase
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionWithAttendanceFixture
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class AttendancesHistoryResponseV2Test :
+    FeatureSpec({
+        feature("출석 이력 v2 상태값 생성") {
+            scenario("종료된 미출석 세션은 결석 상태를 반환한다.") {
+                val now = LocalDateTime.of(2025, 2, 16, 12, 0)
+                val session = getSessionWithAttendanceFixture(
+                    attendanceStatus = AttendanceStatus.PENDING,
+                    checkedInAt = null
+                )
+
+                AttendancesHistoryResponseV2.of(listOf(session), now).histories.single().let {
+                    it.attendanceStatus shouldBe AttendanceStatus.ABSENT
+                    it.progressPhase shouldBe SessionProgressPhase.DONE
+                }
+            }
+
+            scenario("예정된 미출석 세션은 출석 상태 없이 진행 상태만 반환한다.") {
+                val now = LocalDateTime.of(2025, 2, 14, 12, 0)
+                val session = getSessionWithAttendanceFixture(
+                    attendanceStatus = AttendanceStatus.PENDING,
+                    checkedInAt = null
+                )
+
+                AttendancesHistoryResponseV2.of(listOf(session), now).histories.single().let {
+                    it.attendanceStatus.shouldBeNull()
+                    it.progressPhase shouldBe SessionProgressPhase.PENDING
+                }
+            }
+
+            scenario("지각 세션은 LATE 상태를 반환한다.") {
+                val now = LocalDateTime.of(2025, 2, 15, 15, 0)
+                val session = getSessionWithAttendanceFixture(attendanceStatus = AttendanceStatus.LATE)
+
+                AttendancesHistoryResponseV2.of(listOf(session), now).histories.single().let {
+                    it.attendanceStatus shouldBe AttendanceStatus.LATE
+                    it.progressPhase shouldBe SessionProgressPhase.ONGOING
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponseTest.kt
@@ -1,0 +1,40 @@
+package co.yappuworld.schedule.client.dto.response
+
+import co.yappuworld.schedule.client.dto.request.SchedulePageRequest
+import co.yappuworld.support.fixture.ScheduleFixture.getSessionEntityFixture
+import co.yappuworld.support.fixture.ScheduleFixture.getTaskEntityFixture
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class SchedulePageResponseTest :
+    FeatureSpec({
+        feature("일정 페이지 응답") {
+            scenario("세션이 아닌 일정은 제외하고 세션만 변환한다.") {
+                val request = SchedulePageRequest(year = 2025, month = 2)
+                val now = LocalDateTime.of(2025, 2, 15, 10, 0)
+
+                val response = SchedulePageResponse.from(
+                    schedules = listOf(getSessionEntityFixture(name = "OT"), getTaskEntityFixture(name = "사전 과제")),
+                    attendances = emptyList(),
+                    request = request,
+                    now = now
+                )
+
+                response.dates
+                    .first { it.date == now.toLocalDate() }
+                    .schedules
+                    .shouldHaveSize(1)
+                response.dates
+                    .first { it.date == now.toLocalDate() }
+                    .schedules
+                    .single()
+                    .name shouldBe "OT"
+                response.dates
+                    .filter { it.date != now.toLocalDate() }
+                    .flatMap { it.schedules }
+                    .shouldHaveSize(0)
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponseTest.kt
+++ b/src/test/kotlin/co/yappuworld/schedule/client/dto/response/SchedulePageResponseTest.kt
@@ -21,16 +21,12 @@ class SchedulePageResponseTest :
                     request = request,
                     now = now
                 )
+                val todaySchedules = response.dates
+                    .first { it.date == now.toLocalDate() }
+                    .schedules
 
-                response.dates
-                    .first { it.date == now.toLocalDate() }
-                    .schedules
-                    .shouldHaveSize(1)
-                response.dates
-                    .first { it.date == now.toLocalDate() }
-                    .schedules
-                    .single()
-                    .name shouldBe "OT"
+                todaySchedules.shouldHaveSize(1)
+                todaySchedules.single().name shouldBe "OT"
                 response.dates
                     .filter { it.date != now.toLocalDate() }
                     .flatMap { it.schedules }

--- a/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
@@ -1,10 +1,9 @@
 package co.yappuworld.support.fixture
 
 import co.yappuworld.schedule.domain.vo.AttendanceStatus
-import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import co.yappuworld.schedule.domain.vo.SessionType
-import co.yappuworld.schedule.infrastructure.entity.TaskEntity
-import co.yappuworld.schedule.infrastructure.dto.SessionWithAttendanceDto
+import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
+import co.yappuworld.schedule.infrastructure.entity.SessionEntity
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -35,25 +34,6 @@ object ScheduleFixture {
         sessionType = sessionType
     )
 
-    fun getTaskEntityFixture(
-        name: String = "시범 과제",
-        description: String? = "시범 과제이니깐 걱정 마세요",
-        place: String? = "공덕 창업 허브",
-        date: LocalDate = LocalDate.of(2025, 2, 15),
-        endDate: LocalDate = LocalDate.of(2025, 2, 15),
-        time: LocalTime = LocalTime.of(14, 0),
-        endTime: LocalTime = LocalTime.of(18, 0)
-    ) = TaskEntity(
-        name = name,
-        description = description,
-        place = place,
-        date = date,
-        endDate = endDate,
-        isAllDay = false,
-        time = time,
-        endTime = endTime
-    )
-
     fun getSessionWithAttendanceFixture(
         id: UUID = UUID.randomUUID(),
         name: String = "세션 이름",
@@ -70,8 +50,8 @@ object ScheduleFixture {
         sessionType: SessionType = SessionType.OFFLINE,
         attendanceStatus: AttendanceStatus? = AttendanceStatus.ON_TIME,
         checkedInAt: LocalDateTime? = LocalDateTime.of(2025, 2, 15, 14, 0)
-    ): SessionWithAttendanceDto =
-        SessionWithAttendanceDto(
+    ): UserSessionAttendance =
+        UserSessionAttendance(
             id = id,
             name = name,
             description = description,

--- a/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
+++ b/src/test/kotlin/co/yappuworld/support/fixture/ScheduleFixture.kt
@@ -4,6 +4,7 @@ import co.yappuworld.schedule.domain.vo.AttendanceStatus
 import co.yappuworld.schedule.domain.vo.SessionType
 import co.yappuworld.schedule.infrastructure.dto.UserSessionAttendance
 import co.yappuworld.schedule.infrastructure.entity.SessionEntity
+import co.yappuworld.schedule.infrastructure.entity.TaskEntity
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -32,6 +33,25 @@ object ScheduleFixture {
         endTime = endTime,
         generation = generation,
         sessionType = sessionType
+    )
+
+    fun getTaskEntityFixture(
+        name: String = "시범 과제",
+        description: String? = "시범 과제이니깐 걱정 마세요",
+        place: String? = "공덕 창업 허브",
+        date: LocalDate = LocalDate.of(2025, 2, 15),
+        endDate: LocalDate = LocalDate.of(2025, 2, 15),
+        time: LocalTime = LocalTime.of(14, 0),
+        endTime: LocalTime = LocalTime.of(18, 0)
+    ) = TaskEntity(
+        name = name,
+        description = description,
+        place = place,
+        date = date,
+        endDate = endDate,
+        isAllDay = false,
+        time = time,
+        endTime = endTime
     )
 
     fun getSessionWithAttendanceFixture(


### PR DESCRIPTION
## 📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- [출석 현황 개선](https://www.notion.so/yapp-workspace/2632106a0e8480d48b53d9dd88e45bcd?source=copy_link)을 위한 API 작업이 필요합니다.


## ⭐️ 어떻게 해결했나요?
- 기존 API 중 statistics는 재활용하고, history API를 v2로 올리면서 전체 내역을 반환할 수 있도록 처리했습니다.
- 목록과 상세 내역 모두 하나의 API에서 모두 데이터를 전달할 수 있도록 처리합니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 출석 관리 기능 업데이트

* **새로운 기능**
  * 출석 내역 V2 API 추가: 세션 제목·유형·시작/종료시각·진행상태와 선택적 체크인/출석상태 포함한 상세 히스토리 제공
  * 출석 내역 조회 서비스(V2) 및 관련 응답 포맷 추가

* **새 필드**
  * 출석 통계에 종합 평가(summaryStatus) 추가(GOOD/CAUTION/INCOMPLETE)

* **문서**
  * Swagger 예시·응답 설명 업데이트 및 오류 응답 코드 조정(409)

* **테스트**
  * V2 히스토리·통계·일정 매핑 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->