### PR TITLE
feat: 역대 서비스 커서 기반 목록 및 상세 조회 API 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/global/response/CursorPageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/global/response/CursorPageResponse.kt
@@ -3,12 +3,12 @@ package co.yappuworld.global.response
 import io.swagger.v3.oas.annotations.media.Schema
 
 class CursorPageResponse<T, R>(
-    @Schema(description = "데이터 목록")
+    @field:Schema(description = "데이터 목록")
     val data: List<T>,
-    @Schema(description = "다음 요청에 사용되는 커서 정보, 사용 방법은 API 별로 상이할 수 있음")
+    @field:Schema(description = "다음 요청에 사용되는 커서 정보, 사용 방법은 API 별로 상이할 수 있음")
     val lastCursor: R?,
-    @Schema(description = "조회 개수")
+    @field:Schema(description = "조회 개수")
     val limit: Int,
-    @Schema(description = "다음 데이터 존재 여부")
+    @field:Schema(description = "다음 데이터 존재 여부")
     val hasNext: Boolean
 )

--- a/src/main/kotlin/co/yappuworld/team/client/application/HistoricalServiceService.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/application/HistoricalServiceService.kt
@@ -1,0 +1,49 @@
+package co.yappuworld.team.client.application
+
+import co.yappuworld.global.response.CursorPageResponse
+import co.yappuworld.team.client.dto.request.HistoricalServicesPageRequest
+import co.yappuworld.team.client.dto.response.HistoricalServiceDetailResponse
+import co.yappuworld.team.client.dto.response.HistoricalServicePageResponse
+import co.yappuworld.team.infrastructure.TeamMemberFindService
+import co.yappuworld.team.infrastructure.TeamServiceFindService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+import kotlin.math.min
+
+@Service
+class HistoricalServiceService(
+    private val teamServiceFindService: TeamServiceFindService,
+    private val teamMemberFindService: TeamMemberFindService
+) {
+
+    @Transactional(readOnly = true)
+    fun getHistoricalServices(
+        request: HistoricalServicesPageRequest
+    ): CursorPageResponse<HistoricalServicePageResponse, UUID> {
+        val services = teamServiceFindService.findHistoricalServices(
+            generation = request.generation,
+            platform = request.platform,
+            lastServiceId = request.lastCursorId,
+            limit = request.limit + 1
+        )
+        val data = services
+            .take(min(request.limit, services.size))
+            .map(HistoricalServicePageResponse::from)
+
+        return CursorPageResponse(
+            data = data,
+            lastCursor = data.lastOrNull()?.serviceId,
+            limit = request.limit,
+            hasNext = services.size > request.limit
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getHistoricalServiceDetail(serviceId: UUID): HistoricalServiceDetailResponse {
+        val service = teamServiceFindService.findTeamService(serviceId)
+        val members = teamMemberFindService.findTeamMembersDetail(service.team.id).filterNotNull()
+
+        return HistoricalServiceDetailResponse.of(service, members)
+    }
+}

--- a/src/main/kotlin/co/yappuworld/team/client/dto/request/HistoricalServicesPageRequest.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/dto/request/HistoricalServicesPageRequest.kt
@@ -1,0 +1,20 @@
+package co.yappuworld.team.client.dto.request
+
+import co.yappuworld.team.domain.vo.Platform
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+import java.util.UUID
+
+@Schema(description = "역대 서비스 목록 조회 요청")
+data class HistoricalServicesPageRequest(
+    @field:Schema(description = "지난 요청 마지막 데이터의 ID, 첫 요청인 경우 null", required = false)
+    val lastCursorId: UUID? = null,
+    @field:Schema(description = "요청 데이터 개수", required = true, example = "20", defaultValue = "20")
+    @field:Min(value = 1L, message = "요청 데이터 개수는 최소 1개 이상이어야 합니다.")
+    val limit: Int = 20,
+    @field:Schema(description = "기수 필터", example = "25")
+    @field:Min(value = 1L, message = "기수는 1 이상이어야 합니다.")
+    val generation: Int? = null,
+    @field:Schema(description = "플랫폼 필터 (APP/WEB)", example = "APP")
+    val platform: Platform? = null
+)

--- a/src/main/kotlin/co/yappuworld/team/client/dto/response/HistoricalServiceDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/dto/response/HistoricalServiceDetailResponse.kt
@@ -1,0 +1,74 @@
+package co.yappuworld.team.client.dto.response
+
+import co.yappuworld.team.infrastructure.dto.TeamMemberDetailDto
+import co.yappuworld.team.infrastructure.entity.TeamServiceEntity
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+data class HistoricalServiceDetailResponse(
+    @field:Schema(description = "서비스 ID")
+    val serviceId: UUID,
+    @field:Schema(description = "기수")
+    val generation: Int,
+    @field:Schema(description = "서비스명")
+    val serviceName: String?,
+    @field:Schema(description = "앱 플랫폼 여부")
+    val hasApp: Boolean,
+    @field:Schema(description = "웹 플랫폼 여부")
+    val hasWeb: Boolean,
+    @field:Schema(description = "한 줄 소개")
+    val summary: String?,
+    @field:Schema(description = "상세 설명")
+    val description: String?,
+    @field:Schema(description = "썸네일 이미지 URL")
+    val thumbnailImageUrl: String?,
+    @field:Schema(description = "구글 플레이 링크")
+    val googlePlayLink: String?,
+    @field:Schema(description = "앱스토어 링크")
+    val appStoreLink: String?,
+    @field:Schema(description = "웹 링크")
+    val webLink: String?,
+    @field:Schema(description = "팀원 목록")
+    val members: List<HistoricalServiceMemberResponse>
+) {
+    companion object {
+        fun of(
+            service: TeamServiceEntity,
+            members: List<TeamMemberDetailDto>
+        ): HistoricalServiceDetailResponse =
+            HistoricalServiceDetailResponse(
+                serviceId = service.id,
+                generation = service.team.generation,
+                serviceName = service.name,
+                hasApp = service.hasApp,
+                hasWeb = service.hasWeb,
+                summary = service.summary,
+                description = service.description,
+                thumbnailImageUrl = null,
+                googlePlayLink = service.serviceLinks?.googlePlay,
+                appStoreLink = service.serviceLinks?.appStore,
+                webLink = service.serviceLinks?.web,
+                members = members
+                    .sortedWith(compareBy({ it.position.order }, { it.userName }))
+                    .map(HistoricalServiceMemberResponse::from)
+            )
+    }
+}
+
+data class HistoricalServiceMemberResponse(
+    @field:Schema(description = "활동 이력 ID")
+    val activityUnitId: UUID,
+    @field:Schema(description = "이름")
+    val name: String,
+    @field:Schema(description = "직군명")
+    val position: String
+) {
+    companion object {
+        fun from(dto: TeamMemberDetailDto): HistoricalServiceMemberResponse =
+            HistoricalServiceMemberResponse(
+                activityUnitId = dto.activityUnitId,
+                name = dto.userName,
+                position = dto.position.label
+            )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/team/client/dto/response/HistoricalServicePageResponse.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/dto/response/HistoricalServicePageResponse.kt
@@ -1,0 +1,35 @@
+package co.yappuworld.team.client.dto.response
+
+import co.yappuworld.team.infrastructure.dto.HistoricalServiceSummaryProjection
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+data class HistoricalServicePageResponse(
+    @field:Schema(description = "서비스 ID")
+    val serviceId: UUID,
+    @field:Schema(description = "기수")
+    val generation: Int,
+    @field:Schema(description = "서비스명")
+    val serviceName: String?,
+    @field:Schema(description = "앱 플랫폼 여부")
+    val hasApp: Boolean,
+    @field:Schema(description = "웹 플랫폼 여부")
+    val hasWeb: Boolean,
+    @field:Schema(description = "한 줄 소개")
+    val summary: String?,
+    @field:Schema(description = "썸네일 이미지 URL")
+    val thumbnailImageUrl: String?
+) {
+    companion object {
+        fun from(projection: HistoricalServiceSummaryProjection): HistoricalServicePageResponse =
+            HistoricalServicePageResponse(
+                serviceId = projection.serviceId,
+                generation = projection.generation,
+                serviceName = projection.serviceName,
+                hasApp = projection.hasApp,
+                hasWeb = projection.hasWeb,
+                summary = projection.summary,
+                thumbnailImageUrl = null
+            )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/team/client/presentation/HistoricalServiceApi.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/presentation/HistoricalServiceApi.kt
@@ -1,0 +1,137 @@
+package co.yappuworld.team.client.presentation
+
+import co.yappuworld.global.response.CursorPageResponse
+import co.yappuworld.global.response.ErrorResponse
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.team.client.dto.request.HistoricalServicesPageRequest
+import co.yappuworld.team.client.dto.response.HistoricalServiceDetailResponse
+import co.yappuworld.team.client.dto.response.HistoricalServicePageResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import java.util.UUID
+
+@Tag(name = "역대 서비스 API", description = "역대 서비스 목록 및 상세 조회")
+interface HistoricalServiceApi {
+
+    @Operation(summary = "역대 서비스 목록 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "역대 서비스 목록 조회",
+                                value = """
+                                    {
+                                        "data": {
+                                            "data": [
+                                                {
+                                                    "serviceId": "a1b2c3d4-e5f6-7890-ab12-cd34ef56ab78",
+                                                    "generation": 25,
+                                                    "serviceName": "역대 서비스",
+                                                    "hasApp": true,
+                                                    "hasWeb": false,
+                                                    "summary": "한 줄 소개입니다.",
+                                                    "thumbnailImageUrl": null
+                                                }
+                                            ],
+                                            "lastCursor": "a1b2c3d4-e5f6-7890-ab12-cd34ef56ab78",
+                                            "limit": 20,
+                                            "hasNext": true
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/v1/team-services")
+    fun getHistoricalServices(
+        @Valid @ParameterObject request: HistoricalServicesPageRequest
+    ): ResponseEntity<SuccessResponse<CursorPageResponse<HistoricalServicePageResponse, UUID>>>
+
+    @Operation(summary = "역대 서비스 상세 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                content = [
+                    Content(
+                        schema = Schema(implementation = HistoricalServiceDetailResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "역대 서비스 상세 조회",
+                                value = """
+                                    {
+                                        "data": {
+                                            "serviceId": "a1b2c3d4-e5f6-7890-ab12-cd34ef56ab78",
+                                            "generation": 17,
+                                            "serviceName": "무슨무슨 서비스",
+                                            "hasApp": false,
+                                            "hasWeb": true,
+                                            "summary": "서비스의 한 줄 설명입니다.",
+                                            "description": "서비스 상세 설명입니다.",
+                                            "thumbnailImageUrl": null,
+                                            "googlePlayLink": null,
+                                            "appStoreLink": null,
+                                            "webLink": "https://yapp.co.kr",
+                                            "members": [
+                                                {
+                                                    "activityUnitId": "a1b2c3d4-e5f6-7890-ab12-cd34ef56ab79",
+                                                    "name": "김야푸",
+                                                    "position": "PM"
+                                                }
+                                            ]
+                                        },
+                                        "isSuccess": true
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "서비스를 찾을 수 없습니다.",
+                                value = """
+                                    {
+                                        "message": "서비스를 찾을 수 없습니다.",
+                                        "errorCode": "TEAM_0002",
+                                        "isSuccess": false
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/v1/team-services/{serviceId}")
+    fun getHistoricalServiceDetail(
+        @PathVariable serviceId: UUID
+    ): ResponseEntity<SuccessResponse<HistoricalServiceDetailResponse>>
+}

--- a/src/main/kotlin/co/yappuworld/team/client/presentation/HistoricalServiceController.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/presentation/HistoricalServiceController.kt
@@ -1,0 +1,31 @@
+package co.yappuworld.team.client.presentation
+
+import co.yappuworld.global.response.CursorPageResponse
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.team.client.application.HistoricalServiceService
+import co.yappuworld.team.client.dto.request.HistoricalServicesPageRequest
+import co.yappuworld.team.client.dto.response.HistoricalServiceDetailResponse
+import co.yappuworld.team.client.dto.response.HistoricalServicePageResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+class HistoricalServiceController(
+    private val historicalServiceService: HistoricalServiceService
+) : HistoricalServiceApi {
+
+    override fun getHistoricalServices(
+        request: HistoricalServicesPageRequest
+    ): ResponseEntity<SuccessResponse<CursorPageResponse<HistoricalServicePageResponse, UUID>>> =
+        ResponseEntity.ok(
+            SuccessResponse(historicalServiceService.getHistoricalServices(request))
+        )
+
+    override fun getHistoricalServiceDetail(
+        serviceId: UUID
+    ): ResponseEntity<SuccessResponse<HistoricalServiceDetailResponse>> =
+        ResponseEntity.ok(
+            SuccessResponse(historicalServiceService.getHistoricalServiceDetail(serviceId))
+        )
+}

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/CustomTeamDsl.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/CustomTeamDsl.kt
@@ -2,6 +2,7 @@ package co.yappuworld.team.infrastructure
 
 import co.yappuworld.team.infrastructure.dto.TeamWithServiceDto
 import co.yappuworld.team.domain.vo.Platform
+import co.yappuworld.team.infrastructure.dto.HistoricalServiceSummaryProjection
 import co.yappuworld.team.infrastructure.dto.TeamMemberDetailDto
 import co.yappuworld.team.infrastructure.dto.TeamServiceSummary
 import co.yappuworld.team.infrastructure.entity.TeamServiceEntity
@@ -36,6 +37,21 @@ CustomTeamDsl : Jpql() {
             add(path(TeamEntity::name).desc())
         }
 
+    fun historicalServiceSorting(platform: Platform?): List<Sortable> =
+        buildList {
+            add(path(TeamEntity::generation).desc())
+            if (platform == null) {
+                add(
+                    caseWhen(path(TeamServiceEntity::hasApp).equal(true))
+                        .then(1)
+                        .`else`(2)
+                        .asc()
+                )
+            }
+            add(path(TeamServiceEntity::name).desc())
+            add(path(TeamServiceEntity::getId).desc())
+        }
+
     fun selectTeamWithService(): SelectQueryFromStep<TeamWithServiceDto> =
         selectNew<TeamWithServiceDto>(
             path(TeamEntity::getId),
@@ -65,5 +81,15 @@ CustomTeamDsl : Jpql() {
             path(TeamServiceEntity::hasWeb),
             path(TeamServiceEntity::summary),
             path(TeamServiceEntity::isOperating)
+        )
+
+    fun selectHistoricalServices(): SelectQueryFromStep<HistoricalServiceSummaryProjection> =
+        selectNew<HistoricalServiceSummaryProjection>(
+            path(TeamServiceEntity::getId),
+            path(TeamEntity::generation),
+            path(TeamServiceEntity::name),
+            path(TeamServiceEntity::hasApp),
+            path(TeamServiceEntity::hasWeb),
+            path(TeamServiceEntity::summary)
         )
 }

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/TeamServiceFindService.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/TeamServiceFindService.kt
@@ -1,11 +1,14 @@
 package co.yappuworld.team.infrastructure
 
 import co.yappuworld.global.exception.BusinessException
+import co.yappuworld.team.domain.vo.Platform
+import co.yappuworld.team.infrastructure.dto.HistoricalServiceSummaryProjection
 import co.yappuworld.team.domain.vo.TeamError
 import co.yappuworld.team.infrastructure.dto.TeamServiceSummary
 import co.yappuworld.team.infrastructure.entity.TeamEntity
 import co.yappuworld.team.infrastructure.entity.TeamServiceEntity
 import co.yappuworld.team.infrastructure.jpa.TeamServiceRepository
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -19,6 +22,12 @@ import java.util.UUID
 class TeamServiceFindService(
     private val teamServiceRepository: TeamServiceRepository
 ) {
+    private data class HistoricalServiceCursor(
+        val serviceId: UUID,
+        val generation: Int,
+        val isApp: Boolean,
+        val serviceName: String?
+    )
 
     fun findServiceOrNull(team: TeamEntity): TeamServiceEntity? = teamServiceRepository.findByTeam(team).singleOrNull()
 
@@ -27,6 +36,44 @@ class TeamServiceFindService(
             ?: throw BusinessException(TeamError.SERVICE_NOT_FOUND)
 
     fun findTeamServices(teams: List<TeamEntity>): List<TeamServiceEntity> = teamServiceRepository.findByTeamIn(teams)
+
+    fun findHistoricalServices(
+        generation: Int?,
+        platform: Platform?,
+        lastServiceId: UUID?,
+        limit: Int
+    ): List<HistoricalServiceSummaryProjection> {
+        val cursor = lastServiceId?.let { createHistoricalServiceCursor(it) }
+
+        return teamServiceRepository
+            .findAll(CustomTeamDsl, Pageable.ofSize(limit)) {
+                val predicates = mutableListOf<Predicate>()
+
+                generation?.let { predicates.add(path(TeamEntity::generation).equal(it)) }
+                platform?.let {
+                    predicates.add(
+                        when (it) {
+                            Platform.APP -> path(TeamServiceEntity::hasApp).equal(true)
+                            Platform.WEB -> path(TeamServiceEntity::hasWeb).equal(true)
+                        }
+                    )
+                }
+                cursor?.let {
+                    predicates.add(createHistoricalServiceCursorPredicate(cursor, platform))
+                }
+
+                selectHistoricalServices()
+                    .from(
+                        entity(TeamServiceEntity::class),
+                        join(TeamEntity::class).on(
+                            path(TeamServiceEntity::team)
+                                .path(TeamEntity::getId)
+                                .equal(path(TeamEntity::getId))
+                        )
+                    ).whereAnd(*predicates.toTypedArray())
+                    .orderBy(*historicalServiceSorting(platform).toTypedArray())
+            }.filterNotNull()
+    }
 
     fun findTeamServices(
         generation: Int?,
@@ -48,4 +95,75 @@ class TeamServiceFindService(
             }.let { page ->
                 PageImpl(page.content, page.pageable, page.totalElements)
             }
+
+    private fun createHistoricalServiceCursor(serviceId: UUID): HistoricalServiceCursor =
+        findTeamService(serviceId).let { service ->
+            HistoricalServiceCursor(
+                serviceId = service.id,
+                generation = service.team.generation,
+                isApp = service.hasApp,
+                serviceName = service.name
+            )
+        }
+
+    private fun CustomTeamDsl.createHistoricalServiceCursorPredicate(
+        cursor: HistoricalServiceCursor,
+        platform: Platform?
+    ): Predicate =
+        when {
+            cursor.isApp && platform == null ->
+                or(
+                    createHistoricalServiceCommonCursorPredicate(cursor, platform),
+                    createRemainingWebOfSameGenerationPredicate(cursor)
+                )
+            else -> createHistoricalServiceCommonCursorPredicate(cursor, platform)
+        }
+
+    private fun CustomTeamDsl.createHistoricalServiceCommonCursorPredicate(
+        cursor: HistoricalServiceCursor,
+        platform: Platform?
+    ): Predicate =
+        or(
+            createLowerGenerationPredicate(cursor),
+            createSameOrderingBucketAfterCursorPredicate(cursor, platform)
+        )
+
+    private fun CustomTeamDsl.createLowerGenerationPredicate(cursor: HistoricalServiceCursor): Predicate =
+        path(TeamEntity::generation).lessThan(cursor.generation)
+
+    private fun CustomTeamDsl.createSameOrderingBucketAfterCursorPredicate(
+        cursor: HistoricalServiceCursor,
+        platform: Platform?
+    ): Predicate =
+        when (platform) {
+            null ->
+                and(
+                    path(TeamEntity::generation).equal(cursor.generation),
+                    path(TeamServiceEntity::hasApp).equal(cursor.isApp),
+                    createNameAndIdAfterCursorPredicate(cursor)
+                )
+            else ->
+                and(
+                    path(TeamEntity::generation).equal(cursor.generation),
+                    createNameAndIdAfterCursorPredicate(cursor)
+                )
+        }
+
+    private fun CustomTeamDsl.createNameAndIdAfterCursorPredicate(cursor: HistoricalServiceCursor): Predicate =
+        or(
+            path(TeamServiceEntity::name).lessThan(cursor.serviceName),
+            createSameNameAfterCursorIdPredicate(cursor)
+        )
+
+    private fun CustomTeamDsl.createSameNameAfterCursorIdPredicate(cursor: HistoricalServiceCursor): Predicate =
+        and(
+            path(TeamServiceEntity::name).equal(cursor.serviceName),
+            path(TeamServiceEntity::getId).lessThan(cursor.serviceId)
+        )
+
+    private fun CustomTeamDsl.createRemainingWebOfSameGenerationPredicate(cursor: HistoricalServiceCursor): Predicate =
+        and(
+            path(TeamEntity::generation).equal(cursor.generation),
+            path(TeamServiceEntity::hasApp).equal(false)
+        )
 }

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/dto/HistoricalServiceSummaryProjection.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/dto/HistoricalServiceSummaryProjection.kt
@@ -1,0 +1,12 @@
+package co.yappuworld.team.infrastructure.dto
+
+import java.util.UUID
+
+data class HistoricalServiceSummaryProjection(
+    val serviceId: UUID,
+    val generation: Int,
+    val serviceName: String?,
+    val hasApp: Boolean,
+    val hasWeb: Boolean,
+    val summary: String?
+)

--- a/src/test/kotlin/co/yappuworld/team/client/application/HistoricalServiceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/team/client/application/HistoricalServiceServiceTest.kt
@@ -1,0 +1,151 @@
+package co.yappuworld.team.client.application
+
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
+import co.yappuworld.support.fixture.TeamFixture.getTeamEntityFixture
+import co.yappuworld.support.fixture.TeamFixture.getTeamServiceEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getActivityUnitEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
+import co.yappuworld.team.client.dto.request.HistoricalServicesPageRequest
+import co.yappuworld.team.domain.vo.Platform
+import co.yappuworld.team.infrastructure.TeamMemberFindService
+import co.yappuworld.team.infrastructure.TeamServiceFindService
+import co.yappuworld.team.infrastructure.entity.TeamMemberEntity
+import co.yappuworld.team.infrastructure.jpa.TeamMemberRepository
+import co.yappuworld.team.infrastructure.jpa.TeamRepository
+import co.yappuworld.team.infrastructure.jpa.TeamServiceRepository
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
+import co.yappuworld.user.infrastructure.jpa.UserRepository
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+
+class HistoricalServiceServiceTest @Autowired constructor(
+    private val teamRepository: TeamRepository,
+    private val teamServiceRepository: TeamServiceRepository,
+    private val teamMemberRepository: TeamMemberRepository,
+    private val userRepository: UserRepository,
+    private val activityUnitRepository: ActivityUnitRepository
+) : CustomDataJpaTestFeatureSpec({
+        lateinit var historicalServiceService: HistoricalServiceService
+
+        beforeEach {
+            historicalServiceService = HistoricalServiceService(
+                teamServiceFindService = TeamServiceFindService(teamServiceRepository),
+                teamMemberFindService = TeamMemberFindService(teamMemberRepository)
+            )
+        }
+
+        feature("역대 서비스 목록 조회") {
+            scenario("기수와 플랫폼 필터를 적용해 목록을 조회한다") {
+                val targetTeam = teamRepository.save(getTeamEntityFixture(generation = 25, name = "타겟팀"))
+                val filteredOutTeam = teamRepository.save(getTeamEntityFixture(generation = 24, name = "제외팀"))
+
+                teamServiceRepository.save(
+                    getTeamServiceEntityFixture(
+                        team = targetTeam,
+                        name = "타겟 서비스",
+                        hasApp = true,
+                        summary = "한 줄 소개"
+                    )
+                )
+                teamServiceRepository.save(
+                    getTeamServiceEntityFixture(
+                        team = filteredOutTeam,
+                        name = "제외 서비스",
+                        hasWeb = true
+                    )
+                )
+
+                val result = historicalServiceService.getHistoricalServices(
+                    HistoricalServicesPageRequest(generation = 25, platform = Platform.APP)
+                )
+
+                result.data shouldHaveSize 1
+                result.data.single().serviceName shouldBe "타겟 서비스"
+                result.data.single().summary shouldBe "한 줄 소개"
+                result.data.single().thumbnailImageUrl shouldBe null
+                result.limit shouldBe 20
+                result.hasNext shouldBe false
+            }
+
+            scenario("커서 기반으로 다음 페이지를 조회한다") {
+                val web25Team = teamRepository.save(getTeamEntityFixture(generation = 25, name = "25웹팀"))
+                val app25Team = teamRepository.save(getTeamEntityFixture(generation = 25, name = "25앱팀"))
+                val app24Team = teamRepository.save(getTeamEntityFixture(generation = 24, name = "24앱팀"))
+
+                val web25Service = teamServiceRepository.save(
+                    getTeamServiceEntityFixture(team = web25Team, name = "25웹", hasWeb = true)
+                )
+                teamServiceRepository.save(
+                    getTeamServiceEntityFixture(team = app25Team, name = "25앱", hasApp = true)
+                )
+                teamServiceRepository.save(
+                    getTeamServiceEntityFixture(team = app24Team, name = "24앱", hasApp = true)
+                )
+
+                val firstPage = historicalServiceService.getHistoricalServices(
+                    HistoricalServicesPageRequest(limit = 2)
+                )
+
+                firstPage.data shouldHaveSize 2
+                firstPage.data.map { it.serviceName } shouldBe listOf("25앱", "25웹")
+                firstPage.lastCursor shouldBe web25Service.id
+                firstPage.hasNext shouldBe true
+
+                val secondPage = historicalServiceService.getHistoricalServices(
+                    HistoricalServicesPageRequest(lastCursorId = firstPage.lastCursor, limit = 2)
+                )
+
+                secondPage.data shouldHaveSize 1
+                secondPage.data.single().serviceName shouldBe "24앱"
+                secondPage.hasNext shouldBe false
+            }
+        }
+
+        feature("역대 서비스 상세 조회") {
+            scenario("서비스 상세와 팀원 목록을 함께 조회한다") {
+                val team = teamRepository.save(getTeamEntityFixture(generation = 17, name = "상세팀"))
+                val service = teamServiceRepository.save(
+                    getTeamServiceEntityFixture(
+                        team = team,
+                        name = "상세 서비스",
+                        hasWeb = true,
+                        webLink = "https://yapp.co.kr",
+                        summary = "짧은 설명",
+                        description = "긴 설명"
+                    )
+                )
+                val pmUser = userRepository.save(getUserEntityFixture(name = "김피엠"))
+                val serverUser = userRepository.save(getUserEntityFixture(name = "김서버"))
+                val pmActivityUnit = activityUnitRepository.save(
+                    getActivityUnitEntityFixture(
+                        userId = pmUser.id,
+                        generation = 17,
+                        position = Position.PM
+                    )
+                )
+                val serverActivityUnit = activityUnitRepository.save(
+                    getActivityUnitEntityFixture(
+                        userId = serverUser.id,
+                        generation = 17,
+                        position = Position.SERVER
+                    )
+                )
+                teamMemberRepository.save(TeamMemberEntity(team = team, activityUnit = serverActivityUnit))
+                teamMemberRepository.save(TeamMemberEntity(team = team, activityUnit = pmActivityUnit))
+
+                val result = historicalServiceService.getHistoricalServiceDetail(service.id)
+
+                result.generation shouldBe 17
+                result.serviceName shouldBe "상세 서비스"
+                result.webLink shouldBe "https://yapp.co.kr"
+                result.thumbnailImageUrl shouldBe null
+                result.members shouldHaveSize 2
+                result.members[0].position shouldBe "PM"
+                result.members[0].name shouldBe "김피엠"
+                result.members[1].position shouldBe "Server"
+                result.members[1].name shouldBe "김서버"
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/team/infrastructure/TeamServiceFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/team/infrastructure/TeamServiceFindServiceTest.kt
@@ -103,7 +103,7 @@ class TeamServiceFindServiceTest @Autowired constructor(
                     getTeamEntityFixture(24, "아래웹팀", hasApp = false, hasWeb = true)
                 )
 
-                val firstWebService = teamServiceRepository.save(
+                teamServiceRepository.save(
                     getTeamServiceEntityFixture(firstWebTeam, "B서비스", hasWeb = true)
                 )
                 teamServiceRepository.save(
@@ -126,7 +126,7 @@ class TeamServiceFindServiceTest @Autowired constructor(
                 val secondPage = teamServiceFindService.findHistoricalServices(
                     generation = null,
                     platform = Platform.WEB,
-                    lastServiceId = firstWebService.id,
+                    lastServiceId = firstPage.single().serviceId,
                     limit = 10
                 )
 

--- a/src/test/kotlin/co/yappuworld/team/infrastructure/TeamServiceFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/team/infrastructure/TeamServiceFindServiceTest.kt
@@ -3,6 +3,7 @@ package co.yappuworld.team.infrastructure
 import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
 import co.yappuworld.support.fixture.TeamFixture.getTeamEntityFixture
 import co.yappuworld.support.fixture.TeamFixture.getTeamServiceEntityFixture
+import co.yappuworld.team.domain.vo.Platform
 import co.yappuworld.team.infrastructure.jpa.TeamRepository
 import co.yappuworld.team.infrastructure.jpa.TeamServiceRepository
 import io.kotest.matchers.collections.shouldHaveSize
@@ -56,6 +57,80 @@ class TeamServiceFindServiceTest @Autowired constructor(
 
                 result.content shouldHaveSize 0
                 result.totalElements shouldBe 0
+            }
+
+            scenario("플랫폼으로 역대 서비스를 필터링한다") {
+                val appTeam = teamRepository.save(getTeamEntityFixture(25, "앱팀"))
+                val webTeam = teamRepository.save(getTeamEntityFixture(25, "웹팀"))
+                teamServiceRepository.save(getTeamServiceEntityFixture(appTeam, "앱 서비스", hasApp = true))
+                teamServiceRepository.save(getTeamServiceEntityFixture(webTeam, "웹 서비스", hasWeb = true))
+
+                val result = teamServiceFindService.findHistoricalServices(
+                    generation = 25,
+                    platform = Platform.APP,
+                    lastServiceId = null,
+                    limit = 20
+                )
+
+                result shouldHaveSize 1
+                result.single().serviceName shouldBe "앱 서비스"
+                result.single().hasApp shouldBe true
+            }
+
+            scenario("역대 서비스는 기수 내림차순, 플랫폼 순으로 정렬한다") {
+                val web25Team = teamRepository.save(getTeamEntityFixture(25, "25웹팀"))
+                val app25Team = teamRepository.save(getTeamEntityFixture(25, "25앱팀"))
+                val app24Team = teamRepository.save(getTeamEntityFixture(24, "24앱팀"))
+
+                teamServiceRepository.save(getTeamServiceEntityFixture(web25Team, "25웹", hasWeb = true))
+                teamServiceRepository.save(getTeamServiceEntityFixture(app25Team, "25앱", hasApp = true))
+                teamServiceRepository.save(getTeamServiceEntityFixture(app24Team, "24앱", hasApp = true))
+
+                val result = teamServiceFindService.findHistoricalServices(
+                    generation = null,
+                    platform = null,
+                    lastServiceId = null,
+                    limit = 20
+                )
+
+                result.map { it.serviceName } shouldBe listOf("25앱", "25웹", "24앱")
+            }
+
+            scenario("WEB 필터 커서 조회 시 hasApp 값이 달라도 다음 페이지가 누락되지 않는다") {
+                val firstWebTeam = teamRepository.save(getTeamEntityFixture(25, "첫웹팀", hasApp = false, hasWeb = true))
+                val secondWebTeam = teamRepository.save(getTeamEntityFixture(25, "둘웹팀", hasApp = true, hasWeb = true))
+                val lowerGenerationWebTeam = teamRepository.save(
+                    getTeamEntityFixture(24, "아래웹팀", hasApp = false, hasWeb = true)
+                )
+
+                val firstWebService = teamServiceRepository.save(
+                    getTeamServiceEntityFixture(firstWebTeam, "B서비스", hasWeb = true)
+                )
+                teamServiceRepository.save(
+                    getTeamServiceEntityFixture(secondWebTeam, "A서비스", hasApp = true, hasWeb = true)
+                )
+                teamServiceRepository.save(
+                    getTeamServiceEntityFixture(lowerGenerationWebTeam, "C서비스", hasWeb = true)
+                )
+
+                val firstPage = teamServiceFindService.findHistoricalServices(
+                    generation = null,
+                    platform = Platform.WEB,
+                    lastServiceId = null,
+                    limit = 1
+                )
+
+                firstPage shouldHaveSize 1
+                firstPage.single().serviceName shouldBe "B서비스"
+
+                val secondPage = teamServiceFindService.findHistoricalServices(
+                    generation = null,
+                    platform = Platform.WEB,
+                    lastServiceId = firstWebService.id,
+                    limit = 10
+                )
+
+                secondPage.map { it.serviceName } shouldBe listOf("A서비스", "C서비스")
             }
         }
     })


### PR DESCRIPTION
📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 서비스 목록 및 상세 API를 제공합니다.


## ⭐️ 어떻게 해결했나요?
- 무한 스크롤에 맞춰 커서 페이지네이션으로 제공했습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?

- 아래의 커서 페이지네이션 로직에 집중하여 리뷰 부탁드립니다.

- 프론트에는 최대한 간단한 형태의 커서 요구를 위해 service id만 받습니다.
- 서버에서 service id 기반으로 cursor를 조립합니다.
- 복합 정렬 형태이므로 사전식 SQL 구성을 진행합니다.
	- generation 비교
	- generation이 같으면 platform 비교
	- generation, platform이 같으면 name 비교
	- 셋 다 같으면 id 비교
	- 위의 네 조건을 or로 연결


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 역대 서비스 목록 조회 API 추가 (커서 기반 페이지네이션, 기수·플랫폼 필터링)
  * 역대 서비스 상세 조회 API 추가 (서비스 메타데이터 및 팀원 목록 포함)

* **Documentation**
  * API 응답 필드 설명(스웨거/OpenAPI) 개선으로 문서화 정확도 향상

* **Tests**
  * 역대 서비스 목록·상세 조회 및 커서 기반 페이징 동작에 대한 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->