### PR TITLE
feat: 공개 유저 프로필 조회 API 추가

### DIFF
--- a/src/main/kotlin/co/yappuworld/team/client/dto/response/HistoricalServiceDetailResponse.kt
+++ b/src/main/kotlin/co/yappuworld/team/client/dto/response/HistoricalServiceDetailResponse.kt
@@ -56,6 +56,8 @@ data class HistoricalServiceDetailResponse(
 }
 
 data class HistoricalServiceMemberResponse(
+    @field:Schema(description = "유저 ID")
+    val userId: UUID,
     @field:Schema(description = "활동 이력 ID")
     val activityUnitId: UUID,
     @field:Schema(description = "이름")
@@ -66,6 +68,7 @@ data class HistoricalServiceMemberResponse(
     companion object {
         fun from(dto: TeamMemberDetailDto): HistoricalServiceMemberResponse =
             HistoricalServiceMemberResponse(
+                userId = dto.userId,
                 activityUnitId = dto.activityUnitId,
                 name = dto.userName,
                 position = dto.position.label

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/CustomTeamDsl.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/CustomTeamDsl.kt
@@ -65,6 +65,7 @@ CustomTeamDsl : Jpql() {
 
     fun selectTeamMemberDetail(): SelectQueryFromStep<TeamMemberDetailDto> =
         selectNew<TeamMemberDetailDto>(
+            path(UserEntity::getId),
             path(TeamMemberEntity::activityUnit).path(ActivityUnitEntity::getId),
             path(TeamMemberEntity::activityUnit).path(ActivityUnitEntity::generation),
             path(TeamMemberEntity::activityUnit).path(ActivityUnitEntity::position),

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/TeamServiceFindService.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/TeamServiceFindService.kt
@@ -37,6 +37,11 @@ class TeamServiceFindService(
 
     fun findTeamServices(teams: List<TeamEntity>): List<TeamServiceEntity> = teamServiceRepository.findByTeamIn(teams)
 
+    fun findTeamServices(serviceIds: Collection<UUID>): List<TeamServiceEntity> {
+        require(serviceIds.isNotEmpty()) { "서비스 조회 요청에 들어오는 ID는 최소 하나 이상이어야 합니다." }
+        return teamServiceRepository.findAllById(serviceIds)
+    }
+
     fun findHistoricalServices(
         generation: Int?,
         platform: Platform?,

--- a/src/main/kotlin/co/yappuworld/team/infrastructure/dto/TeamMemberDetailDto.kt
+++ b/src/main/kotlin/co/yappuworld/team/infrastructure/dto/TeamMemberDetailDto.kt
@@ -4,6 +4,7 @@ import co.yappuworld.user.domain.vo.Position
 import java.util.UUID
 
 data class TeamMemberDetailDto(
+    val userId: UUID,
     val activityUnitId: UUID,
     val generation: Int,
     val position: Position,

--- a/src/main/kotlin/co/yappuworld/user/client/application/UserPersonProfileService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/UserPersonProfileService.kt
@@ -1,0 +1,46 @@
+package co.yappuworld.user.client.application
+
+import co.yappuworld.user.client.dto.response.UserPersonHistoryResponse
+import co.yappuworld.user.client.dto.response.UserPersonProfileResponse
+import co.yappuworld.team.infrastructure.TeamServiceFindService
+import co.yappuworld.user.infrastructure.UserFindService
+import co.yappuworld.user.infrastructure.model.UserPersonProfileHistoryProjection
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class UserPersonProfileService(
+    private val userFindService: UserFindService,
+    private val teamServiceFindService: TeamServiceFindService
+) {
+
+    @Transactional(readOnly = true)
+    fun getUserPersonProfile(userId: UUID): UserPersonProfileResponse {
+        val user = userFindService.findUser(userId)
+        val historyProjections = userFindService
+            .findUserPersonProfileHistories(userId)
+            .sortedWith(
+                compareByDescending<UserPersonProfileHistoryProjection> { it.generation }
+                    .thenBy { it.position.order }
+            )
+        val servicesById = historyProjections
+            .mapNotNull(UserPersonProfileHistoryProjection::serviceId)
+            .distinct()
+            .takeIf { it.isNotEmpty() }
+            ?.let(teamServiceFindService::findTeamServices)
+            ?.associateBy { it.id }
+            ?: emptyMap()
+        val histories = historyProjections.map { projection ->
+            UserPersonHistoryResponse.from(
+                projection = projection,
+                service = projection.serviceId?.let(servicesById::get)
+            )
+        }
+
+        return UserPersonProfileResponse.of(
+            user = user,
+            histories = histories
+        )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/client/application/UserPersonProfileService.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/application/UserPersonProfileService.kt
@@ -7,6 +7,7 @@ import co.yappuworld.user.infrastructure.UserFindService
 import co.yappuworld.user.infrastructure.model.UserPersonProfileHistoryProjection
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -20,10 +21,7 @@ class UserPersonProfileService(
         val user = userFindService.findUser(userId)
         val historyProjections = userFindService
             .findUserPersonProfileHistories(userId)
-            .sortedWith(
-                compareByDescending<UserPersonProfileHistoryProjection> { it.generation }
-                    .thenBy { it.position.order }
-            )
+            .sortedWith(userPersonProfileHistoryComparator())
         val servicesById = historyProjections
             .mapNotNull(UserPersonProfileHistoryProjection::serviceId)
             .distinct()
@@ -43,4 +41,11 @@ class UserPersonProfileService(
             histories = histories
         )
     }
+
+    private fun userPersonProfileHistoryComparator(): Comparator<UserPersonProfileHistoryProjection> =
+        compareByDescending<UserPersonProfileHistoryProjection> { it.generation }
+            .thenBy { it.position.order }
+            .thenByDescending { it.activityEndDate ?: LocalDate.MIN }
+            .thenByDescending { it.activityStartDate ?: LocalDate.MIN }
+            .thenByDescending { it.activityUnitId }
 }

--- a/src/main/kotlin/co/yappuworld/user/client/dto/response/UserPersonProfileResponse.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/dto/response/UserPersonProfileResponse.kt
@@ -1,0 +1,123 @@
+package co.yappuworld.user.client.dto.response
+
+import co.yappuworld.user.infrastructure.entity.UserEntity
+import co.yappuworld.team.infrastructure.entity.TeamServiceEntity
+import co.yappuworld.user.infrastructure.model.UserPersonProfileHistoryProjection
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.util.UUID
+
+data class UserPersonProfileResponse(
+    @field:Schema(description = "유저 식별자")
+    val userId: UUID,
+    @field:Schema(description = "이름")
+    val name: String,
+    @field:Schema(description = "권한")
+    val role: String,
+    @field:Schema(description = "가장 최근 활동 정보", nullable = true)
+    val latestActivity: UserPersonLatestActivityResponse?,
+    @field:Schema(description = "역대 활동 내역")
+    val histories: List<UserPersonHistoryResponse>
+) {
+    companion object {
+        fun of(
+            user: UserEntity,
+            histories: List<UserPersonHistoryResponse>
+        ): UserPersonProfileResponse =
+            UserPersonProfileResponse(
+                userId = user.id,
+                name = user.name,
+                role = user.role.label,
+                latestActivity = histories.firstOrNull()?.let(UserPersonLatestActivityResponse::from),
+                histories = histories
+            )
+    }
+}
+
+data class UserPersonLatestActivityResponse(
+    @field:Schema(description = "기수")
+    val generation: Int,
+    @field:Schema(description = "직군")
+    val position: String
+) {
+    companion object {
+        fun from(history: UserPersonHistoryResponse): UserPersonLatestActivityResponse =
+            UserPersonLatestActivityResponse(
+                generation = history.generation,
+                position = history.position
+            )
+    }
+}
+
+data class UserPersonHistoryResponse(
+    @field:Schema(description = "기수")
+    val generation: Int,
+    @field:Schema(description = "직군")
+    val position: String,
+    @field:Schema(description = "활동 시작일", nullable = true)
+    val activityStartDate: LocalDate?,
+    @field:Schema(description = "활동 종료일", nullable = true)
+    val activityEndDate: LocalDate?,
+    @field:Schema(description = "서비스 정보", nullable = true)
+    val service: UserPersonHistoryServiceResponse?
+) {
+    companion object {
+        fun from(
+            projection: UserPersonProfileHistoryProjection,
+            service: TeamServiceEntity?
+        ): UserPersonHistoryResponse =
+            UserPersonHistoryResponse(
+                generation = projection.generation,
+                position = projection.position.label,
+                activityStartDate = projection.activityStartDate,
+                activityEndDate = projection.activityEndDate,
+                service = if (projection.teamName != null && projection.serviceId != null) {
+                    UserPersonHistoryServiceResponse.from(projection, service)
+                } else {
+                    null
+                }
+            )
+    }
+}
+
+data class UserPersonHistoryServiceResponse(
+    @field:Schema(description = "서비스 ID")
+    val serviceId: UUID,
+    @field:Schema(description = "팀명")
+    val teamName: String,
+    @field:Schema(description = "서비스명")
+    val serviceName: String?,
+    @field:Schema(description = "한 줄 소개")
+    val summary: String?,
+    @field:Schema(description = "앱 플랫폼 여부")
+    val hasApp: Boolean,
+    @field:Schema(description = "웹 플랫폼 여부")
+    val hasWeb: Boolean,
+    @field:Schema(description = "구글 플레이 링크")
+    val googlePlayLink: String?,
+    @field:Schema(description = "앱스토어 링크")
+    val appStoreLink: String?,
+    @field:Schema(description = "웹 링크")
+    val webLink: String?,
+    @field:Schema(description = "썸네일 이미지 URL")
+    val thumbnailImageUrl: String?
+) {
+    companion object {
+        fun from(
+            projection: UserPersonProfileHistoryProjection,
+            service: TeamServiceEntity?
+        ): UserPersonHistoryServiceResponse =
+            UserPersonHistoryServiceResponse(
+                serviceId = requireNotNull(projection.serviceId),
+                teamName = requireNotNull(projection.teamName),
+                serviceName = projection.serviceName,
+                summary = projection.summary,
+                hasApp = projection.hasApp ?: false,
+                hasWeb = projection.hasWeb ?: false,
+                googlePlayLink = service?.serviceLinks?.googlePlay,
+                appStoreLink = service?.serviceLinks?.appStore,
+                webLink = service?.serviceLinks?.web,
+                thumbnailImageUrl = null
+            )
+    }
+}

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserPersonProfileApi.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserPersonProfileApi.kt
@@ -1,0 +1,97 @@
+package co.yappuworld.user.client.presentation
+
+import co.yappuworld.global.response.ErrorResponse
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.user.client.dto.response.UserPersonProfileResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import java.util.UUID
+
+@Tag(name = "공개 유저 프로필 API", description = "_")
+interface UserPersonProfileApi {
+
+    @Operation(summary = "공개 유저 프로필 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                useReturnTypeSchema = true,
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "공개 유저 프로필 조회 성공",
+                                value = """
+                                    {
+                                        "isSuccess": true,
+                                        "data": {
+                                            "userId": "79d52d77-6123-40f1-9f70-64bcbd6ca21a",
+                                            "name": "김뿌야",
+                                            "role": "활동회원",
+                                            "latestActivity": {
+                                                "generation": 25,
+                                                "position": "Design"
+                                            },
+                                            "histories": [
+                                                {
+                                                    "generation": 25,
+                                                    "position": "Design",
+                                                    "activityStartDate": "2023-11-01",
+                                                    "activityEndDate": "2024-06-30",
+                                                    "service": {
+                                                        "serviceId": "a1b2c3d4-e5f6-7890-ab12-cd34ef56ab78",
+                                                        "teamName": "팀 이름",
+                                                        "serviceName": "서비스명",
+                                                        "summary": "무수무수한 서비스 두줄까지 들어갈것 같아요",
+                                                        "hasApp": true,
+                                                        "hasWeb": true,
+                                                        "googlePlayLink": "https://play.google.com/store/apps/details?id=com.example",
+                                                        "appStoreLink": "https://apps.apple.com/app/id123456789",
+                                                        "webLink": "https://example.com",
+                                                        "thumbnailImageUrl": null
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "존재하지 않는 유저",
+                                value = """
+                                    {
+                                        "isSuccess": false,
+                                        "message": "사용자를 찾을 수 없습니다.",
+                                        "errorCode": "USER_0001"
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/v1/users/{userId}/profile")
+    fun getUserPersonProfile(
+        @PathVariable userId: UUID
+    ): ResponseEntity<SuccessResponse<UserPersonProfileResponse>>
+}

--- a/src/main/kotlin/co/yappuworld/user/client/presentation/UserPersonProfileController.kt
+++ b/src/main/kotlin/co/yappuworld/user/client/presentation/UserPersonProfileController.kt
@@ -1,0 +1,19 @@
+package co.yappuworld.user.client.presentation
+
+import co.yappuworld.global.response.SuccessResponse
+import co.yappuworld.user.client.application.UserPersonProfileService
+import co.yappuworld.user.client.dto.response.UserPersonProfileResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+class UserPersonProfileController(
+    private val userPersonProfileService: UserPersonProfileService
+) : UserPersonProfileApi {
+
+    override fun getUserPersonProfile(userId: UUID): ResponseEntity<SuccessResponse<UserPersonProfileResponse>> =
+        ResponseEntity.ok(
+            SuccessResponse(userPersonProfileService.getUserPersonProfile(userId))
+        )
+}

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/CustomUserDsl.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/CustomUserDsl.kt
@@ -1,9 +1,14 @@
 package co.yappuworld.user.infrastructure
 
+import co.yappuworld.operation.domain.GenerationEntity
+import co.yappuworld.team.infrastructure.entity.TeamEntity
+import co.yappuworld.team.infrastructure.entity.TeamMemberEntity
+import co.yappuworld.team.infrastructure.entity.TeamServiceEntity
 import co.yappuworld.user.domain.vo.Position
 import co.yappuworld.user.infrastructure.entity.ActivityUnitEntity
 import co.yappuworld.user.infrastructure.entity.UserEntity
 import co.yappuworld.user.domain.model.UserWithActivityUnit
+import co.yappuworld.user.infrastructure.model.UserPersonProfileHistoryProjection
 import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.dsl.jpql.JpqlDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.select.SelectQueryGroupByStep
@@ -49,4 +54,32 @@ class CustomUserDsl : Jpql() {
                 path(ActivityUnitEntity::generation).equal(generation),
                 path(ActivityUnitEntity::position).notEqual(Position.STAFF)
             )
+
+    fun selectUserPersonProfileHistories(): SelectQueryWhereStep<UserPersonProfileHistoryProjection> =
+        selectNew<UserPersonProfileHistoryProjection>(
+            path(ActivityUnitEntity::getId),
+            path(ActivityUnitEntity::generation),
+            path(ActivityUnitEntity::position),
+            path(GenerationEntity::startDate),
+            path(GenerationEntity::endDate),
+            path(TeamEntity::name),
+            path(TeamServiceEntity::getId),
+            path(TeamServiceEntity::name),
+            path(TeamServiceEntity::summary),
+            path(TeamServiceEntity::hasApp),
+            path(TeamServiceEntity::hasWeb)
+        ).from(
+            entity(ActivityUnitEntity::class),
+            leftJoin(entity(GenerationEntity::class))
+                .on(path(ActivityUnitEntity::generation).equal(path(GenerationEntity::value))),
+            leftJoin(entity(TeamMemberEntity::class))
+                .on(
+                    path(ActivityUnitEntity::getId)
+                        .equal(path(TeamMemberEntity::activityUnit).path(ActivityUnitEntity::getId))
+                ),
+            leftJoin(entity(TeamEntity::class))
+                .on(path(TeamMemberEntity::team).path(TeamEntity::getId).equal(path(TeamEntity::getId))),
+            leftJoin(entity(TeamServiceEntity::class))
+                .on(path(TeamEntity::getId).equal(path(TeamServiceEntity::team).path(TeamEntity::getId)))
+        )
 }

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/UserFindService.kt
@@ -11,6 +11,7 @@ import co.yappuworld.user.infrastructure.entity.UserEntity
 import co.yappuworld.user.infrastructure.jpa.UserRepository
 import co.yappuworld.user.infrastructure.model.ActivityUnitWithRowNumber
 import co.yappuworld.user.domain.model.UserWithActivityUnit
+import co.yappuworld.user.infrastructure.model.UserPersonProfileHistoryProjection
 import co.yappuworld.user.infrastructure.model.UserWithLastActivityUnit
 import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
@@ -150,6 +151,13 @@ class UserFindService(
             .findAll(CustomUserDsl) { getActiveUser(userId, generation) }
             .singleOrNull()
             ?: throw BusinessException(UserError.USER_NOT_FOUND_WITH_GENERATION_ACTIVITY)
+
+    fun findUserPersonProfileHistories(userId: UUID): List<UserPersonProfileHistoryProjection> =
+        userRepository
+            .findAll(CustomUserDsl) {
+                selectUserPersonProfileHistories()
+                    .where(path(ActivityUnitEntity::userId).equal(userId))
+            }.filterNotNull()
 
     private fun Jpql.getUserWithLastActivityUnit(
         userId: UUID? = null

--- a/src/main/kotlin/co/yappuworld/user/infrastructure/model/UserPersonProfileHistoryProjection.kt
+++ b/src/main/kotlin/co/yappuworld/user/infrastructure/model/UserPersonProfileHistoryProjection.kt
@@ -1,0 +1,19 @@
+package co.yappuworld.user.infrastructure.model
+
+import co.yappuworld.user.domain.vo.Position
+import java.time.LocalDate
+import java.util.UUID
+
+data class UserPersonProfileHistoryProjection(
+    val activityUnitId: UUID,
+    val generation: Int,
+    val position: Position,
+    val activityStartDate: LocalDate?,
+    val activityEndDate: LocalDate?,
+    val teamName: String?,
+    val serviceId: UUID?,
+    val serviceName: String?,
+    val summary: String?,
+    val hasApp: Boolean?,
+    val hasWeb: Boolean?
+)

--- a/src/test/kotlin/co/yappuworld/team/client/application/HistoricalServiceServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/team/client/application/HistoricalServiceServiceTest.kt
@@ -144,8 +144,10 @@ class HistoricalServiceServiceTest @Autowired constructor(
                 result.members shouldHaveSize 2
                 result.members[0].position shouldBe "PM"
                 result.members[0].name shouldBe "김피엠"
+                result.members[0].userId shouldBe pmUser.id
                 result.members[1].position shouldBe "Server"
                 result.members[1].name shouldBe "김서버"
+                result.members[1].userId shouldBe serverUser.id
             }
         }
     })

--- a/src/test/kotlin/co/yappuworld/team/infrastructure/TeamMemberFindServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/team/infrastructure/TeamMemberFindServiceTest.kt
@@ -39,6 +39,7 @@ class TeamMemberFindServiceTest @Autowired constructor(
                 result.filterNotNull() shouldHaveSize 1
 
                 val member1 = result.find { it?.userName == "홍길동" }
+                member1?.userId shouldBe user.id
                 member1?.generation shouldBe 36
                 member1?.position shouldBe Position.IOS
                 member1?.activityUnitId shouldBe activityUnit.id

--- a/src/test/kotlin/co/yappuworld/user/application/UserPersonProfileServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserPersonProfileServiceTest.kt
@@ -1,0 +1,124 @@
+package co.yappuworld.user.application
+
+import co.yappuworld.operation.infrastructure.GenerationRepository
+import co.yappuworld.support.environment.CustomDataJpaTestFeatureSpec
+import co.yappuworld.support.fixture.OperationFixture.getGenerationFixture
+import co.yappuworld.support.fixture.TeamFixture.getTeamEntityFixture
+import co.yappuworld.support.fixture.TeamFixture.getTeamServiceEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getActivityUnitEntityFixture
+import co.yappuworld.support.fixture.UserFixture.getUserEntityFixture
+import co.yappuworld.team.infrastructure.entity.TeamMemberEntity
+import co.yappuworld.team.infrastructure.TeamServiceFindService
+import co.yappuworld.team.infrastructure.jpa.TeamMemberRepository
+import co.yappuworld.team.infrastructure.jpa.TeamRepository
+import co.yappuworld.team.infrastructure.jpa.TeamServiceRepository
+import co.yappuworld.user.client.application.UserPersonProfileService
+import co.yappuworld.user.domain.vo.Position
+import co.yappuworld.user.infrastructure.UserFindService
+import co.yappuworld.user.infrastructure.jpa.ActivityUnitRepository
+import co.yappuworld.user.infrastructure.jpa.UserRepository
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
+
+class UserPersonProfileServiceTest @Autowired constructor(
+    private val userRepository: UserRepository,
+    private val activityUnitRepository: ActivityUnitRepository,
+    private val generationRepository: GenerationRepository,
+    private val teamRepository: TeamRepository,
+    private val teamServiceRepository: TeamServiceRepository,
+    private val teamMemberRepository: TeamMemberRepository,
+    private val entityManager: EntityManager,
+    private val context: JpqlRenderContext
+) : CustomDataJpaTestFeatureSpec({
+        lateinit var userPersonProfileService: UserPersonProfileService
+
+        beforeEach {
+            userPersonProfileService = UserPersonProfileService(
+                userFindService = UserFindService(userRepository, entityManager, context),
+                teamServiceFindService = TeamServiceFindService(teamServiceRepository)
+            )
+        }
+
+        feature("공개 유저 프로필 조회") {
+            scenario("가장 최근 활동 정보와 역대 서비스 이력을 함께 조회한다") {
+                val user = userRepository.save(getUserEntityFixture(name = "김뿌야"))
+                generationRepository.save(
+                    getGenerationFixture(
+                        value = 125,
+                        startDate = LocalDate.of(2023, 11, 1),
+                        endDate = LocalDate.of(2024, 6, 30)
+                    )
+                )
+                generationRepository.save(
+                    getGenerationFixture(
+                        value = 120,
+                        startDate = LocalDate.of(2018, 11, 1),
+                        endDate = LocalDate.of(2019, 6, 30)
+                    )
+                )
+                val latestActivityUnit = activityUnitRepository.save(
+                    getActivityUnitEntityFixture(
+                        userId = user.id,
+                        generation = 125,
+                        position = Position.DESIGN
+                    )
+                )
+                val staffActivityUnit = activityUnitRepository.save(
+                    getActivityUnitEntityFixture(
+                        userId = user.id,
+                        generation = 120,
+                        position = Position.STAFF
+                    )
+                )
+                val latestTeam = teamRepository.save(
+                    getTeamEntityFixture(
+                        generation = 125,
+                        name = "팀 이름",
+                        hasApp = true,
+                        hasWeb = true
+                    )
+                )
+                val service = teamServiceRepository.save(
+                    getTeamServiceEntityFixture(
+                        team = latestTeam,
+                        name = "서비스명",
+                        hasApp = true,
+                        hasWeb = true,
+                        googlePlayLink = "https://play.google.com/store/apps/details?id=com.example",
+                        appStoreLink = "https://apps.apple.com/app/id123456789",
+                        webLink = "https://example.com",
+                        summary = "무수무수한 서비스 두줄까지 들어갈것 같아요"
+                    )
+                )
+                teamMemberRepository.save(TeamMemberEntity(team = latestTeam, activityUnit = latestActivityUnit))
+
+                val result = userPersonProfileService.getUserPersonProfile(user.id)
+
+                result.userId shouldBe user.id
+                result.name shouldBe "김뿌야"
+                result.role shouldBe "활동회원"
+                result.latestActivity?.generation shouldBe 125
+                result.latestActivity?.position shouldBe "Design"
+                result.histories shouldHaveSize 2
+                result.histories[0].generation shouldBe 125
+                result.histories[0].position shouldBe "Design"
+                result.histories[0].activityStartDate shouldBe LocalDate.of(2023, 11, 1)
+                result.histories[0].activityEndDate shouldBe LocalDate.of(2024, 6, 30)
+                result.histories[0].service?.serviceId shouldBe service.id
+                result.histories[0].service?.teamName shouldBe "팀 이름"
+                result.histories[0].service?.serviceName shouldBe "서비스명"
+                result.histories[0].service?.hasApp shouldBe true
+                result.histories[0].service?.hasWeb shouldBe true
+                result.histories[0].service?.thumbnailImageUrl shouldBe null
+                result.histories[1].generation shouldBe staffActivityUnit.generation
+                result.histories[1].position shouldBe "운영진"
+                result.histories[1].activityStartDate shouldBe LocalDate.of(2018, 11, 1)
+                result.histories[1].activityEndDate shouldBe LocalDate.of(2019, 6, 30)
+                result.histories[1].service shouldBe null
+            }
+        }
+    })

--- a/src/test/kotlin/co/yappuworld/user/application/UserPersonProfileServiceTest.kt
+++ b/src/test/kotlin/co/yappuworld/user/application/UserPersonProfileServiceTest.kt
@@ -120,5 +120,63 @@ class UserPersonProfileServiceTest @Autowired constructor(
                 result.histories[1].activityEndDate shouldBe LocalDate.of(2019, 6, 30)
                 result.histories[1].service shouldBe null
             }
+
+            scenario("같은 기수와 같은 포지션의 활동 이력도 최신 활동 기준이 흔들리지 않는다") {
+                val user = userRepository.save(getUserEntityFixture(name = "김뿌야"))
+                generationRepository.save(
+                    getGenerationFixture(
+                        value = 125,
+                        startDate = LocalDate.of(2023, 11, 1),
+                        endDate = LocalDate.of(2024, 6, 30)
+                    )
+                )
+                val firstActivityUnit = activityUnitRepository.save(
+                    getActivityUnitEntityFixture(
+                        userId = user.id,
+                        generation = 125,
+                        position = Position.DESIGN
+                    )
+                )
+                val secondActivityUnit = activityUnitRepository.save(
+                    getActivityUnitEntityFixture(
+                        userId = user.id,
+                        generation = 125,
+                        position = Position.DESIGN
+                    )
+                )
+                val team = teamRepository.save(
+                    getTeamEntityFixture(
+                        generation = 125,
+                        name = "팀 이름",
+                        hasApp = true,
+                        hasWeb = false
+                    )
+                )
+                teamServiceRepository.save(
+                    getTeamServiceEntityFixture(
+                        team = team,
+                        name = "서비스명",
+                        hasApp = true,
+                        hasWeb = false
+                    )
+                )
+                teamMemberRepository.save(TeamMemberEntity(team = team, activityUnit = secondActivityUnit))
+
+                val result = userPersonProfileService.getUserPersonProfile(user.id)
+                val expectedLatestActivityUnitId = maxOf(firstActivityUnit.id, secondActivityUnit.id)
+
+                result.latestActivity?.generation shouldBe 125
+                result.latestActivity?.position shouldBe "Design"
+                result.histories shouldHaveSize 2
+                result.histories.first().activityStartDate shouldBe LocalDate.of(2023, 11, 1)
+                result
+                    .histories
+                    .first()
+                    .service
+                    ?.serviceName shouldBe when (expectedLatestActivityUnitId) {
+                    secondActivityUnit.id -> "서비스명"
+                    else -> null
+                }
+            }
         }
     })


### PR DESCRIPTION
📌 Related Issue


## 🚨 해결하려는 문제가 무엇인가요?
- 서비스 목록에서 팀원 상세로 이동할 때 사용할 API를 제공합니다.


## ⭐️ 어떻게 해결했나요?
- 단순 CRUD라 크게.. 고려한 부분은 없습니다.


## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?


## 🗒️ 참고자료


## RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 공개 유저 프로필 조회 API 및 조회 서비스 추가 — 사용자 최신 활동과 이력 제공
  * 프로필/히스토리 관련 응답 DTO 및 히스토리 프로젝션 추가
  * 팀 멤버 응답에 userId 포함 및 조회 쿼리 확장
  * 팀 서비스 조회 유틸리티 메서드 추가

* **Tests**
  * 공개 프로필 조회 서비스 테스트 추가
  * 팀 멤버 관련 검증 테스트 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->